### PR TITLE
Modified PascalCaseWordPartsRegex to accept more "word characters"

### DIFF
--- a/src/Humanizer.Tests.Shared/StringHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/StringHumanizeTests.cs
@@ -18,7 +18,16 @@ namespace Humanizer.Tests
         [InlineData("?)@", "")]
         [InlineData("?", "")]
         [InlineData("", "")]
+        [InlineData("JeNeParlePasFrançais", "Je ne parle pas français")]
         public void CanHumanizeStringInPascalCase(string input, string expectedResult)
+        {
+            Assert.Equal(expectedResult, input.Humanize());
+        }
+
+        [Theory, UseCulture("tr-TR")]
+        [InlineData("istanbul", "İstanbul")]
+        [InlineData("diyarbakır", "Diyarbakır")]
+        public void CanHumanizeStringInPascalCaseInTurkish(string input, string expectedResult)
         {
             Assert.Equal(expectedResult, input.Humanize());
         }
@@ -56,7 +65,9 @@ namespace Humanizer.Tests
         [InlineData("CanReturnTitleCase", "Can Return Title Case")]
         [InlineData("Can_return_title_Case", "Can Return Title Case")]
         [InlineData("Title_humanization_Honors_ALLCAPS", "Title Humanization Honors ALLCAPS")]
-        public void CanHumanizeIntoTileCase(string input, string expectedResult)
+        [InlineData("MühldorferStraße23", "Mühldorfer Straße 23")]
+        [InlineData("mühldorfer_STRAẞE_23", "Mühldorfer STRAẞE 23")]
+        public void CanHumanizeIntoTitleCase(string input, string expectedResult)
         {
             Assert.Equal(expectedResult, input.Humanize(LetterCasing.Title));
         }
@@ -64,6 +75,7 @@ namespace Humanizer.Tests
         [Theory]
         [InlineData("CanReturnLowerCase", "can return lower case")]
         [InlineData("LOWERCASE", "lowercase")]
+        [InlineData("STRAẞE", "straße")]
         public void CanHumanizeIntoLowerCase(string input, string expectedResult)
         {
             Assert.Equal(expectedResult, input.Humanize(LetterCasing.LowerCase));
@@ -72,6 +84,7 @@ namespace Humanizer.Tests
         [Theory]
         [InlineData("CanReturnSentenceCase", "Can return sentence case")]
         [InlineData("", "")]
+        [InlineData("égoïste", "Égoïste")]
         public void CanHumanizeIntoSentenceCase(string input, string expectedResult)
         {
             Assert.Equal(expectedResult, input.Humanize(LetterCasing.Sentence));
@@ -80,6 +93,7 @@ namespace Humanizer.Tests
         [Theory]
         [InlineData("CanHumanizeIntoUpperCase", "CAN HUMANIZE INTO UPPER CASE")]
         [InlineData("Can_Humanize_into_Upper_case", "CAN HUMANIZE INTO UPPER CASE")]
+        [InlineData("coûts_privés", "COÛTS PRIVÉS")]
         public void CanHumanizeIntoUpperCase(string input, string expectedResult)
         {
             Assert.Equal(expectedResult, input.Humanize(LetterCasing.AllCaps));

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -14,7 +14,7 @@ namespace Humanizer
 
         static StringHumanizeExtensions()
         {
-            PascalCaseWordPartsRegex = new Regex(@"[A-Z]?[a-z]+|[0-9]+[a-z]*|[A-Z]+(?=[A-Z][a-z]|[0-9]|\b)",
+            PascalCaseWordPartsRegex = new Regex(@"[\p{Lu}]?[\p{Ll}]+|[0-9]+[\p{Ll}]*|[\p{Lu}]+(?=[\p{Lu}][\p{Ll}]|[0-9]|\b)",
                 RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture | RegexOptionsUtil.Compiled);
             FreestandingSpacingCharRegex = new Regex(@"\s[-_]|[-_]\s", RegexOptionsUtil.Compiled);
         }


### PR DESCRIPTION
Instead of [A-Z] this uses \p{Lu} (Upper Case Unicode letters) and instead of [a-z] this uess \p{Ll} (lower case Unicode letters). This enables us to use some word characters of different languages, see #532 and 563.

Note that this does not handle the example "mühldorfer STRAßE 23" from #532, but if it were written as "mühldorfer STRAẞE 23", it would be okay.  The previously missing capital ß (ẞ) would require special culture dependent handling, which I do not know if it is wanted in here. However, this deals with "MÜNCHEN" and "ajouté" fine and better than the previous version.

The current `StringHumanizeTests` pass this change, but there might be unexpected changes in production code, as much, much more characters will be accepted and returned in the humanized string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/humanizr/humanizer/564)
<!-- Reviewable:end -->
