### PR TITLE
Fixes issue #525

### DIFF
--- a/src/Humanizer.Tests.Shared/TruncatorTests.cs
+++ b/src/Humanizer.Tests.Shared/TruncatorTests.cs
@@ -39,7 +39,7 @@ namespace Humanizer.Tests
         {
             Assert.Equal(expectedOutput, input.Truncate(length, Truncator.FixedNumberOfCharacters));
         }
-
+        
         [Theory]
         [InlineData(null, 10, null)]
         [InlineData("", 10, "")]
@@ -91,7 +91,8 @@ namespace Humanizer.Tests
         [InlineData("Text with number of characters equal to truncate length", 47, "...", "Text with number of characters equal to truncate length")]
         [InlineData("Text with less characters than truncate length", 41, "...", "Text with less characters than truncate length")]
         [InlineData("Text with delimiter length greater than truncate length truncates to fixed length without truncation string", 2, "...", "Te")]
-        [InlineData("Null truncation string truncates to truncate length without truncation string", 4, null, "Null")]
+        [InlineData("Text     with additional spaces and null truncate string", 10, null, "Text     with ad")]
+        [InlineData("Text     with additional spaces and empty string as truncate string", 10, "", "Text     with ad")]
         public void TruncateWithTruncationStringAndFixedNumberOfCharactersTruncator(string input, int length, string truncationString, string expectedOutput)
         {
             Assert.Equal(expectedOutput, input.Truncate(length, truncationString, Truncator.FixedNumberOfCharacters));

--- a/src/Humanizer/Truncation/FixedNumberOfCharactersTruncator.cs
+++ b/src/Humanizer/Truncation/FixedNumberOfCharactersTruncator.cs
@@ -16,7 +16,10 @@ namespace Humanizer
             if (value.Length == 0)
                 return value;
 
-            if (truncationString == null || truncationString.Length > length)
+            if (truncationString == null)
+                truncationString = string.Empty;
+
+            if (truncationString.Length > length)
                 return truncateFrom == TruncateFrom.Right ? value.Substring(0, length) : value.Substring(value.Length - length);
 
             var alphaNumericalCharactersProcessed = 0;


### PR DESCRIPTION
I believe the proper way to fix this is to make the instance with null passed as Truncation String behave the same way when you pass an empty string.
According to description of the class it's suppose to count just characters and digits and whitespace is none of those. It is ignoring it for empty string, but not for null string.