### PR TITLE
Adding 'never' threshold to DateTimeHumanizeStrategy

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -283,10 +283,13 @@ DateTimeOffset.AddHours(1).Humanize() => "an hour from now"
 
 Humanizer supports both local and UTC dates as well as dates with offset (`DateTimeOffset`). You could also provide the date you want the input date to be compared against. If null, it will use the current date as comparison base.
 Also, culture to use can be specified explicitly. If it is not, current thread's current UI culture is used.
+
+In addition when applied to `DateTime` a threshold may be specified (`dateNeverThreshold`). If the measured time is smaller than the threshold, the returned value will default to *never*.
+
 Here is the API signature:
 
 ```C#
-public static string Humanize(this DateTime input, bool utcDate = true, DateTime? dateToCompareAgainst = null, CultureInfo culture = null)
+public static string Humanize(this DateTime input, bool utcDate = true, DateTime? dateToCompareAgainst = null, CultureInfo culture = null, DateTime? dateNeverThreshold = null)
 public static string Humanize(this DateTimeOffset input, DateTimeOffset? dateToCompareAgainst = null, CultureInfo culture = null)
 ```
 

--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
@@ -129,7 +129,7 @@ namespace Humanizer
     public class static DateHumanizeExtensions
     {
         public static string Humanize(this System.DateTime input, bool utcDate = True, System.Nullable<System.DateTime> dateToCompareAgainst = null, System.Globalization.CultureInfo culture = null, System.Nullable<System.DateTime> dateNeverThreshold = null) { }
-        public static string Humanize(this System.DateTimeOffset input, System.Nullable<System.DateTimeOffset> dateToCompareAgainst = null, System.Globalization.CultureInfo culture = null) { }
+        public static string Humanize(this System.DateTimeOffset input, System.Nullable<System.DateTimeOffset> dateToCompareAgainst = null, System.Globalization.CultureInfo culture = null, System.Nullable<System.DateTimeOffset> dateNeverThreshold = null) { }
     }
     public class static EnumDehumanizeExtensions
     {
@@ -1016,7 +1016,7 @@ namespace Humanizer.DateTimeHumanizeStrategy
     public class DefaultDateTimeOffsetHumanizeStrategy : Humanizer.DateTimeHumanizeStrategy.IDateTimeOffsetHumanizeStrategy
     {
         public DefaultDateTimeOffsetHumanizeStrategy() { }
-        public string Humanize(System.DateTimeOffset input, System.DateTimeOffset comparisonBase, System.Globalization.CultureInfo culture) { }
+        public string Humanize(System.DateTimeOffset input, System.DateTimeOffset comparisonBase, System.Globalization.CultureInfo culture, System.DateTimeOffset dateNeverThreshold) { }
     }
     public interface IDateTimeHumanizeStrategy
     {
@@ -1024,7 +1024,7 @@ namespace Humanizer.DateTimeHumanizeStrategy
     }
     public interface IDateTimeOffsetHumanizeStrategy
     {
-        string Humanize(System.DateTimeOffset input, System.DateTimeOffset comparisonBase, System.Globalization.CultureInfo culture);
+        string Humanize(System.DateTimeOffset input, System.DateTimeOffset comparisonBase, System.Globalization.CultureInfo culture, System.DateTimeOffset dateNeverThreshold);
     }
     public class PrecisionDateTimeHumanizeStrategy : Humanizer.DateTimeHumanizeStrategy.IDateTimeHumanizeStrategy
     {
@@ -1034,7 +1034,7 @@ namespace Humanizer.DateTimeHumanizeStrategy
     public class PrecisionDateTimeOffsetHumanizeStrategy : Humanizer.DateTimeHumanizeStrategy.IDateTimeOffsetHumanizeStrategy
     {
         public PrecisionDateTimeOffsetHumanizeStrategy(double precision = 0.75) { }
-        public string Humanize(System.DateTimeOffset input, System.DateTimeOffset comparisonBase, System.Globalization.CultureInfo culture) { }
+        public string Humanize(System.DateTimeOffset input, System.DateTimeOffset comparisonBase, System.Globalization.CultureInfo culture, System.DateTimeOffset dateNeverThreshold) { }
     }
 }
 namespace Humanizer.Inflections

--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
@@ -128,7 +128,7 @@ namespace Humanizer
     }
     public class static DateHumanizeExtensions
     {
-        public static string Humanize(this System.DateTime input, bool utcDate = True, System.Nullable<System.DateTime> dateToCompareAgainst = null, System.Globalization.CultureInfo culture = null) { }
+        public static string Humanize(this System.DateTime input, bool utcDate = True, System.Nullable<System.DateTime> dateToCompareAgainst = null, System.Globalization.CultureInfo culture = null, System.Nullable<System.DateTime> dateNeverThreshold = null) { }
         public static string Humanize(this System.DateTimeOffset input, System.Nullable<System.DateTimeOffset> dateToCompareAgainst = null, System.Globalization.CultureInfo culture = null) { }
     }
     public class static EnumDehumanizeExtensions
