### PR TITLE
IsDefined is prefered

### DIFF
--- a/samples/Humanizer.MvcSample/HumanizerMetadataProvider.cs
+++ b/samples/Humanizer.MvcSample/HumanizerMetadataProvider.cs
@@ -30,10 +30,10 @@ namespace Humanizer.MvcSample
             if (string.IsNullOrEmpty(modelMetadata.PropertyName))
                 return false;
 
-            if (propertyAttributes.OfType<DisplayNameAttribute>().Any())
+            if (propertyAttributes.IsDefined(typeof(DisplayNameAttribute), true))
                 return false;
 
-            if (propertyAttributes.OfType<DisplayAttribute>().Any())
+            if (propertyAttributes.IsDefined(typeof(DisplayAttribute), true))
                 return false;
 
             return true;


### PR DESCRIPTION
`IsDefined` won't loop through all the attributes.
Just saying, didn't bench it.