### PR TITLE
DutchNumberToWordsConverter - Convert encoding to UTF-8 with BOM to fix E-umlaut symbol

### DIFF
--- a/src/Humanizer/Localisation/NumberToWords/DutchNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/DutchNumberToWordsConverter.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace Humanizer.Localisation.NumberToWords
@@ -70,7 +70,7 @@ namespace Humanizer.Localisation.NumberToWords
                     {
                         var units = UnitsMap[unit];
                         var trema = units.EndsWith("e");
-                        word += units + (trema ? "�n" : "en") + tens;
+                        word += units + (trema ? "ën" : "en") + tens;
                     }
                     else
                         word += tens;


### PR DESCRIPTION
Can someone with Dutch locale test this?
