### PR TITLE
allow formatted byte size when humanizing ByteRate

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -937,6 +937,13 @@ text = size.Per(measurementInterval).Humanize(TimeUnit.Hour);
 // 35.15625 GB/hour
 ```
 
+You can specify a format for the bytes part of the humanized output:
+
+```
+19854651984.Bytes().Per(1.Seconds()).Humanize("#.##");
+// 18.49 GB/s
+```
+
 ##<a id="mix-this-into-your-framework-to-simplify-your-life">Mix this into your framework to simplify your life</a>
 This is just a baseline and you can use this to simplify your day to day job. For example, in Asp.Net MVC we keep chucking `Display` attribute on ViewModel properties so `HtmlHelper` can generate correct labels for us; but, just like enums, in vast majority of cases we just need a space between the words in property name - so why not use `"string".Humanize` for that?!
 

--- a/src/Humanizer.Tests.Shared/Bytes/ByteRateTests.cs
+++ b/src/Humanizer.Tests.Shared/Bytes/ByteRateTests.cs
@@ -42,9 +42,24 @@ namespace Humanizer.Tests.Bytes
 
             var rate = size.Per(measurementInterval);
             var text = rate.Humanize(displayInterval);
-                        
+
             Assert.Equal(expectedValue, text);
         }
+
+        [Theory]
+        [InlineData(19854651984, 1, TimeUnit.Second, null, "18.4910856038332 GB/s")]
+        [InlineData(19854651984, 1, TimeUnit.Second, "#.##", "18.49 GB/s")]
+        public void FormattedTimeUnitTests(long bytes, int measurementIntervalSeconds, TimeUnit displayInterval, string format, string expectedValue)
+        {
+            var size = ByteSize.FromBytes(bytes);
+            var measurementInterval = TimeSpan.FromSeconds(measurementIntervalSeconds);
+            var rate = size.Per(measurementInterval);
+            var text = rate.Humanize(format, displayInterval);
+
+            Assert.Equal(expectedValue, text);
+        }
+
+
 
         [Theory]
         [InlineData(TimeUnit.Millisecond)]
@@ -61,5 +76,6 @@ namespace Humanizer.Tests.Bytes
                 dummyRate.Humanize(units);
             });
         }
+
     }
 }

--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
@@ -10,6 +10,7 @@ namespace Humanizer.Bytes
         public System.TimeSpan Interval { get; }
         public Humanizer.Bytes.ByteSize Size { get; }
         public string Humanize(Humanizer.Localisation.TimeUnit timeUnit = 1) { }
+        public string Humanize(string format, Humanizer.Localisation.TimeUnit timeUnit = 1) { }
     }
     public struct ByteSize : System.IComparable, System.IComparable<Humanizer.Bytes.ByteSize>, System.IEquatable<Humanizer.Bytes.ByteSize>
     {

--- a/src/Humanizer/Bytes/ByteRate.cs
+++ b/src/Humanizer/Bytes/ByteRate.cs
@@ -39,6 +39,17 @@ namespace Humanizer.Bytes
         /// <returns></returns>
         public string Humanize(TimeUnit timeUnit = TimeUnit.Second)
         {
+            return Humanize(null, timeUnit);
+        }
+
+        /// <summary>
+        /// Calculate rate for the quantity of bytes and interval defined by this instance
+        /// </summary>
+        /// <param name="timeUnit">Unit of time to calculate rate for (defaults is per second)</param>
+        /// <param name="format">The string format to use for the number of bytes</param>
+        /// <returns></returns>
+        public string Humanize(string format, TimeUnit timeUnit = TimeUnit.Second)
+        {
             TimeSpan displayInterval;
             string displayUnit;
 
@@ -60,7 +71,8 @@ namespace Humanizer.Bytes
             else
                 throw new NotSupportedException("timeUnit must be Second, Minute, or Hour");
 
-            return (new ByteSize(Size.Bytes / Interval.TotalSeconds * displayInterval.TotalSeconds)).Humanize() + '/' + displayUnit;
+            return new ByteSize(Size.Bytes / Interval.TotalSeconds * displayInterval.TotalSeconds)
+                .Humanize(format) + '/' + displayUnit;
         }
     }
 }


### PR DESCRIPTION
I have needed this on more than one occasion and have had to resort to not using ByteRate because I couldn't format the byte size part of the string.