### PR TITLE
ToPossessive 

### DIFF
--- a/src/Humanizer.Tests/Humanizer.Tests.csproj
+++ b/src/Humanizer.Tests/Humanizer.Tests.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Localisation\zh-Hant\TimeSpanHumanizeTests.cs" />
     <Compile Include="Localisation\zh-CN\DateHumanizeTests.cs" />
     <Compile Include="Localisation\zh-CN\TimeSpanHumanizeTests.cs" />
+    <Compile Include="PossessiveTests.cs" />
     <Compile Include="ResourceKeyTests.cs" />
     <Compile Include="RomanNumeralTests.cs" />
     <Compile Include="StringExtensionsTests.cs" />

--- a/src/Humanizer.Tests/PossessiveTests.cs
+++ b/src/Humanizer.Tests/PossessiveTests.cs
@@ -1,0 +1,23 @@
+﻿using Xunit;
+using Xunit.Extensions;
+
+namespace Humanizer.Tests
+{
+    public class PossessiveTests
+    {
+        [Theory]
+        [InlineData("Joe", "Joe's")]
+        [InlineData("Car", "Car's")]
+        [InlineData("Jones", "Jones'")]
+        [InlineData("Joneses", "Joneses'")]
+        [InlineData("Desks", "Desks'")]
+        [InlineData("his", "his")]
+        [InlineData("Yours", "Yours")]
+        [InlineData("Illinois", "Illinois's")]
+        [InlineData("corps", "corps's")]
+        public void ApplyPossessive(string input, string expectedOutput)
+        {
+            Assert.Equal(expectedOutput, input.ToPossessive());
+        }
+    }
+}

--- a/src/Humanizer/Humanizer.csproj
+++ b/src/Humanizer/Humanizer.csproj
@@ -151,6 +151,7 @@
     <Compile Include="NoMatchFoundException.cs" />
     <Compile Include="RomanNumeralExtensions.cs" />
     <Compile Include="StringExtensions.cs" />
+    <Compile Include="TransformToPossessive.cs" />
     <Compile Include="ToQuantityExtensions.cs" />
     <Compile Include="Transformer\To.cs" />
     <Compile Include="Transformer\IStringTransformer.cs" />
@@ -243,9 +244,6 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetPortable)' == 'false' ">
-    <Reference Include="System" />
   </ItemGroup>
   <Import Condition=" '$(TargetPortable)' == 'false' " Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Condition=" '$(TargetPortable)' == 'true' " Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />

--- a/src/Humanizer/Humanizer.csproj
+++ b/src/Humanizer/Humanizer.csproj
@@ -245,6 +245,9 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetPortable)' == 'false' ">
+    <Reference Include="System" />
+  </ItemGroup>
   <Import Condition=" '$(TargetPortable)' == 'false' " Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Condition=" '$(TargetPortable)' == 'true' " Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <PropertyGroup>

--- a/src/Humanizer/TransformToPossessive.cs
+++ b/src/Humanizer/TransformToPossessive.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+using System.Text;
+
+namespace Humanizer
+{
+    public static class TransformToPossessive
+    {
+        private static readonly string[] _possessivePronouns = { "ITS", "MY", "MINE", "YOUR", "HER", "HERS", "HIS", "OUR", "OURS", "THEIR", "THEIRS", "YOURS" };
+        private static readonly string[] _nounsEndingInSilentS = { "ILLINOIS", "ARKANSAS", "CORPS" };
+        public static string ToPossessive(this string input)
+        {
+            if (IsPossessivePronoun(input))
+                return input;
+            var possessiveBuilder = new StringBuilder();
+            possessiveBuilder.Append(input);
+            var result = (EndsInS(input) ? 
+                (EndsInSilentS(input) ? 
+                    possessiveBuilder.Append("'s") : possessiveBuilder.Append("'")) : 
+                possessiveBuilder.Append("'s"));
+            return result.ToString();
+        }
+
+        private static bool EndsInS(string input)
+        {
+            var len = input.Length;
+            var lastChar = input[len - 1];
+            return (char.ToUpper(lastChar) == 'S');
+        }
+
+        private static bool EndsInSilentS(string input)
+        {
+            var uppercaseInput = input.ToUpper().Trim();
+            return (_nounsEndingInSilentS.Contains(uppercaseInput));
+        }
+
+        private static bool IsPossessivePronoun(string input)
+        {
+            var uppercaseInput = input.ToUpper().Trim();
+            return (_possessivePronouns.Contains(uppercaseInput));
+        }
+    }
+}


### PR DESCRIPTION
To Possessive functionality added along with tests in new branch ToPossessive, covering cases of default, words ending in 's', common words ending in silent 's' and common possessive pronouns which require no changes. These latter two lists of words will almost certainly be appended to as time goes by.

Just looking at this code I can see that you guys are awesome developers and way beyond my level. Whether you accept this fix or not I welcome any criticism concerning the code and future advice for submitting pull requests and designing bug fixes in general. Thanks for looking!
