### PR TITLE
Only return 'tomorrow' if datetime is actually tomorrow for DateTime Humanize

### DIFF
--- a/src/Humanizer.Tests/DateHumanize.cs
+++ b/src/Humanizer.Tests/DateHumanize.cs
@@ -15,8 +15,7 @@ namespace Humanizer.Tests
             var localNow = DateTime.Now;
 
             // feels like the only way to avoid breaking tests because CPU ticks over is to inject the base date
-            Assert.Equal(expectedString, utcNow.Add(deltaFromNow).Humanize(utcDate: true, dateToCompareAgainst: utcNow, culture: culture));
-            Assert.Equal(expectedString, localNow.Add(deltaFromNow).Humanize(utcDate: false, dateToCompareAgainst: localNow, culture: culture));
+            VerifyWithDate(expectedString, deltaFromNow, culture, localNow, utcNow);
         }
 
         static void VerifyWithDateInjection(string expectedString, TimeSpan deltaFromNow, CultureInfo culture)
@@ -24,11 +23,16 @@ namespace Humanizer.Tests
             var utcNow = new DateTime(2013, 6, 20, 9, 58, 22, DateTimeKind.Utc);
             var now = new DateTime(2013, 6, 20, 11, 58, 22, DateTimeKind.Local);
 
-            Assert.Equal(expectedString, utcNow.Add(deltaFromNow).Humanize(utcDate: true, dateToCompareAgainst: utcNow, culture: culture));
-            Assert.Equal(expectedString, now.Add(deltaFromNow).Humanize(false, now, culture: culture));
+            VerifyWithDate(expectedString, deltaFromNow, culture, now, utcNow);
         }
 
-        public static void Verify(string expectedString, int unit, TimeUnit timeUnit, Tense tense, double? precision = null, CultureInfo culture = null)
+        static void VerifyWithDate(string expectedString, TimeSpan deltaFromBase, CultureInfo culture, DateTime baseDate, DateTime baseDateUtc)
+        {
+            Assert.Equal(expectedString, baseDateUtc.Add(deltaFromBase).Humanize(utcDate: true, dateToCompareAgainst: baseDateUtc, culture: culture));
+            Assert.Equal(expectedString, baseDate.Add(deltaFromBase).Humanize(false, baseDate, culture: culture));
+        }
+
+        public static void Verify(string expectedString, int unit, TimeUnit timeUnit, Tense tense, double? precision = null, CultureInfo culture = null, DateTime? baseDate = null, DateTime? baseDateUtc = null)
         {
             if (precision.HasValue)
                 Configurator.DateTimeHumanizeStrategy = new PrecisionDateTimeHumanizeStrategy(precision.Value);
@@ -66,8 +70,15 @@ namespace Humanizer.Tests
                     break;
             }
 
-            VerifyWithCurrentDate(expectedString, deltaFromNow, culture);
-            VerifyWithDateInjection(expectedString, deltaFromNow, culture);
+            if (baseDate == null)
+            { 
+                VerifyWithCurrentDate(expectedString, deltaFromNow, culture);
+                VerifyWithDateInjection(expectedString, deltaFromNow, culture);
+            }
+            else
+            {
+                VerifyWithDate(expectedString, deltaFromNow, culture, baseDate.Value, baseDateUtc.Value);
+            }
         }
     }
 }

--- a/src/Humanizer.Tests/DateHumanizeDefaultStrategyTests.cs
+++ b/src/Humanizer.Tests/DateHumanizeDefaultStrategyTests.cs
@@ -2,6 +2,7 @@
 using Humanizer.Localisation;
 using Xunit;
 using Xunit.Extensions;
+using System;
 
 namespace Humanizer.Tests
 {
@@ -76,6 +77,18 @@ namespace Humanizer.Tests
         public void HoursFromNow(int hours, string expected)
         {
             DateHumanize.Verify(expected, hours, TimeUnit.Hour, Tense.Future);
+        }
+
+        [Theory]
+        [InlineData(38, "tomorrow")]
+        [InlineData(40, "2 days from now")]
+        public void HoursFromNowNotTomorrow(int hours, string expected)
+        {
+            //Only test with injected date, as results are dependent on time of day
+            var utcNow = new DateTime(2014, 6, 28, 9, 58, 22, DateTimeKind.Utc);
+            var now = new DateTime(2014, 6, 28, 9, 58, 22, DateTimeKind.Local);
+
+            DateHumanize.Verify(expected, hours, TimeUnit.Hour, Tense.Future, null, null, now, utcNow);
         }
 
         [Theory]

--- a/src/Humanizer/DateTimeHumanizeStrategy/DefaultDateTimeHumanizeStrategy.cs
+++ b/src/Humanizer/DateTimeHumanizeStrategy/DefaultDateTimeHumanizeStrategy.cs
@@ -44,7 +44,10 @@ namespace Humanizer.DateTimeHumanizeStrategy
                 return formatter.DateHumanize(TimeUnit.Hour, tense, ts.Hours);
 
             if (ts.TotalHours < 48)
-                return formatter.DateHumanize(TimeUnit.Day, tense, 1);
+            {
+                var days = Math.Abs((input.Date - comparisonBase.Date).Days);
+                return formatter.DateHumanize(TimeUnit.Day, tense, days);
+            }
 
             if (ts.TotalDays < 28)
                 return formatter.DateHumanize(TimeUnit.Day, tense, ts.Days);


### PR DESCRIPTION
Fixes issue #254

Restructured the DateHumanize test helper class to allow tests to only test against a specified date (rather than current), as you'd get inconsistent results with the current date/time.
