### PR TITLE
Register Portuguese translations as `pt`

### DIFF
--- a/src/Humanizer.Tests.Shared/Humanizer.Tests.Shared.projitems
+++ b/src/Humanizer.Tests.Shared/Humanizer.Tests.Shared.projitems
@@ -104,6 +104,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\pt-BR\NumberToWordsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\pt-BR\OrdinalizeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\pt-BR\TimeSpanHumanizeTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Localisation\pt\OrdinalizeTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Localisation\pt\TimeSpanHumanizeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\ResourcesTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\ro-Ro\CollectionFormatterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\ro-Ro\DateHumanizeTests.cs" />

--- a/src/Humanizer.Tests.Shared/Localisation/pt/OrdinalizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/pt/OrdinalizeTests.cs
@@ -1,0 +1,87 @@
+﻿using Xunit;
+
+namespace Humanizer.Tests.Localisation.pt
+{
+    [UseCulture("pt")]
+    public class OrdinalizeTests 
+    {
+
+        [Theory]
+        [InlineData("0", "0")]
+        [InlineData("1", "1º")]
+        [InlineData("2", "2º")]
+        [InlineData("3", "3º")]
+        [InlineData("4", "4º")]
+        [InlineData("5", "5º")]
+        [InlineData("6", "6º")]
+        [InlineData("23", "23º")]
+        [InlineData("100", "100º")]
+        [InlineData("101", "101º")]
+        [InlineData("102", "102º")]
+        [InlineData("103", "103º")]
+        [InlineData("1001", "1001º")]
+        public void OrdinalizeString(string number, string ordinalized)
+        {
+            Assert.Equal(number.Ordinalize(GrammaticalGender.Masculine), ordinalized);
+        }
+
+        [Theory]
+        [InlineData("0", "0")]
+        [InlineData("1", "1ª")]
+        [InlineData("2", "2ª")]
+        [InlineData("3", "3ª")]
+        [InlineData("4", "4ª")]
+        [InlineData("5", "5ª")]
+        [InlineData("6", "6ª")]
+        [InlineData("23", "23ª")]
+        [InlineData("100", "100ª")]
+        [InlineData("101", "101ª")]
+        [InlineData("102", "102ª")]
+        [InlineData("103", "103ª")]
+        [InlineData("1001", "1001ª")]
+        public void OrdinalizeStringFeminine(string number, string ordinalized)
+        {
+            Assert.Equal(number.Ordinalize(GrammaticalGender.Feminine), ordinalized);
+        }
+
+        [Theory]
+        [InlineData(0, "0")]
+        [InlineData(1, "1º")]
+        [InlineData(2, "2º")]
+        [InlineData(3, "3º")]
+        [InlineData(4, "4º")]
+        [InlineData(5, "5º")]
+        [InlineData(6, "6º")]
+        [InlineData(10, "10º")]
+        [InlineData(23, "23º")]
+        [InlineData(100, "100º")]
+        [InlineData(101, "101º")]
+        [InlineData(102, "102º")]
+        [InlineData(103, "103º")]
+        [InlineData(1001, "1001º")]
+        public void OrdinalizeNumber(int number, string ordinalized)
+        {
+            Assert.Equal(number.Ordinalize(GrammaticalGender.Masculine), ordinalized);
+        }
+
+        [Theory]
+        [InlineData(0, "0")]
+        [InlineData(1, "1ª")]
+        [InlineData(2, "2ª")]
+        [InlineData(3, "3ª")]
+        [InlineData(4, "4ª")]
+        [InlineData(5, "5ª")]
+        [InlineData(6, "6ª")]
+        [InlineData(10, "10ª")]
+        [InlineData(23, "23ª")]
+        [InlineData(100, "100ª")]
+        [InlineData(101, "101ª")]
+        [InlineData(102, "102ª")]
+        [InlineData(103, "103ª")]
+        [InlineData(1001, "1001ª")]
+        public void OrdinalizeNumberFeminine(int number, string ordinalized)
+        {
+            Assert.Equal(number.Ordinalize(GrammaticalGender.Feminine), ordinalized);
+        }
+    }
+}

--- a/src/Humanizer.Tests.Shared/Localisation/pt/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/pt/TimeSpanHumanizeTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using Xunit;
+
+namespace Humanizer.Tests.Localisation.pt
+{
+    [UseCulture("pt")]
+    public class TimeSpanHumanizeTests
+    {
+        [Fact]
+        public void TwoWeeks()
+        {
+            Assert.Equal("2 semanas", TimeSpan.FromDays(14).Humanize());
+        }
+
+        [Fact]
+        public void OneWeek()
+        {
+            Assert.Equal("1 semana", TimeSpan.FromDays(7).Humanize());
+        }
+
+        [Fact]
+        public void SixDays()
+        {
+            Assert.Equal("6 dias", TimeSpan.FromDays(6).Humanize());
+        }
+
+        [Fact]
+        public void TwoDays()
+        {
+            Assert.Equal("2 dias", TimeSpan.FromDays(2).Humanize());
+        }
+
+        [Fact]
+        public void OneDay()
+        {
+            Assert.Equal("1 dia", TimeSpan.FromDays(1).Humanize());
+        }
+
+        [Fact]
+        public void TwoHours()
+        {
+            Assert.Equal("2 horas", TimeSpan.FromHours(2).Humanize());
+        }
+
+        [Fact]
+        public void OneHour()
+        {
+            Assert.Equal("1 hora", TimeSpan.FromHours(1).Humanize());
+        }
+
+        [Fact]
+        public void TwoMinutes()
+        {
+            Assert.Equal("2 minutos", TimeSpan.FromMinutes(2).Humanize());
+        }
+
+        [Fact]
+        public void OneMinute()
+        {
+            Assert.Equal("1 minuto", TimeSpan.FromMinutes(1).Humanize());
+        }
+
+        [Fact]
+        public void TwoSeconds()
+        {
+            Assert.Equal("2 segundos", TimeSpan.FromSeconds(2).Humanize());
+        }
+
+        [Fact]
+        public void OneSecond()
+        {
+            Assert.Equal("1 segundo", TimeSpan.FromSeconds(1).Humanize());
+        }
+
+        [Fact]
+        public void TwoMilliseconds()
+        {
+            Assert.Equal("2 milisegundos", TimeSpan.FromMilliseconds(2).Humanize());
+        }
+
+        [Fact]
+        public void OneMillisecond()
+        {
+            Assert.Equal("1 milisegundo", TimeSpan.FromMilliseconds(1).Humanize());
+        }
+
+        [Fact]
+        public void NoTime()
+        {
+            // This one doesn't make a lot of sense but ... w/e
+            Assert.Equal("sem horário", TimeSpan.Zero.Humanize());
+        }
+    }
+}

--- a/src/Humanizer/Configuration/FormatterRegistry.cs
+++ b/src/Humanizer/Configuration/FormatterRegistry.cs
@@ -19,7 +19,7 @@ namespace Humanizer.Configuration
             RegisterCzechSlovakPolishFormatter("pl");
             RegisterCzechSlovakPolishFormatter("sk");
             RegisterDefaultFormatter("bg");
-            RegisterDefaultFormatter("pt-BR");
+            RegisterDefaultFormatter("pt");
             RegisterDefaultFormatter("sv");
             RegisterDefaultFormatter("tr");
             RegisterDefaultFormatter("vi");


### PR DESCRIPTION
Registering the Portuguese translations as `pt` instead of `pt-BR` fixes #601.