### PR TITLE
Issue 38 - Possible fix

### DIFF
--- a/src/Humanizer.Tests/InflectorTests.cs
+++ b/src/Humanizer.Tests/InflectorTests.cs
@@ -18,11 +18,29 @@ namespace Humanizer.Tests
         }
 
         [Fact]
+        public void PluralizeAlreadyPluralWord()
+        {
+            foreach (var pair in TestData)
+            {
+                Assert.Equal(pair.Value.Pluralize(), pair.Value);
+            }
+        }
+
+        [Fact]
         public void Singularize()
         {
             foreach (var pair in TestData)
             {
                 Assert.Equal(pair.Value.Singularize(), pair.Key);
+            }
+        }
+
+        [Fact]
+        public void SingularizeAlreadySingularWord()
+        {
+            foreach (var pair in TestData)
+            {
+                Assert.Equal(pair.Key.Singularize(), pair.Key);
             }
         }
 

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Humanizer
@@ -127,7 +128,13 @@ namespace Humanizer
         /// <returns></returns>
         public static string Pluralize(this string word)
         {
-            return ApplyRules(Plurals, word);
+            var asSingular = ApplyRules(Singulars, word);
+            var asSingularAsPlural = ApplyRules(Plurals, asSingular);
+            var result = ApplyRules(Plurals, word);
+            if (asSingular != null && asSingular != word && asSingular + "s" != word && asSingularAsPlural == word && result != word)
+                return word;
+
+            return result;
         }
 
         /// <summary>
@@ -137,12 +144,21 @@ namespace Humanizer
         /// <returns></returns>
         public static string Singularize(this string word)
         {
-            return ApplyRules(Singulars, word);
+            var asPlural = ApplyRules(Plurals, word);
+            var asPluralAsSingular = ApplyRules(Singulars, asPlural);
+            var result = ApplyRules(Singulars, word);
+            if (asPlural != word && word+"s" != asPlural && asPluralAsSingular == word && result != word)
+                return word;
+
+            return result ?? word;
         }
 
         private static string ApplyRules(List<Rule> rules, string word)
         {
-            string result = word;
+            if (word == null)
+                return null;
+
+            var result = word;
 
             if (!Uncountables.Contains(word.ToLower()))
             {


### PR DESCRIPTION
Created a way of detecting if a word is already singular or plural that passes all existing test cases - there may be others that don't pass though?

Also, this won't be the most performant thing ever...

Simple code change though :)

Originally I started tracking the irregulars in a list of regexes to make a special case for them (i.e. if it's an irregular singular and you are calling Singularize then return), but in the end the logic I have in there seems to work for those special cases.
