### PR TITLE
Set culture in tests to prevent failing tests when run on different cult...

### DIFF
--- a/src/Humanizer.Tests/AmbientCulture.cs
+++ b/src/Humanizer.Tests/AmbientCulture.cs
@@ -11,6 +11,7 @@ namespace Humanizer.Tests
         public AmbientCulture(CultureInfo culture)
         {
             _culture = Thread.CurrentThread.CurrentUICulture;
+            Thread.CurrentThread.CurrentCulture = culture;
             Thread.CurrentThread.CurrentUICulture = culture;
         }
 

--- a/src/Humanizer.Tests/Bytes/ByteSizeExtensionsTests.cs
+++ b/src/Humanizer.Tests/Bytes/ByteSizeExtensionsTests.cs
@@ -1,17 +1,12 @@
-﻿using System.Globalization;
-using System.Threading;
-using Humanizer.Bytes;
+﻿using Humanizer.Bytes;
 using Xunit;
 using Xunit.Extensions;
 
 namespace Humanizer.Tests.Bytes
 {
-    public class ByteSizeExtensionsTests
+    public class ByteSizeExtensionsTests : AmbientCulture
     {
-        public ByteSizeExtensionsTests()
-        {
-            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
-        }
+        public ByteSizeExtensionsTests() : base("en") { }
 
         [Fact]
         public void Terabytes()

--- a/src/Humanizer.Tests/Bytes/ParsingTests.cs
+++ b/src/Humanizer.Tests/Bytes/ParsingTests.cs
@@ -1,18 +1,14 @@
 ﻿using System;
-using System.Globalization;
-using System.Threading;
+
 using Humanizer.Bytes;
 using Xunit;
 using Xunit.Extensions;
 
 namespace Humanizer.Tests.Bytes
 {
-    public class ParsingTests
+    public class ParsingTests : AmbientCulture
     {
-        public ParsingTests()
-        {
-            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
-        }
+        public ParsingTests() : base("en") { }
 
         [Fact]
         public void Parse()

--- a/src/Humanizer.Tests/Bytes/ToStringTests.cs
+++ b/src/Humanizer.Tests/Bytes/ToStringTests.cs
@@ -1,16 +1,11 @@
-﻿using System.Globalization;
-using System.Threading;
-using Humanizer.Bytes;
+﻿using Humanizer.Bytes;
 using Xunit;
 
 namespace Humanizer.Tests.Bytes
 {
-    public class ToStringTests
+    public class ToStringTests : AmbientCulture
     {
-        public ToStringTests()
-        {
-            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
-        }
+        public ToStringTests() : base("en") { }
 
         [Fact]
         public void ReturnsLargestMetricSuffix()


### PR DESCRIPTION
...ure machines. Right now, if someone runs the tests on a machine for which the current culture uses a different decimal separator, the tests fails. This fix explicitly sets the culture.
