### PR TITLE
Fixed incorrect locale in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -791,7 +791,7 @@ The possible values are `GrammaticalGender.Masculine`, `GrammaticalGender.Femini
 ```
 
 ```C#
-// for Brazilian Portuguese locale
+// for Arabic locale
 1.ToOrdinalWords(GrammaticalGender.Masculine) => "الأول"
 1.ToOrdinalWords(GrammaticalGender.Feminine) => "الأولى"
 1.ToOrdinalWords(GrammaticalGender.Neuter) => "الأول"


### PR DESCRIPTION
---

No code changes, only documentation.

The example on `ToOrdinalWords` the Arabic example was incorrectly listed as 'Brazilian Portuguese'