### PR TITLE
Pass through the content of the "Letter, other" Unicode category.

### DIFF
--- a/src/Humanizer.Tests.Shared/StringHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/StringHumanizeTests.cs
@@ -32,6 +32,13 @@ namespace Humanizer.Tests
             Assert.Equal(expectedResult, input.Humanize());
         }
 
+        [Theory, UseCulture("ar")]
+        [InlineData("جمهورية ألمانيا الاتحادية", "جمهورية ألمانيا الاتحادية")]
+        public void CanHumanizeOtherUnicodeLetter(string input, string expectedResult)
+        {
+            Assert.Equal(expectedResult, input.Humanize());
+        }
+
         [Theory]
         [InlineData("Underscored_input_string_is_turned_into_sentence", "Underscored input string is turned into sentence")]
         [InlineData("Underscored_input_String_is_turned_INTO_sentence", "Underscored input String is turned INTO sentence")]

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -14,7 +14,7 @@ namespace Humanizer
 
         static StringHumanizeExtensions()
         {
-            PascalCaseWordPartsRegex = new Regex(@"[\p{Lu}]?[\p{Ll}]+|[0-9]+[\p{Ll}]*|[\p{Lu}]+(?=[\p{Lu}][\p{Ll}]|[0-9]|\b)",
+            PascalCaseWordPartsRegex = new Regex(@"[\p{Lu}]?[\p{Ll}]+|[0-9]+[\p{Ll}]*|[\p{Lu}]+(?=[\p{Lu}][\p{Ll}]|[0-9]|\b)|[\p{Lo}]+",
                 RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture | RegexOptionsUtil.Compiled);
             FreestandingSpacingCharRegex = new Regex(@"\s[-_]|[-_]\s", RegexOptionsUtil.Compiled);
         }


### PR DESCRIPTION
fixes Humanizr/Humanizer#578 - see issue discussion for possible limitations