@@ -1011,7 +1011,7 @@ namespace Humanizer.DateTimeHumanizeStrategy
     public class DefaultDateTimeHumanizeStrategy : Humanizer.DateTimeHumanizeStrategy.IDateTimeHumanizeStrategy
     {
         public DefaultDateTimeHumanizeStrategy() { }
-        public string Humanize(System.DateTime input, System.DateTime comparisonBase, System.Globalization.CultureInfo culture) { }
+        public string Humanize(System.DateTime input, System.DateTime comparisonBase, System.Globalization.CultureInfo culture, System.Nullable<System.DateTime> dateNeverThreshold = null) { }
     }
     public class DefaultDateTimeOffsetHumanizeStrategy : Humanizer.DateTimeHumanizeStrategy.IDateTimeOffsetHumanizeStrategy
     {
@@ -1020,7 +1020,7 @@ namespace Humanizer.DateTimeHumanizeStrategy
     }
     public interface IDateTimeHumanizeStrategy
     {
-        string Humanize(System.DateTime input, System.DateTime comparisonBase, System.Globalization.CultureInfo culture);
+        string Humanize(System.DateTime input, System.DateTime comparisonBase, System.Globalization.CultureInfo culture, System.Nullable<System.DateTime> dateNeverThreshold = null);
     }
     public interface IDateTimeOffsetHumanizeStrategy
     {
@@ -1029,7 +1029,7 @@ namespace Humanizer.DateTimeHumanizeStrategy
     public class PrecisionDateTimeHumanizeStrategy : Humanizer.DateTimeHumanizeStrategy.IDateTimeHumanizeStrategy
     {
         public PrecisionDateTimeHumanizeStrategy(double precision = 0.75) { }
-        public string Humanize(System.DateTime input, System.DateTime comparisonBase, System.Globalization.CultureInfo culture) { }
+        public string Humanize(System.DateTime input, System.DateTime comparisonBase, System.Globalization.CultureInfo culture, System.Nullable<System.DateTime> dateNeverThreshold = null) { }
     }
     public class PrecisionDateTimeOffsetHumanizeStrategy : Humanizer.DateTimeHumanizeStrategy.IDateTimeOffsetHumanizeStrategy
     {
@@ -1122,6 +1122,7 @@ namespace Humanizer.Localisation
         public ResourceKeys() { }
         public class static DateHumanize
         {
+            public const string Never = "DateHumanize_Never";
             public const string Now = "DateHumanize_Now";
             public static string GetResourceKey(Humanizer.Localisation.TimeUnit timeUnit, Humanizer.Localisation.Tense timeUnitTense, int count = 1) { }
         }
@@ -1149,5 +1150,6 @@ namespace Humanizer.Localisation
         Week = 5,
         Month = 6,
         Year = 7,
+        Never = 8,
     }
 }

--- a/src/Humanizer.Tests/DateHumanize.cs
+++ b/src/Humanizer.Tests/DateHumanize.cs
@@ -19,6 +19,15 @@ namespace Humanizer.Tests
             VerifyWithDate(expectedString, deltaFromNow, culture, localNow, utcNow);
         }
 
