### PR TITLE
WIK Fixed Bits vs Bytes issue

### DIFF
--- a/src/Humanizer.Tests/Bytes/ArithmeticTests.cs
+++ b/src/Humanizer.Tests/Bytes/ArithmeticTests.cs
@@ -1,0 +1,133 @@
+﻿using Humanizer.Bytes;
+using Xunit;
+
+namespace Humanizer.Tests.Bytes
+{
+    public class ArithmeticTests
+    {
+        [Fact]
+        public void Add()
+        {
+            var size1 = ByteSize.FromBytes(1);
+            var result = size1.Add(size1);
+
+            Assert.Equal(2, result.Bytes);
+            Assert.Equal(16, result.Bits);
+        }
+
+        [Fact]
+        public void AddBits()
+        {
+            var size = ByteSize.FromBytes(1).AddBits(8);
+
+            Assert.Equal(2, size.Bytes);
+            Assert.Equal(16, size.Bits);
+        }
+
+        [Fact]
+        public void AddBytes()
+        {
+            var size = ByteSize.FromBytes(1).AddBytes(1);
+
+            Assert.Equal(2, size.Bytes);
+            Assert.Equal(16, size.Bits);
+        }
+
+        [Fact]
+        public void AddKilobytes()
+        {
+            var size = ByteSize.FromKilobytes(2).AddKilobytes(2);
+
+            Assert.Equal(4 * 1024 * 8, size.Bits);
+            Assert.Equal(4 * 1024, size.Bytes);
+            Assert.Equal(4, size.Kilobytes);
+        }
+
+        [Fact]
+        public void AddMegabytes()
+        {
+            var size = ByteSize.FromMegabytes(2).AddMegabytes(2);
+
+            Assert.Equal(4 * 1024 * 1024 * 8, size.Bits);
+            Assert.Equal(4 * 1024 * 1024, size.Bytes);
+            Assert.Equal(4 * 1024, size.Kilobytes);
+            Assert.Equal(4, size.Megabytes);
+        }
+
+        [Fact]
+        public void AddGigabytes()
+        {
+            var size = ByteSize.FromGigabytes(2).AddGigabytes(2);
+
+            Assert.Equal(4d * 1024 * 1024 * 1024 * 8, size.Bits);
+            Assert.Equal(4d * 1024 * 1024 * 1024, size.Bytes);
+            Assert.Equal(4d * 1024 * 1024, size.Kilobytes);
+            Assert.Equal(4d * 1024, size.Megabytes);
+            Assert.Equal(4d, size.Gigabytes);
+        }
+
+        [Fact]
+        public void AddTerabytes()
+        {
+            var size = ByteSize.FromTerabytes(2).AddTerabytes(2);
+
+            Assert.Equal(4d * 1024 * 1024 * 1024 * 1024 * 8, size.Bits);
+            Assert.Equal(4d * 1024 * 1024 * 1024 * 1024, size.Bytes);
+            Assert.Equal(4d * 1024 * 1024 * 1024, size.Kilobytes);
+            Assert.Equal(4d * 1024 * 1024, size.Megabytes);
+            Assert.Equal(4d * 1024, size.Gigabytes);
+            Assert.Equal(4d, size.Terabytes);
+        }
+
+        [Fact]
+        public void Subtract()
+        {
+            var size = ByteSize.FromBytes(4).Subtract(ByteSize.FromBytes(2));
+
+            Assert.Equal(16, size.Bits);
+            Assert.Equal(2, size.Bytes);
+        }
+
+        [Fact]
+        public void IncrementOperator()
+        {
+            var size = ByteSize.FromBytes(2);
+            size++;
+
+            Assert.Equal(24, size.Bits);
+            Assert.Equal(3, size.Bytes);
+        }
+
+        [Fact]
+        public void MinusOperator()
+        {
+            var size = ByteSize.FromBytes(2);
+
+            size = -size;
+
+            Assert.Equal(-16, size.Bits);
+            Assert.Equal(-2, size.Bytes);
+        }
+
+        [Fact]
+        public void DecrementOperator()
+        {
+            var size = ByteSize.FromBytes(2);
+            size--;
+
+            Assert.Equal(8, size.Bits);
+            Assert.Equal(1, size.Bytes);
+        }
+
+        [Fact]
+        public void PlusOperator()
+        {
+            var size1 = ByteSize.FromBytes(1);
+            var size2 = ByteSize.FromBytes(1);
+
+            var result = size1 + size2;
+
+            Assert.Equal(2, result.Bytes);
+        }
+    }
+}

--- a/src/Humanizer.Tests/Humanizer.Tests.csproj
+++ b/src/Humanizer.Tests/Humanizer.Tests.csproj
@@ -57,6 +57,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Bytes\ArithmeticTests.cs" />
     <Compile Include="Bytes\ByteRateTests.cs" />
     <Compile Include="Bytes\ComparingTests.cs" />
     <Compile Include="Bytes\CreatingTests.cs" />

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -223,12 +223,12 @@ namespace Humanizer.Bytes
 
         public ByteSize Add(ByteSize bs)
         {
-            return new ByteSize(Bits + bs.Bits);
+            return new ByteSize(Bytes + bs.Bytes);
         }
 
         public ByteSize AddBits(long value)
         {
-            return new ByteSize(Bits + value);
+            return this + FromBits(value);
         }
 
         public ByteSize AddBytes(double value)
@@ -258,27 +258,27 @@ namespace Humanizer.Bytes
 
         public ByteSize Subtract(ByteSize bs)
         {
-            return new ByteSize(Bits - bs.Bits);
+            return new ByteSize(Bytes - bs.Bytes);
         }
 
         public static ByteSize operator +(ByteSize b1, ByteSize b2)
         {
-            return new ByteSize(b1.Bits + b2.Bits);
+            return new ByteSize(b1.Bytes + b2.Bytes);
         }
 
         public static ByteSize operator ++(ByteSize b)
         {
-            return new ByteSize(b.Bits++);
+            return new ByteSize(b.Bytes + 1);
         }
 
         public static ByteSize operator -(ByteSize b)
         {
-            return new ByteSize(-b.Bits);
+            return new ByteSize(-b.Bytes);
         }
 
         public static ByteSize operator --(ByteSize b)
         {
-            return new ByteSize(b.Bits--);
+            return new ByteSize(b.Bytes - 1);
         }
 
         public static bool operator ==(ByteSize b1, ByteSize b2)


### PR DESCRIPTION
Fixes #337 

I'm not sure we want to also port the fix for the Culture. Humanizer supports different cultures. If I were to set my culture to `fr` I think I would prefer to see `10,5 KB` instead of `10.5 KB`. Let me know what you think, I can also port the culture fixes.

I added an extra unit test for the + operator overload. I also renamed the tests so they would fit more with the naming convention in Humanizer (`Add` vs `AddMethod`)
