### PR TITLE
Letter casing bitflags fix

### DIFF
--- a/src/Humanizer.Tests/BitFieldEnumHumanizeTests.cs
+++ b/src/Humanizer.Tests/BitFieldEnumHumanizeTests.cs
@@ -7,8 +7,10 @@ using Xunit;
 
 namespace Humanizer.Tests
 {
-    public class BitFieldEnumHumanizeTests
+    public class BitFieldEnumHumanizeTests : AmbientCulture
     {
+        public BitFieldEnumHumanizeTests() : base("en") { }
+
         [Fact]
         public void CanHumanizeSingleWordDescriptionAttribute()
         {

--- a/src/Humanizer.Tests/BitFieldEnumHumanizeTests.cs
+++ b/src/Humanizer.Tests/BitFieldEnumHumanizeTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Humanizer.Tests
+{
+    public class BitFieldEnumHumanizeTests
+    {
+        [Fact]
+        public void CanHumanizeSingleWordDescriptionAttribute()
+        {
+            Assert.Equal(BitFlagEnumTestsResources.MemberWithSingleWordDescriptionAttribute, BitFieldEnumUnderTest.RED.Humanize());
+        }
+
+        [Fact]
+        public void CanHumanizeMultipleWordDescriptionAttribute()
+        {
+            Assert.Equal(BitFlagEnumTestsResources.MemberWithMultipleWordDescriptionAttribute, BitFieldEnumUnderTest.DARK_GRAY.Humanize());
+        }
+
+        [Fact]
+        public void CanHumanizeMultipleValueBitFieldEnum()
+        {
+            var xoredBitFlag = (BitFieldEnumUnderTest.RED | BitFieldEnumUnderTest.DARK_GRAY);
+            Assert.Equal(BitFlagEnumTestsResources.ExpectedResultWhenBothValuesXored, xoredBitFlag.Humanize());
+        }
+    }
+}

--- a/src/Humanizer.Tests/BitFieldEnumUnderTest.cs
+++ b/src/Humanizer.Tests/BitFieldEnumUnderTest.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Humanizer.Tests
+{
+    [Flags]
+    public enum BitFieldEnumUnderTest : int
+    {
+        [Description(BitFlagEnumTestsResources.MemberWithSingleWordDescriptionAttribute)]
+        RED = 1,
+        [Description(BitFlagEnumTestsResources.MemberWithMultipleWordDescriptionAttribute)]
+        DARK_GRAY = 2
+    }
+
+    public class BitFlagEnumTestsResources
+    {
+        public const string MemberWithSingleWordDescriptionAttribute = "Red";
+        public const string MemberWithMultipleWordDescriptionAttribute = "Dark Gray";
+
+        public const string ExpectedResultWhenBothValuesXored = "Red, Dark Gray";
+    }
+}

--- a/src/Humanizer.Tests/BitFieldEnumUnderTest.cs
+++ b/src/Humanizer.Tests/BitFieldEnumUnderTest.cs
@@ -21,6 +21,6 @@ namespace Humanizer.Tests
         public const string MemberWithSingleWordDescriptionAttribute = "Red";
         public const string MemberWithMultipleWordDescriptionAttribute = "Dark Gray";
 
-        public const string ExpectedResultWhenBothValuesXored = "Red, Dark Gray";
+        public const string ExpectedResultWhenBothValuesXored = "Red and Dark Gray";
     }
 }

--- a/src/Humanizer.Tests/Humanizer.Tests.csproj
+++ b/src/Humanizer.Tests/Humanizer.Tests.csproj
@@ -97,6 +97,8 @@
   <ItemGroup>
     <Compile Include="App_Packages\ApiApprover.3.0.1\PublicApiApprover.cs" />
     <Compile Include="App_Packages\ApiApprover.3.0.1\PublicApiGenerator.cs" />
+    <Compile Include="BitFieldEnumHumanizeTests.cs" />
+    <Compile Include="BitFieldEnumUnderTest.cs" />
     <Compile Include="Bytes\ArithmeticTests.cs" />
     <Compile Include="Bytes\ByteRateTests.cs" />
     <Compile Include="Bytes\ComparingTests.cs" />

--- a/src/Humanizer/EnumHumanizeExtensions.cs
+++ b/src/Humanizer/EnumHumanizeExtensions.cs
@@ -61,7 +61,6 @@ namespace Humanizer
         /// <summary>
         /// Checks whether the given enum is to be used as a bit field type.
         /// </summary>
-        /// <seealso cref="https://msdn.microsoft.com/en-us/library/system.flagsattribute(v=vs.110).aspx" />
         /// <param name="input">An enum</param>
         /// <returns>True if the given enum is a bit field enum, false otherwise.</returns>
         private static bool IsBitFieldEnum(Enum input)
@@ -80,22 +79,6 @@ namespace Humanizer
         /// </summary>
         /// <param name="input">An instance of an enum.</param>
         /// <returns>True, if the instance maps directly to a single enum property, false if otherwise.</returns>
-        /// <example>
-        /// <code>
-        /// [FlagsAttribute] 
-        /// enum MultiHue : short
-        /// {
-        ///     None = 0,
-        ///     Black = 1,
-        ///     Red = 2,
-        ///     Green = 4,
-        ///     Blue = 8
-        /// };
-        /// 
-        /// var matches = (MultiHue) 1; // Same as "MultieHue.Black" and maps directly to an enum property.
-        /// var doesntMatch = (MultieHue) 3; // Equivalent to "MultieHue.Black | MultieHue.Red" but doesn't map directly to any single enum property.
-        /// </code>
-        /// </example>
         private static bool DirectlyMapsToEnumConstant(Enum input)
         {
             bool exactMatch = false;

--- a/src/Humanizer/EnumHumanizeExtensions.cs
+++ b/src/Humanizer/EnumHumanizeExtensions.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using Humanizer.Configuration;
+using System.Collections.Generic;
 
 namespace Humanizer
 {
@@ -23,6 +24,26 @@ namespace Humanizer
         public static string Humanize(this Enum input)
         {
             var type = input.GetType();
+
+            if (IsBitFieldEnum(input) && !DirectlyMapsToEnumConstant(input))
+            {
+                var inputIntValue = Convert.ToInt32(input);
+
+                var humanizedEnumValues = new List<string>();
+
+                foreach (var enumValue in Enum.GetValues(type))
+                {
+                    var enumIntValue = (int)enumValue;
+
+                    if ((inputIntValue & enumIntValue) != 0)
+                    {
+                        humanizedEnumValues.Add(EnumHumanizeExtensions.Humanize((Enum)enumValue));
+                    }
+                }
+
+                return String.Join(", ", humanizedEnumValues);
+            }
+
             var caseName = input.ToString();
             var memInfo = type.GetTypeInfo().GetDeclaredField(caseName);
 
@@ -35,6 +56,60 @@ namespace Humanizer
             }
 
             return caseName.Humanize();
+        }
+
+        /// <summary>
+        /// Checks whether the given enum is to be used as a bit field type.
+        /// </summary>
+        /// <seealso cref="https://msdn.microsoft.com/en-us/library/system.flagsattribute(v=vs.110).aspx" />
+        /// <param name="input">An enum</param>
+        /// <returns>True if the given enum is a bit field enum, false otherwise.</returns>
+        private static bool IsBitFieldEnum(Enum input)
+        {
+            var type = input.GetType();
+
+            var hasFlagsAttribute = type.GetTypeInfo().GetCustomAttribute(typeof(FlagsAttribute)) != null;
+            var underlyingTypeIsInt = Enum.GetUnderlyingType(type) == typeof(int);
+
+            return hasFlagsAttribute && underlyingTypeIsInt;
+        }
+
+        /// <summary>
+        /// Returns true if the given enum instance can map exactly to one of the enum's constants.
+        /// This doesn't always happen when using BitField enums.
+        /// </summary>
+        /// <param name="input">An instance of an enum.</param>
+        /// <returns>True, if the instance maps directly to a single enum property, false if otherwise.</returns>
+        /// <example>
+        /// <code>
+        /// [FlagsAttribute] 
+        /// enum MultiHue : short
+        /// {
+        ///     None = 0,
+        ///     Black = 1,
+        ///     Red = 2,
+        ///     Green = 4,
+        ///     Blue = 8
+        /// };
+        /// 
+        /// var matches = (MultiHue) 1; // Same as "MultieHue.Black" and maps directly to an enum property.
+        /// var doesntMatch = (MultieHue) 3; // Equivalent to "MultieHue.Black | MultieHue.Red" but doesn't map directly to any single enum property.
+        /// </code>
+        /// </example>
+        private static bool DirectlyMapsToEnumConstant(Enum input)
+        {
+            bool exactMatch = false;
+
+            foreach (var raw in Enum.GetValues(input.GetType()))
+            {
+                if (input.Equals(raw))
+                {
+                    exactMatch = true;
+                    break;
+                }
+            }
+
+            return exactMatch;
         }
 
         // I had to add this method because PCL doesn't have DescriptionAttribute & I didn't want two versions of the code & thus the reflection

--- a/src/Humanizer/EnumHumanizeExtensions.cs
+++ b/src/Humanizer/EnumHumanizeExtensions.cs
@@ -41,7 +41,7 @@ namespace Humanizer
                     }
                 }
 
