### PR TITLE
NeutralResourcesLanguage resolves #75 in Windows Store apps

### DIFF
--- a/src/Humanizer/Properties/AssemblyInfo.cs
+++ b/src/Humanizer/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Resources;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -33,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0")]
 [assembly: AssemblyFileVersion("1.0")]
+[assembly: NeutralResourcesLanguage("en")]


### PR DESCRIPTION
Adding NeutralResourcesLanguage resolves the problem not getting empty strings from System.Resources.ResourceManager in Windows Store apps.

I've tested this with a sample Windows Store app but haven't included a full on test project for this one test.
