### PR TITLE
Workaround for Croatian TimeSpan localization bug

### DIFF
--- a/src/Humanizer.Tests.Shared/Humanizer.Tests.Shared.projitems
+++ b/src/Humanizer.Tests.Shared/Humanizer.Tests.Shared.projitems
@@ -74,6 +74,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\he\NumberToWordsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\he\TimeSpanHumanizeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\hr\DateHumanizeTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Localisation\hr\TimeSpanHumanizeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\hu\DateHumanizeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\hu\TimeSpanHumanizeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\id\DateHumanizeTests.cs" />

--- a/src/Humanizer.Tests.Shared/Localisation/hr/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/hr/TimeSpanHumanizeTests.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Xunit;
+
+namespace Humanizer.Tests.Localisation.hr
+{
+    [UseCulture("hr-HR")]
+    public class TimeSpanHumanizeTests
+    {
+        [Theory]
+        [InlineData(1, "1 dan")]
+        [InlineData(2, "2 dana")]
+        [InlineData(3, "3 dana")]
+        [InlineData(4, "4 dana")]
+        [InlineData(5, "5 dana")]
+        [InlineData(7, "1 tjedan")]
+        [InlineData(14, "2 tjedna")]
+        public void Days(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize());
+        }
+    }
+}

--- a/src/Humanizer/Properties/Resources.hr.resx
+++ b/src/Humanizer/Properties/Resources.hr.resx
@@ -171,6 +171,9 @@
   <data name="TimeSpanHumanize_MultipleDays" xml:space="preserve">
     <value>{0} dana</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleDays_DualTrialQuadral" xml:space="preserve">
+    <value>{0} dana</value>
+  </data>
   <data name="TimeSpanHumanize_MultipleHours" xml:space="preserve">
     <value>{0} sati</value>
   </data>


### PR DESCRIPTION
This fixes #597 by using the same value for both resource keys. As far as I found out "dana" is the general plural for days, and the postfix is not required. However, the method that gets the resource key does not know that it is not formatting numbers but timespans at this point, so I think this workaround is the best available quick fix for the bug.