+        static void VerifyWithCurrentDateAndNeverThreshold(string expectedString, TimeSpan deltaFromNow, CultureInfo culture, DateTime dateNeverThreshold, DateTime dateNeverThresholdUtc)
+        {
+            var utcNow = DateTime.UtcNow;
+            var localNow = DateTime.Now;
+
+            // feels like the only way to avoid breaking tests because CPU ticks over is to inject the base date
+            VerifyWithDateAndNeverThreshold(expectedString, deltaFromNow, culture, localNow, utcNow, dateNeverThreshold, dateNeverThresholdUtc);
+        }
+
         static void VerifyWithDateInjection(string expectedString, TimeSpan deltaFromNow, CultureInfo culture)
         {
             var utcNow = new DateTime(2013, 6, 20, 9, 58, 22, DateTimeKind.Utc);
@@ -27,13 +36,27 @@ namespace Humanizer.Tests
             VerifyWithDate(expectedString, deltaFromNow, culture, now, utcNow);
         }
 
+        static void VerifyWithDateInjectionAndNeverThreshold(string expectedString, TimeSpan deltaFromNow, CultureInfo culture, DateTime dateNeverThreshold, DateTime dateNeverThresholdUtc)
+        {
+            var utcNow = new DateTime(2013, 6, 20, 9, 58, 22, DateTimeKind.Utc);
+            var now = new DateTime(2013, 6, 20, 11, 58, 22, DateTimeKind.Local);
+
+            VerifyWithDateAndNeverThreshold(expectedString, deltaFromNow, culture, now, utcNow, dateNeverThreshold, dateNeverThresholdUtc);
+        }
+
         static void VerifyWithDate(string expectedString, TimeSpan deltaFromBase, CultureInfo culture, DateTime baseDate, DateTime baseDateUtc)
         {
             Assert.Equal(expectedString, baseDateUtc.Add(deltaFromBase).Humanize(utcDate: true, dateToCompareAgainst: baseDateUtc, culture: culture));
             Assert.Equal(expectedString, baseDate.Add(deltaFromBase).Humanize(false, baseDate, culture: culture));
         }
 
-        public static void Verify(string expectedString, int unit, TimeUnit timeUnit, Tense tense, double? precision = null, CultureInfo culture = null, DateTime? baseDate = null, DateTime? baseDateUtc = null)
+        static void VerifyWithDateAndNeverThreshold(string expectedString, TimeSpan deltaFromBase, CultureInfo culture, DateTime baseDate, DateTime baseDateUtc, DateTime dateNeverThreshold, DateTime dateNeverThresholdUtc)
+        {
+            Assert.Equal(expectedString, baseDateUtc.Add(deltaFromBase).Humanize(utcDate: true, dateToCompareAgainst: baseDateUtc, culture: culture, dateNeverThreshold: dateNeverThresholdUtc));
+            Assert.Equal(expectedString, baseDate.Add(deltaFromBase).Humanize(false, baseDate, culture: culture, dateNeverThreshold: dateNeverThreshold));
+        }
+
+        public static void Verify(string expectedString, int unit, TimeUnit timeUnit, Tense tense, double? precision = null, CultureInfo culture = null, DateTime? baseDate = null, DateTime? baseDateUtc = null, DateTime? dateNeverThreshold = null, DateTime? dateNeverThresholdUtc = null)
         {
             // We lock this as these tests can be multi-threaded and we're setting a static
             lock (LockObject)
@@ -76,13 +99,28 @@ namespace Humanizer.Tests
 
                 if (baseDate == null)
                 {
-                    VerifyWithCurrentDate(expectedString, deltaFromNow, culture);
-                    VerifyWithDateInjection(expectedString, deltaFromNow, culture);
-                }
+                    if (dateNeverThreshold.HasValue && dateNeverThresholdUtc.HasValue)
+                    {
+                        VerifyWithCurrentDateAndNeverThreshold(expectedString, deltaFromNow, culture, dateNeverThreshold.Value, dateNeverThresholdUtc.Value);
+                        VerifyWithDateInjectionAndNeverThreshold(expectedString, deltaFromNow, culture, dateNeverThreshold.Value, dateNeverThresholdUtc.Value);
+                    }
+                    else
+                    {
+                        VerifyWithCurrentDate(expectedString, deltaFromNow, culture);
+                        VerifyWithDateInjection(expectedString, deltaFromNow, culture);
+                    }                        
+                }                
                 else
                 {
-                    VerifyWithDate(expectedString, deltaFromNow, culture, baseDate.Value, baseDateUtc.Value);
-                }
+                    if (dateNeverThreshold.HasValue && dateNeverThresholdUtc.HasValue)
+                    {
+                        VerifyWithDateAndNeverThreshold(expectedString, deltaFromNow, culture, baseDate.Value, baseDateUtc.Value, dateNeverThreshold.Value, dateNeverThresholdUtc.Value);
+                    }
+                    else
+                    {
+                        VerifyWithDate(expectedString, deltaFromNow, culture, baseDate.Value, baseDateUtc.Value);
+                    }                    
+                }                
             }
         }
     }

