### PR TITLE
Allow pluralization/singularization to be controlled by a boolean.

### DIFF
--- a/src/Humanizer.Tests/InflectorTests.cs
+++ b/src/Humanizer.Tests/InflectorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 using Xunit.Extensions;
 
@@ -133,6 +134,20 @@ namespace Humanizer.Tests
             TestData.Add("alumna", "alumnae");
             TestData.Add("alumnus", "alumni");
             TestData.Add("fungus", "fungi");
+        }
+
+        [Fact]
+        public void DoNotPluralize()
+        {
+            var singular = TestData.First(pair => pair.Key != pair.Value).Key;
+            Assert.Equal(singular.Pluralize(), singular);
+        }
+
+        [Fact]
+        public void DoNotSingularize()
+        {
+            var plural = TestData.First(pair => pair.Key != pair.Value).Value;
+            Assert.Equal(plural.Singularize(), plural);
         }
 
         //Uppercases individual words and removes some characters 

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -124,9 +124,15 @@ namespace Humanizer
         /// Pluralizes the provided input considering irregular words
         /// </summary>
         /// <param name="word">Word to be pluralized</param>
+        /// <param name="onlyIf">Only perform pluralization if expression is true</param>
         /// <returns></returns>
-        public static string Pluralize(this string word)
+        public static string Pluralize(this string word, bool onlyIf = true)
         {
+            if (onlyIf == false)
+            {
+                return word;
+            }
+
             return ApplyRules(Plurals, word);
         }
 
@@ -134,9 +140,15 @@ namespace Humanizer
         /// Singularizes the provided input considering irregular words
         /// </summary>
         /// <param name="word">Word to be singularized</param>
+        /// <param name="onlyIf">Only perform pluralization if expression is true</param>
         /// <returns></returns>
-        public static string Singularize(this string word)
+        public static string Singularize(this string word, bool onlyIf = true)
         {
+            if (onlyIf == false)
+            {
+                return word;
+            }
+
             return ApplyRules(Singulars, word);
         }
 


### PR DESCRIPTION
I would like your thoughts on being able to control these extension methods with a bool like:

```
string.Format("{0} {1}", count, "request".Pluralize(count != 1));
```

Maybe I should take it further to be:

```
"request".Pluralize(count); // "0 requests", "1 request", "2 requests"
```
