### PR TITLE
correct russian ordinal of 3

### DIFF
--- a/src/Humanizer.Tests/Localisation/ru-RU/NumberToWordsTests.cs
+++ b/src/Humanizer.Tests/Localisation/ru-RU/NumberToWordsTests.cs
@@ -79,6 +79,7 @@ namespace Humanizer.Tests.Localisation.ruRU
         [InlineData(0, "нулевой")]
         [InlineData(1, "первый")]
         [InlineData(2, "второй")]
+        [InlineData(3, "третий")]
         [InlineData(10, "десятый")]
         [InlineData(11, "одиннадцатый")]
         [InlineData(12, "двенадцатый")]
@@ -139,6 +140,7 @@ namespace Humanizer.Tests.Localisation.ruRU
         [InlineData(0, "нулевая")]
         [InlineData(1, "первая")]
         [InlineData(2, "вторая")]
+        [InlineData(3, "третья")]
         [InlineData(10, "десятая")]
         [InlineData(11, "одиннадцатая")]
         [InlineData(12, "двенадцатая")]
@@ -200,6 +202,7 @@ namespace Humanizer.Tests.Localisation.ruRU
         }
 
         [Theory]
+        [InlineData(3, "третье")]
         [InlineData(111, "сто одиннадцатое")]
         [InlineData(1112, "одна тысяча сто двенадцатое")]
         [InlineData(11213, "одиннадцать тысячь двести тринадцатое")]

--- a/src/Humanizer/Localisation/NumberToWords/RussianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/RussianNumberToWordsConverter.cs
@@ -188,10 +188,16 @@ namespace Humanizer.Localisation.NumberToWords
                 case GrammaticalGender.Masculine:
                     if (number == 0 || number == 2 || number == 6 || number == 7 || number == 8 || number == 40)
                         return "ой";
+                    if (number == 3)
+                        return "ий";
                     return "ый";
                 case GrammaticalGender.Feminine:
+                    if (number == 3)
+                        return "ья";
                     return "ая";
                 case GrammaticalGender.Neuter:
+                    if (number == 3)
+                        return "ье";
                     return "ое";
                 default:
                     throw new ArgumentOutOfRangeException("gender");


### PR DESCRIPTION
add case missed in #211

@hazzik there is more uncovered cases, like for 21.000, 230.000.000 or 2.000.000.000
Actually it's not a big deal, cause how often do you get a two-billionth request :) But for completeness we should tackle those case also.

```
        [InlineData(21000, "двадцатиоднатысячьный")]
        [InlineData(230000000, "двухсоттридцатимиллионный")]
        [InlineData(2000000000, "двухмиллиардный")]
```