--- a/src/Humanizer.Tests/DateHumanizeDefaultStrategyTests.cs
+++ b/src/Humanizer.Tests/DateHumanizeDefaultStrategyTests.cs
@@ -145,6 +145,27 @@ namespace Humanizer.Tests
         {
             DateHumanize.Verify(expected, years, TimeUnit.Year, Tense.Future);
         }
+        
+        [Fact]
+        public void NeverWithoutBaseDate()
+        {
+            var dateNeverThresholdUtc = DateTime.UtcNow.Subtract(TimeSpan.FromDays(1));
+            var dateNeverThreshold = DateTime.Now.Subtract(TimeSpan.FromDays(1));
+
+            DateHumanize.Verify("never", 2, TimeUnit.Day, Tense.Past, null, null, null, null, dateNeverThreshold, dateNeverThresholdUtc);
+        }
+
+        [Fact]
+        public void NeverWithBaseDate()
+        {
+            var baseDateUtc = DateTime.UtcNow.Subtract(TimeSpan.FromDays(1));
+            var baseDate = DateTime.Now.Subtract(TimeSpan.FromDays(1));
+
+            var dateNeverThresholdUtc = DateTime.UtcNow.Subtract(TimeSpan.FromDays(1));
+            var dateNeverThreshold = DateTime.Now.Subtract(TimeSpan.FromDays(1));
+
+            DateHumanize.Verify("never", 2, TimeUnit.Day, Tense.Past, null, null, baseDate, baseDateUtc, dateNeverThreshold, dateNeverThresholdUtc);
+        }
 
         [Fact]
         public void Now()

--- a/src/Humanizer.Tests/DateTimeOffsetHumanizeTests.cs
+++ b/src/Humanizer.Tests/DateTimeOffsetHumanizeTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Humanizer.Configuration;
 using Humanizer.DateTimeHumanizeStrategy;
 using Xunit;
+using Humanizer.Localisation;
 
 namespace Humanizer.Tests
 {
@@ -68,6 +69,19 @@ namespace Humanizer.Tests
             var actualResult = inputTime.Humanize(baseTime);
 
             Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void DefaultStrategy_Never()
+        {
+            Configurator.DateTimeOffsetHumanizeStrategy = new DefaultDateTimeOffsetHumanizeStrategy();
+
+            var inputTime = new DateTimeOffset(2015, 11, 23, 01, 30, 0, new TimeSpan(1, 0, 0));
+            var thresholdTime = new DateTimeOffset(2015, 11, 23, 02, 45, 0, new TimeSpan(2, 0, 0));
+
+            var actualResult = inputTime.Humanize(dateNeverThreshold: thresholdTime);
+
+            Assert.Equal("never", actualResult);            
         }
     }
 }

--- a/src/Humanizer/DateHumanizeExtensions.cs
+++ b/src/Humanizer/DateHumanizeExtensions.cs
@@ -44,8 +44,9 @@ namespace Humanizer
         public static string Humanize(this DateTimeOffset input, DateTimeOffset? dateToCompareAgainst = null, CultureInfo culture = null, DateTimeOffset? dateNeverThreshold = null)
         {
             var comparisonBase = dateToCompareAgainst ?? DateTimeOffset.UtcNow;
+            var neverThreshold = dateNeverThreshold ?? new DateTimeOffset();
 
-            return Configurator.DateTimeOffsetHumanizeStrategy.Humanize(input, comparisonBase, culture, dateNeverThreshold.Value);
+            return Configurator.DateTimeOffsetHumanizeStrategy.Humanize(input, comparisonBase, culture, neverThreshold);
         }
     }
 }

