### PR TITLE
Include some English plurals by default

### DIFF
--- a/src/Humanizer.Tests.Shared/InflectorTests.cs
+++ b/src/Humanizer.Tests.Shared/InflectorTests.cs
@@ -247,6 +247,8 @@ namespace Humanizer.Tests
             yield return new object[] {"fungus", "fungi"};
             yield return new object[] {"water", "water"};
             yield return new object[] {"waters", "waters"};
+            yield return new object[] {"semen", "semen"};
+            yield return new object[] {"sperm", "sperm"};
 
             yield return new object[] {"wave","waves"};
 

--- a/src/Humanizer.Tests.Shared/InflectorTests.cs
+++ b/src/Humanizer.Tests.Shared/InflectorTests.cs
@@ -245,6 +245,8 @@ namespace Humanizer.Tests
             yield return new object[] {"alumna", "alumnae"};
             yield return new object[] {"alumnus", "alumni"};
             yield return new object[] {"fungus", "fungi"};
+            yield return new object[] {"water", "water"};
+            yield return new object[] {"waters", "waters"};
 
             yield return new object[] {"wave","waves"};
 

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -106,6 +106,8 @@ namespace Humanizer.Inflections
             _default.AddUncountable("l");
             _default.AddUncountable("water");
             _default.AddUncountable("waters");
+            _default.AddUncountable("semen");
+            _default.AddUncountable("sperm");
 
             return _default;
         }

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -104,6 +104,8 @@ namespace Humanizer.Inflections
             _default.AddUncountable("tbsp");
             _default.AddUncountable("ml");
             _default.AddUncountable("l");
+            _default.AddUncountable("water");
+            _default.AddUncountable("waters");
 
             return _default;
         }


### PR DESCRIPTION
There are quite a few english plurals which have special rules which are not implemented.
Here are some extra ones which hadn't been added.