-                return String.Join(", ", humanizedEnumValues);
+                return CollectionHumanizeExtensions.Humanize<string>(humanizedEnumValues);
             }
 
             var caseName = input.ToString();


### PR DESCRIPTION
fixes #473

Fix for humanizing bitfield enums which:

* Use the `DescriptionAttribute`
* Don't map to a _single_ enum value because they are created by ORing together multiple values.

Example from #473:
```C#
    class Program
    {
        [Flags]
        private enum Colors : int
        {
            [Description("None")]
            NONE = 0,
            [Description("Red")]
            RED = 1,
            [Description("Green")]
            GREEN = 2,
            [Description("Blue")]
            BLUE = 4,
            [Description("Greenish Yellow")]
            GREENISH_YELLOW = 8
        }

        static void Main(string[] args)
        {
            Colors multipleColors = Colors.GREENISH_YELLOW | Colors.BLUE | Colors.RED;
            Colors singleColor = Colors.RED;

            // CORRECT
            // Expected: "Red"
            // Actual: "Red"
            Console.WriteLine(singleColor.Humanize());

            // INCORRECT
            // Expected: "Red, Blue, Greenish Yellow"
            // Actual: "RED, BLUE, GREENISH YELLOW"
            Console.WriteLine(multipleColors.Humanize());

            Console.ReadKey();
        }
    }
```