--- a/src/Humanizer/DateHumanizeExtensions.cs
+++ b/src/Humanizer/DateHumanizeExtensions.cs
@@ -39,12 +39,13 @@ namespace Humanizer
         /// <param name="input">The date to be humanized</param>
         /// <param name="dateToCompareAgainst">Date to compare the input against. If null, current date is used as base</param>
         /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+        /// <param name="dateNeverThreshold">Threshold date to indicate 'never' if input is before it.</param>
         /// <returns>distance of time in words</returns>
-        public static string Humanize(this DateTimeOffset input, DateTimeOffset? dateToCompareAgainst = null, CultureInfo culture = null)
+        public static string Humanize(this DateTimeOffset input, DateTimeOffset? dateToCompareAgainst = null, CultureInfo culture = null, DateTimeOffset? dateNeverThreshold = null)
         {
             var comparisonBase = dateToCompareAgainst ?? DateTimeOffset.UtcNow;
 
-            return Configurator.DateTimeOffsetHumanizeStrategy.Humanize(input, comparisonBase, culture);
+            return Configurator.DateTimeOffsetHumanizeStrategy.Humanize(input, comparisonBase, culture, dateNeverThreshold.Value);
         }
     }
 }

--- a/src/Humanizer/DateHumanizeExtensions.cs
+++ b/src/Humanizer/DateHumanizeExtensions.cs
@@ -16,15 +16,21 @@ namespace Humanizer
         /// <param name="utcDate">Boolean value indicating whether the date is in UTC or local</param>
         /// <param name="dateToCompareAgainst">Date to compare the input against. If null, current date is used as base</param>
         /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+        /// <param name="dateNeverThreshold">Threshold date to indicate 'never' if input is before it.</param>
         /// <returns>distance of time in words</returns>
-        public static string Humanize(this DateTime input, bool utcDate = true, DateTime? dateToCompareAgainst = null, CultureInfo culture = null)
+        public static string Humanize(this DateTime input, bool utcDate = true, DateTime? dateToCompareAgainst = null, CultureInfo culture = null, DateTime? dateNeverThreshold = null)
         {
             var comparisonBase = dateToCompareAgainst ?? DateTime.UtcNow;
 
             if (!utcDate)
+            {
                 comparisonBase = comparisonBase.ToLocalTime();
+                if (dateNeverThreshold.HasValue)
+                    dateNeverThreshold = dateNeverThreshold.Value.ToLocalTime();
+            }
+                
 
-            return Configurator.DateTimeHumanizeStrategy.Humanize(input, comparisonBase, culture);
+            return Configurator.DateTimeHumanizeStrategy.Humanize(input, comparisonBase, culture, dateNeverThreshold);
         }
 
         /// <summary>

--- a/src/Humanizer/DateTimeHumanizeStrategy/DateTimeHumanizeAlgorithms.cs
+++ b/src/Humanizer/DateTimeHumanizeStrategy/DateTimeHumanizeAlgorithms.cs
@@ -60,12 +60,15 @@ namespace Humanizer.DateTimeHumanizeStrategy
         /// <summary>
         /// Calculates the distance of time in words between two provided dates
         /// </summary>
-        public static string DefaultHumanize(DateTime input, DateTime comparisonBase, CultureInfo culture)
+        public static string DefaultHumanize(DateTime input, DateTime comparisonBase, CultureInfo culture, DateTime? dateNeverThreshold = null)
         {
             var tense = input > comparisonBase ? Tense.Future : Tense.Past;
             var ts = new TimeSpan(Math.Abs(comparisonBase.Ticks - input.Ticks));
 
             var formatter = Configurator.GetFormatter(culture);
+
+            if (dateNeverThreshold.HasValue && tense == Tense.Past && comparisonBase.Subtract(ts) < dateNeverThreshold)
+                return formatter.DateHumanize(TimeUnit.Never, tense, 0);
 
             if (ts.TotalMilliseconds < 500)
                 return formatter.DateHumanize(TimeUnit.Millisecond, tense, 0);

--- a/src/Humanizer/DateTimeHumanizeStrategy/DefaultDateTimeHumanizeStrategy.cs
+++ b/src/Humanizer/DateTimeHumanizeStrategy/DefaultDateTimeHumanizeStrategy.cs
@@ -11,9 +11,9 @@ namespace Humanizer.DateTimeHumanizeStrategy
         /// <summary>
         /// Calculates the distance of time in words between two provided dates
         /// </summary>
-        public string Humanize(DateTime input, DateTime comparisonBase, CultureInfo culture)
+        public string Humanize(DateTime input, DateTime comparisonBase, CultureInfo culture, DateTime? dateNeverThreshold = null)
         {
-            return DateTimeHumanizeAlgorithms.DefaultHumanize(input, comparisonBase, culture);
+            return DateTimeHumanizeAlgorithms.DefaultHumanize(input, comparisonBase, culture, dateNeverThreshold);
         }
     }
 }

