### PR TITLE
Removes UnitPreposition to avoid warnings in Win 8.1 apps

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,5 @@
 ###In Development
-
+ - [#366](https://github.com/MehdiK/Humanizer/pull/366): Removed UnitPreposition to avoid warnings in Win 8.1 apps
  - [#365](https://github.com/MehdiK/Humanizer/pull/365): Added ByteSizeExtensions method for long inputs
  - [#364](https://github.com/MehdiK/Humanizer/pull/364): Added "campuses" as plural of "campus"
  - [#363](https://github.com/MehdiK/Humanizer/pull/363): Use RegexOptions.Compiled if available

--- a/src/Humanizer/Localisation/Formatters/RomanianFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/RomanianFormatter.cs
@@ -8,24 +8,24 @@
         private const int PrepositionIndicatingDecimals = 2;
         private const int MaxNumeralWithNoPreposition = 19;
         private const int MinNumeralWithNoPreposition = 1;
-        private const string PrepositionResourceKey = "UnitPreposition";
+        private const string UnitPreposition = " de";
         private const string RomanianCultureCode = "ro";
 
         private static readonly double Divider = Math.Pow(10, PrepositionIndicatingDecimals);
 
-        private readonly CultureInfo romanianCulture;
+        private readonly CultureInfo _romanianCulture;
 
         public RomanianFormatter()
             : base(RomanianCultureCode)
         {
-            romanianCulture = new CultureInfo(RomanianCultureCode);
+            _romanianCulture = new CultureInfo(RomanianCultureCode);
         }
 
         protected override string Format(string resourceKey, int number)
         {
-            var format = Resources.GetResource(GetResourceKey(resourceKey, number), romanianCulture);
+            var format = Resources.GetResource(GetResourceKey(resourceKey, number), _romanianCulture);
             var preposition = ShouldUsePreposition(number)
-                                     ? Resources.GetResource(PrepositionResourceKey, romanianCulture)
+                                     ? UnitPreposition
                                      : string.Empty;
 
             return format.FormatWith(number, preposition);

--- a/src/Humanizer/Properties/Resources.ro.resx
+++ b/src/Humanizer/Properties/Resources.ro.resx
@@ -192,9 +192,6 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>peste un an</value>
   </data>
-  <data name="UnitPreposition" xml:space="preserve">
-    <value> de</value>
-  </data>
   <data name="TimeSpanHumanize_MultipleDays" xml:space="preserve">
     <value>{0}{1} zile</value>
   </data>


### PR DESCRIPTION
Alternative solution for #360 to fix warnings in #317
