### PR TITLE
Feature. Full acronym support in pascal case identifiers.

### DIFF
--- a/src/Humanizer.Tests/Extensions/StringHumanizeTests.cs
+++ b/src/Humanizer.Tests/Extensions/StringHumanizeTests.cs
@@ -65,6 +65,46 @@ namespace Humanizer.Tests.Extensions
         }
 
         [Fact]
+        public void AcronymsAreSeparatedFromOtherWordsInTheMiddle()
+        {
+            Assert.Equal(
+                "The HTML language",
+                "TheHTMLLanguage".Humanize());
+        }
+
+        [Fact]
+        public void AcronymsAreSeparatedFromOtherWordsInTheStart()
+        {
+            Assert.Equal(
+                "HTML is the language",
+                "HTMLIsTheLanguage".Humanize());
+        }
+
+        [Fact]
+        public void AcronymsAreSeparatedFromOtherWordsInTheEnd()
+        {
+            Assert.Equal(
+                "The language is HTML",
+                "TheLanguageIsHTML".Humanize());
+        }
+
+        [Fact]
+        public void AcronymsAreSeparatedFromNumbersInTheEnd()
+        {
+            Assert.Equal(
+                "HTML 5",
+                "HTML5".Humanize());
+        }
+
+        [Fact]
+        public void AcronymsAreSeparatedFromNumbersInTheStart()
+        {
+            Assert.Equal(
+                "1 HTML",
+                "1HTML".Humanize());
+        }
+
+        [Fact]
         public void CanHumanizeIntoTitleCaseWithoutUsingUnderscores()
         {
             Assert.Equal(


### PR DESCRIPTION
I've found that currently pascal case identifiers containing acronyms are humanized incorrectly, e.g. :
- "HTMLIsTheLanguage" -> "H T M L is the language"
- "TheHTMLLanguage" -> "The H T M L Language"

Only identifiers consisting from single acronym are supported. I considered that as a lack of acronym support.