--- a/src/Humanizer/DateTimeHumanizeStrategy/DefaultDateTimeOffsetHumanizeStrategy.cs
+++ b/src/Humanizer/DateTimeHumanizeStrategy/DefaultDateTimeOffsetHumanizeStrategy.cs
@@ -11,9 +11,9 @@ namespace Humanizer.DateTimeHumanizeStrategy
         /// <summary>
         /// Calculates the distance of time in words between two provided dates
         /// </summary>
-        public string Humanize(DateTimeOffset input, DateTimeOffset comparisonBase, CultureInfo culture)
+        public string Humanize(DateTimeOffset input, DateTimeOffset comparisonBase, CultureInfo culture, DateTimeOffset dateNeverThreshold)
         {
-            return DateTimeHumanizeAlgorithms.DefaultHumanize(input.UtcDateTime, comparisonBase.UtcDateTime, culture);
+            return DateTimeHumanizeAlgorithms.DefaultHumanize(input.UtcDateTime, comparisonBase.UtcDateTime, culture, dateNeverThreshold.UtcDateTime);
         }
     }
 }

--- a/src/Humanizer/DateTimeHumanizeStrategy/IDateTimeHumanizeStrategy.cs
+++ b/src/Humanizer/DateTimeHumanizeStrategy/IDateTimeHumanizeStrategy.cs
@@ -11,6 +11,6 @@ namespace Humanizer.DateTimeHumanizeStrategy
         /// <summary>
         /// Calculates the distance of time in words between two provided dates used for DateTime.Humanize
         /// </summary>
-        string Humanize(DateTime input, DateTime comparisonBase, CultureInfo culture);
+        string Humanize(DateTime input, DateTime comparisonBase, CultureInfo culture, DateTime? dateNeverThreshold = null);
     }
 }

--- a/src/Humanizer/DateTimeHumanizeStrategy/IDateTimeOffsetHumanizeStrategy.cs
+++ b/src/Humanizer/DateTimeHumanizeStrategy/IDateTimeOffsetHumanizeStrategy.cs
@@ -11,6 +11,6 @@ namespace Humanizer.DateTimeHumanizeStrategy
         /// <summary>
         /// Calculates the distance of time in words between two provided dates used for DateTimeOffset.Humanize
         /// </summary>
-        string Humanize(DateTimeOffset input, DateTimeOffset comparisonBase, CultureInfo culture);
+        string Humanize(DateTimeOffset input, DateTimeOffset comparisonBase, CultureInfo culture, DateTimeOffset dateNeverThreshold);
     }
 }

--- a/src/Humanizer/DateTimeHumanizeStrategy/PrecisionDateTimeHumanizeStrategy.cs
+++ b/src/Humanizer/DateTimeHumanizeStrategy/PrecisionDateTimeHumanizeStrategy.cs
@@ -22,7 +22,7 @@ namespace Humanizer.DateTimeHumanizeStrategy
         /// <summary>
         /// Returns localized &amp; humanized distance of time between two dates; given a specific precision.
         /// </summary>
-        public string Humanize(DateTime input, DateTime comparisonBase, CultureInfo culture)
+        public string Humanize(DateTime input, DateTime comparisonBase, CultureInfo culture, DateTime? dateNeverThreshold = null)
         {
             return DateTimeHumanizeAlgorithms.PrecisionHumanize(input, comparisonBase, _precision, culture);
         }

