### PR TITLE
Readme cleanup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -781,7 +781,7 @@ modelMetadata.DisplayName = modelMetadata.PropertyName.Humanize().Transform(To.T
 Please see <a href="CONTRIBUTING.md">CONTRIBUTING.md</a>.
 
 ##<a id="continuous-integration-from-teamcity">Continuous Integration from TeamCity</a>
-Humanizer project is built & tested continuously by TeamCity (more details [here](http://www.mehdi-khalili.com/continuous-integration-delivery-github-teamcity)). That applies to pull requests too. Shortly after you submit a PR you can check the build and test status notification on your PR. I would appreciate if you <a href="CONTRIBUTING.md">contribute</a> some green PRs.
+Humanizer project is built & tested continuously by TeamCity (more details [here](http://www.mehdi-khalili.com/continuous-integration-delivery-github-teamcity)). That applies to pull requests too. Shortly after you submit a PR you can check the build and test status notification on your PR. Feel free to jump in and <a href="CONTRIBUTING.md">contribute</a> some green PRs!
 
 The current build status on the CI server is <a href="http://teamcity.ginnivan.net/viewType.html?buildTypeId=Humanizer_CI&guest=1">
 <img src="http://teamcity.ginnivan.net/app/rest/builds/buildType:(id:Humanizer_CI)/statusIcon"/></a>

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,7 +3,6 @@
   - [#239](https://github.com/Mehdik/Humanizer/pull/239): Added Serbian localisation
   - [#241](https://github.com/Mehdik/Humanizer/pull/241): Added German ToWords localisation
   - [#244](https://github.com/MehdiK/Humanizer/pull/244): Added Slovenian localisation
-  - [#248](https://github.com/MedkiK/Humanizer/pull/248): Cleaned up phrasing and misspellings in readme.md, moved contribution section into CONTRIBUTING.md
 
 [Commits](https://github.com/MehdiK/Humanizer/compare/v1.24.1...master)
 


### PR DESCRIPTION
I hope this doesn't come off as too pushy, but I noticed some misspellings and odd phrases in readme.md.

I cleaned those up, stripped the trailing white space, and moved the contributing section to CONTRIBUTING.md so the guidelines will be linked on github when someone attempts to create a new PR.

I did also rephrase some of the contribution guide to remove "I" and "me" since talking about the project seemed more communal / welcoming. Again, sorry if that is an over-reach.
