### PR TITLE
Have "waves" properly singularize to "wave"

### DIFF
--- a/src/Humanizer.Tests/InflectorTests.cs
+++ b/src/Humanizer.Tests/InflectorTests.cs
@@ -245,6 +245,8 @@ namespace Humanizer.Tests
             yield return new object[] {"alumna", "alumnae"};
             yield return new object[] {"alumnus", "alumni"};
             yield return new object[] {"fungus", "fungi"};
+
+            yield return new object[] {"wave","waves"};
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -103,6 +103,7 @@ namespace Humanizer
             AddIrregular("move", "moves");
             AddIrregular("goose", "geese");
             AddIrregular("alumna", "alumnae");
+            AddIrregular("wave","waves");
 
             AddUncountable("equipment");
             AddUncountable("information");


### PR DESCRIPTION
It seems the inflector thinks the singular version of "waves' is "wafe" due to `AddSingular("([^f])ves$", "$1fe");`. I've added an irregular for properly singularizing "waves" to "wave".