--- a/src/Humanizer/DateTimeHumanizeStrategy/PrecisionDateTimeOffsetHumanizeStrategy.cs
+++ b/src/Humanizer/DateTimeHumanizeStrategy/PrecisionDateTimeOffsetHumanizeStrategy.cs
@@ -22,7 +22,7 @@ namespace Humanizer.DateTimeHumanizeStrategy
         /// <summary>
         /// Returns localized &amp; humanized distance of time between two dates; given a specific precision.
         /// </summary>
-        public string Humanize(DateTimeOffset input, DateTimeOffset comparisonBase, CultureInfo culture)
+        public string Humanize(DateTimeOffset input, DateTimeOffset comparisonBase, CultureInfo culture, DateTimeOffset dateNeverThreshold)
         {
             return DateTimeHumanizeAlgorithms.PrecisionHumanize(input.UtcDateTime, comparisonBase.UtcDateTime, _precision, culture);
         }

--- a/src/Humanizer/Localisation/ResourceKeys.DateHumanize.cs
+++ b/src/Humanizer/Localisation/ResourceKeys.DateHumanize.cs
@@ -13,6 +13,11 @@
             public const string Now = "DateHumanize_Now";
 
             /// <summary>
+            /// Resource key for Never.
+            /// </summary>
+            public const string Never = "DateHumanize_Never";
+
+            /// <summary>
             /// Examples: DateHumanize_SingleMinuteAgo, DateHumanize_MultipleHoursAgo
             /// Note: "s" for plural served separately by third part.
             /// </summary>
@@ -32,9 +37,12 @@
             {
                 ValidateRange(count);
 
+                if (timeUnit == TimeUnit.Never)
+                    return Never;
+
                 if (count == 0) 
                     return Now;
-
+                
                 var singularity = count == 1 ? Single : Multiple;
                 var tense = timeUnitTense == Tense.Future ? FromNow : Ago;
                 var unit = timeUnit.ToString().ToQuantity(count, ShowQuantityAs.None);

--- a/src/Humanizer/Localisation/TimeUnit.cs
+++ b/src/Humanizer/Localisation/TimeUnit.cs
@@ -6,6 +6,7 @@
 #pragma warning disable 1591
     public enum TimeUnit
     {
+        Never,
         Millisecond,
         Second,
         Minute,

--- a/src/Humanizer/Localisation/TimeUnit.cs
+++ b/src/Humanizer/Localisation/TimeUnit.cs
@@ -6,7 +6,6 @@
 #pragma warning disable 1591
     public enum TimeUnit
     {
-        Never,
         Millisecond,
         Second,
         Minute,
@@ -14,7 +13,8 @@
         Day,
         Week,
         Month,
-        Year
+        Year,
+        Never
     }
 #pragma warning restore 1591
 }

--- a/src/Humanizer/Properties/Resources.de.resx
+++ b/src/Humanizer/Properties/Resources.de.resx
@@ -231,4 +231,7 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>in einem Jahr</value>
   </data>
+  <data name="DateHumanize_Never" xml:space="preserve">
+    <value>nie</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.fr.resx
+++ b/src/Humanizer/Properties/Resources.fr.resx
@@ -231,4 +231,7 @@
   <data name="TimeSpanHumanize_Zero" xml:space="preserve">
     <value>pas de temps</value>
   </data>
+  <data name="DateHumanize_Never" xml:space="preserve">
+    <value>jamais</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.resx
+++ b/src/Humanizer/Properties/Resources.resx
@@ -474,4 +474,7 @@
   <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
     <value>1 year</value>
   </data>
+  <data name="DateHumanize_Never" xml:space="preserve">
+    <value>never</value>
+  </data>
 </root>


### PR DESCRIPTION
This adds the ability to specify a 'never' threshold, meaning every `DateTime` measured below this value will result in a return value *never* (also added German and French variant to the resources).

Purpose: I use the `DateTime` Humanize extension to display human readable `DateTime` representations on UIs (e.g. "Last Update: 2 minutes ago"). If the `dateNeverThreshold` is sepcified with `DateTime.Now` upon application start, I can circumvent the fact of DateTime being a struct defaulting to *01.01.0001* and resulting in an unnecessary big value (e.g. *2016 years ago*).

Unsure what you think of this, eager to get some feedback.