### PR TITLE
#632 Continued: Fuzzy month years logic for time span humanize extensions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -426,6 +426,11 @@ In addition, a maximum unit of time may be specified to avoid rolling up to the 
 TimeSpan.FromDays(7).Humanize(maxUnit: TimeUnit.Day) => "7 days"    // instead of 1 week
 TimeSpan.FromMilliseconds(2000).Humanize(maxUnit: TimeUnit.Millisecond) => "2000 milliseconds"    // instead of 2 seconds
 ```
+The default maxUnit is `TimeUnit.Week` because it gives exact results. You can increase this value to `TimeUnit.Month` or `TimeUnit.Year` which will give you an approximation based on 365.2425 days a year and 30.436875 days a month. Therefore the months are alternating between 30 and 31 days in length and every fourth year is 366 days long.
+```C#
+TimeSpan.FromDays(486).Humanize(maxUnit: TimeUnit.Year, precision: 7) => "1 year, 3 months, 29 days" // One day further is 1 year, 4 month
+TimeSpan.FromDays(517).Humanize(maxUnit: TimeUnit.Year, precision: 7) => "1 year, 4 months, 30 days" // This month has 30 days and one day further is 1 year, 5 months
+```
 
 When there are multiple time units, they are combined using the `", "` string: 
 

--- a/src/Humanizer.Tests.Shared/Localisation/DefaultFormatterTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/DefaultFormatterTests.cs
@@ -8,17 +8,6 @@ namespace Humanizer.Tests.Localisation
 {
     public class DefaultFormatterTests
     {
-        [Theory]
-        [InlineData(TimeUnit.Month, 1)]
-        [InlineData(TimeUnit.Month, 2)]
-        [InlineData(TimeUnit.Month, 10)]
-        [InlineData(TimeUnit.Year, 1)]
-        [InlineData(TimeUnit.Year, 2)]
-        [InlineData(TimeUnit.Year, 10)]
-        public void TimeSpanHumanizeThrowsExceptionForTimeUnitsLargerThanWeek(TimeUnit timeUnit, int unit)
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new DefaultFormatter(CultureInfo.InvariantCulture.Name).TimeSpanHumanize(timeUnit, unit));
-        }
 
         [Fact]
         [UseCulture("es")]

--- a/src/Humanizer.Tests.Shared/Localisation/af/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/af/TimeSpanHumanizeTests.cs
@@ -7,6 +7,28 @@ namespace Humanizer.Tests.Localisation.af
     public class TimeSpanHumanizeTests
     {
 
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 jaar")]
+        [InlineData(731, "2 jaar")]
+        [InlineData(1096, "3 jaar")]
+        [InlineData(4018, "11 jaar")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 maand")]
+        [InlineData(61, "2 maande")]
+        [InlineData(92, "3 maande")]
+        [InlineData(335, "11 maande")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Fact]
         public void TwoWeeks()
         {

--- a/src/Humanizer.Tests.Shared/Localisation/ar/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/ar/TimeSpanHumanizeTests.cs
@@ -7,6 +7,28 @@ namespace Humanizer.Tests.Localisation.ar
     public class TimeSpanHumanizeTests
     {
         [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "السنة 1")]
+        [InlineData(731, "سنتين")]
+        [InlineData(1096, "3 سنة")]
+        [InlineData(4018, "11 سنة")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "شهر 1")]
+        [InlineData(61, "شهرين")]
+        [InlineData(92, "3 أشهر")]
+        [InlineData(335, "11 أشهر")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
         [InlineData(7, "أسبوع واحد")]
         [InlineData(14, "أسبوعين")]
         [InlineData(21, "3 أسابيع")]

--- a/src/Humanizer.Tests.Shared/Localisation/bg/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/bg/TimeSpanHumanizeTests.cs
@@ -7,6 +7,28 @@ namespace Humanizer.Tests.Localisation.bg
     public class TimeSpanHumanizeTests
     {
         [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "една година")]
+        [InlineData(731, "2 години")]
+        [InlineData(1096, "3 години")]
+        [InlineData(4018, "11 години")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "един месец")]
+        [InlineData(61, "2 месеца")]
+        [InlineData(92, "3 месеца")]
+        [InlineData(335, "11 месеца")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
         [InlineData(7, "една седмица")]
         [InlineData(14, "2 седмици")]
         public void Weeks(int days, string expected)

--- a/src/Humanizer.Tests.Shared/Localisation/bn-BD/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/bn-BD/TimeSpanHumanizeTests.cs
@@ -6,6 +6,29 @@ namespace Humanizer.Tests.Localisation.bnBD
     [UseCulture("bn-BD")]
     public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "এক বছর")]
+        [InlineData(731, "2 বছর")]
+        [InlineData(1096, "3 বছর")]
+        [InlineData(4018, "11 বছর")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "এক মাসের")]
+        [InlineData(61, "2 মাস")]
+        [InlineData(92, "3 মাস")]
+        [InlineData(335, "11 মাস")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Theory]
         [InlineData(7, "এক সপ্তাহ")]
         [InlineData(14, "2 সপ্তাহ")]

--- a/src/Humanizer.Tests.Shared/Localisation/cs/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/cs/TimeSpanHumanizeTests.cs
@@ -8,6 +8,28 @@ namespace Humanizer.Tests.Localisation.cs
     {
 
         [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 rok")]
+        [InlineData(731, "2 roky")]
+        [InlineData(1096, "3 roky")]
+        [InlineData(4018, "11 let")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 měsíc")]
+        [InlineData(61, "2 měsíce")]
+        [InlineData(92, "3 měsíce")]
+        [InlineData(335, "11 měsíců")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
         [InlineData(1, "1 milisekunda")]
         [InlineData(2, "2 milisekundy")]
         [InlineData(3, "3 milisekundy")]
@@ -80,7 +102,7 @@ namespace Humanizer.Tests.Localisation.cs
         [InlineData(6, "6 týdnů")]
         public void Weeks(int number, string expected)
         {
-            Assert.Equal(expected, TimeSpan.FromDays(number*7).Humanize());
+            Assert.Equal(expected, TimeSpan.FromDays(number * 7).Humanize());
         }
     }
 }

--- a/src/Humanizer.Tests.Shared/Localisation/da/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/da/TimeSpanHumanizeTests.cs
@@ -4,8 +4,30 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.da
 {
     [UseCulture("da-DK")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(366, "et år")]
+        [InlineData(731, "2 år")]
+        [InlineData(1096, "3 år")]
+        [InlineData(4018, "11 år")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(31, "en måned")]
+        [InlineData(61, "2 måneder")]
+        [InlineData(92, "3 måneder")]
+        [InlineData(335, "11 måneder")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Theory]
         [InlineData(7, "en uge")]

--- a/src/Humanizer.Tests.Shared/Localisation/de/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/de/TimeSpanHumanizeTests.cs
@@ -3,8 +3,31 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.de
 {
     [UseCulture("de-DE")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(366, "Ein Jahr")]
+        [InlineData(731, "2 Jahre")]
+        [InlineData(1096, "3 Jahre")]
+        [InlineData(4018, "11 Jahre")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(31, "Ein Monat")]
+        [InlineData(61, "2 Monate")]
+        [InlineData(92, "3 Monate")]
+        [InlineData(335, "11 Monate")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Theory]
         [InlineData(7, "Eine Woche")]
         [InlineData(14, "2 Wochen")]

--- a/src/Humanizer.Tests.Shared/Localisation/es/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/es/TimeSpanHumanizeTests.cs
@@ -6,6 +6,27 @@ namespace Humanizer.Tests.Localisation.es
     [UseCulture("es-ES")]
     public class TimeSpanHumanizeTests
     {
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "un año")]
+        [InlineData(731, "2 años")]
+        [InlineData(1096, "3 años")]
+        [InlineData(4018, "11 años")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "un mes")]
+        [InlineData(61, "2 meses")]
+        [InlineData(92, "3 meses")]
+        [InlineData(335, "11 meses")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Fact]
         public void TwoWeeks()

--- a/src/Humanizer.Tests.Shared/Localisation/fa/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/fa/TimeSpanHumanizeTests.cs
@@ -4,8 +4,30 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.fa
 {
     [UseCulture("fa")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(366, "یک سال")]
+        [InlineData(731, "2 سال")]
+        [InlineData(1096, "3 سال")]
+        [InlineData(4018, "11 سال")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(31, "یک ماه")]
+        [InlineData(61, "2 ماه")]
+        [InlineData(92, "3 ماه")]
+        [InlineData(335, "11 ماه")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Theory]
         [InlineData(7, "یک هفته")]

--- a/src/Humanizer.Tests.Shared/Localisation/fr-BE/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/fr-BE/TimeSpanHumanizeTests.cs
@@ -4,12 +4,35 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.frBE
 {
     [UseCulture("fr-BE")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 année")]
+        [InlineData(731, "2 ans")]
+        [InlineData(1096, "3 ans")]
+        [InlineData(4018, "11 ans")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 mois")]
+        [InlineData(61, "2 mois")]
+        [InlineData(92, "3 mois")]
+        [InlineData(335, "11 mois")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Theory]
         [InlineData(14, "2 semaines")]
         [InlineData(7, "1 semaine")]
-        public void Weeks(int days, string expected) 
+        public void Weeks(int days, string expected)
         {
             var actual = TimeSpan.FromDays(days).Humanize();
             Assert.Equal(expected, actual);
@@ -18,7 +41,7 @@ namespace Humanizer.Tests.Localisation.frBE
         [Theory]
         [InlineData(6, "6 jours")]
         [InlineData(1, "1 jour")]
-        public void Days(int days, string expected) 
+        public void Days(int days, string expected)
         {
             var actual = TimeSpan.FromDays(days).Humanize();
             Assert.Equal(expected, actual);
@@ -27,7 +50,7 @@ namespace Humanizer.Tests.Localisation.frBE
         [Theory]
         [InlineData(2, "2 heures")]
         [InlineData(1, "1 heure")]
-        public void Hours(int hours, string expected) 
+        public void Hours(int hours, string expected)
         {
             var actual = TimeSpan.FromHours(hours).Humanize();
             Assert.Equal(expected, actual);
@@ -36,7 +59,7 @@ namespace Humanizer.Tests.Localisation.frBE
         [Theory]
         [InlineData(2, "2 minutes")]
         [InlineData(1, "1 minute")]
-        public void Minutes(int minutes, string expected) 
+        public void Minutes(int minutes, string expected)
         {
             var actual = TimeSpan.FromMinutes(minutes).Humanize();
             Assert.Equal(expected, actual);
@@ -45,7 +68,7 @@ namespace Humanizer.Tests.Localisation.frBE
         [Theory]
         [InlineData(2, "2 secondes")]
         [InlineData(1, "1 seconde")]
-        public void Seconds(int seconds, string expected) 
+        public void Seconds(int seconds, string expected)
         {
             var actual = TimeSpan.FromSeconds(seconds).Humanize();
             Assert.Equal(expected, actual);
@@ -54,14 +77,14 @@ namespace Humanizer.Tests.Localisation.frBE
         [Theory]
         [InlineData(2, "2 millisecondes")]
         [InlineData(1, "1 milliseconde")]
-        public void Milliseconds(int ms, string expected) 
+        public void Milliseconds(int ms, string expected)
         {
             var actual = TimeSpan.FromMilliseconds(ms).Humanize();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
-        public void NoTime() 
+        public void NoTime()
         {
             var noTime = TimeSpan.Zero;
             var actual = noTime.Humanize();

--- a/src/Humanizer.Tests.Shared/Localisation/fr/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/fr/TimeSpanHumanizeTests.cs
@@ -4,8 +4,30 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.fr
 {
     [UseCulture("fr")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [InlineData(366, "1 année")]
+        [InlineData(731, "2 ans")]
+        [InlineData(1096, "3 ans")]
+        [InlineData(4018, "11 ans")]
+        [Theory]
+        [Trait("Translation", "Google")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 mois")]
+        [InlineData(61, "2 mois")]
+        [InlineData(92, "3 mois")]
+        [InlineData(335, "11 mois")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Theory]
         [InlineData(14, "2 semaines")]

--- a/src/Humanizer.Tests.Shared/Localisation/he/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/he/TimeSpanHumanizeTests.cs
@@ -4,8 +4,31 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.he
 {
     [UseCulture("he")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(366, "שנה")]
+        [InlineData(731, "שנתיים")]
+        [InlineData(1096, "3 שנים")]
+        [InlineData(4018, "11 שנים")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(31, "חודש")]
+        [InlineData(61, "חודשיים")]
+        [InlineData(92, "3 חודשים")]
+        [InlineData(335, "11 חודשים")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Theory]
         [InlineData(7, "שבוע")]
         [InlineData(14, "שבועיים")]

--- a/src/Humanizer.Tests.Shared/Localisation/hr/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/hr/TimeSpanHumanizeTests.cs
@@ -6,6 +6,29 @@ namespace Humanizer.Tests.Localisation.hr
     [UseCulture("hr-HR")]
     public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 godina")]
+        [InlineData(731, "2 godine")]
+        [InlineData(1096, "3 godine")]
+        [InlineData(4018, "11 godina")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 mjesec")]
+        [InlineData(61, "2 mjeseca")]
+        [InlineData(92, "3 mjeseca")]
+        [InlineData(335, "11 mjeseci")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Theory]
         [InlineData(1, "1 dan")]
         [InlineData(2, "2 dana")]

--- a/src/Humanizer.Tests.Shared/Localisation/hu/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/hu/TimeSpanHumanizeTests.cs
@@ -4,8 +4,30 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.hu
 {
     [UseCulture("hu-HU")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "egy év")]
+        [InlineData(731, "2 év")]
+        [InlineData(1096, "3 év")]
+        [InlineData(4018, "11 év")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "egy hónap")]
+        [InlineData(61, "2 hónap")]
+        [InlineData(92, "3 hónap")]
+        [InlineData(335, "11 hónap")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Theory]
         [InlineData(14, "2 hét")]

--- a/src/Humanizer.Tests.Shared/Localisation/id/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/id/TimeSpanHumanizeTests.cs
@@ -4,8 +4,31 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.id
 {
     [UseCulture("id-ID")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 tahun")]
+        [InlineData(731, "2 tahun")]
+        [InlineData(1096, "3 tahun")]
+        [InlineData(4018, "11 tahun")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 bulan")]
+        [InlineData(61, "2 bulan")]
+        [InlineData(92, "3 bulan")]
+        [InlineData(335, "11 bulan")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Theory]
         [InlineData(14, "2 minggu")]
         [InlineData(7, "1 minggu")]

--- a/src/Humanizer.Tests.Shared/Localisation/it/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/it/TimeSpanHumanizeTests.cs
@@ -4,8 +4,31 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.it
 {
     [UseCulture("it")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 anno")]
+        [InlineData(731, "2 anni")]
+        [InlineData(1096, "3 anni")]
+        [InlineData(4018, "11 anni")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 mese")]
+        [InlineData(61, "2 mesi")]
+        [InlineData(92, "3 mesi")]
+        [InlineData(335, "11 mesi")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Theory]
         [InlineData(7, "1 settimana")]

--- a/src/Humanizer.Tests.Shared/Localisation/ja/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/ja/TimeSpanHumanizeTests.cs
@@ -4,8 +4,30 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.ja
 {
     [UseCulture("ja")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 年間の")]
+        [InlineData(731, "2 年")]
+        [InlineData(1096, "3 年")]
+        [InlineData(4018, "11 年")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 ヶ月")]
+        [InlineData(61, "2 ヶ月")]
+        [InlineData(92, "3 ヶ月")]
+        [InlineData(335, "11 ヶ月")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Theory]
         [InlineData(7, "1 週間")]

--- a/src/Humanizer.Tests.Shared/Localisation/nb-NO/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/nb-NO/TimeSpanHumanizeTests.cs
@@ -4,8 +4,30 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.nbNO
 {
     [UseCulture("nb-NO")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(366, "ett år")]
+        [InlineData(731, "2 år")]
+        [InlineData(1096, "3 år")]
+        [InlineData(4018, "11 år")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(31, "en måned")]
+        [InlineData(61, "2 måneder")]
+        [InlineData(92, "3 måneder")]
+        [InlineData(335, "11 måneder")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Theory]
         [InlineData(7, "en uke")]

--- a/src/Humanizer.Tests.Shared/Localisation/nb/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/nb/TimeSpanHumanizeTests.cs
@@ -4,8 +4,30 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.nb
 {
     [UseCulture("nb")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(366, "ett år")]
+        [InlineData(731, "2 år")]
+        [InlineData(1096, "3 år")]
+        [InlineData(4018, "11 år")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(31, "en måned")]
+        [InlineData(61, "2 måneder")]
+        [InlineData(92, "3 måneder")]
+        [InlineData(335, "11 måneder")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Theory]
         [InlineData(7, "en uke")]

--- a/src/Humanizer.Tests.Shared/Localisation/nl/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/nl/TimeSpanHumanizeTests.cs
@@ -4,8 +4,31 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.nl
 {
     [UseCulture("nl-NL")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(366, "1 jaar")]
+        [InlineData(731, "2 jaar")]
+        [InlineData(1096, "3 jaar")]
+        [InlineData(4018, "11 jaar")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(31, "1 maand")]
+        [InlineData(61, "2 maanden")]
+        [InlineData(92, "3 maanden")]
+        [InlineData(335, "11 maanden")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Fact]
         public void TwoWeeks()

--- a/src/Humanizer.Tests.Shared/Localisation/pl/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/pl/TimeSpanHumanizeTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.pl
 {
     [UseCulture("pl")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
         [Theory]
         [InlineData(1, "1 milisekunda")]
@@ -80,6 +80,29 @@ namespace Humanizer.Tests.Localisation.pl
         public void Weeks(int number, string expected)
         {
             Assert.Equal(expected, TimeSpan.FromDays(number * 7).Humanize());
+        }
+
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 miesiąc")]
+        [InlineData(61, "2 miesiące")]
+        [InlineData(92, "3 miesiące")]
+        [InlineData(335, "11 miesięcy")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 rok")]
+        [InlineData(731, "2 lata")]
+        [InlineData(1096, "3 lata")]
+        [InlineData(4018, "11 lat")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
         }
 
         [Fact]

--- a/src/Humanizer.Tests.Shared/Localisation/pt-BR/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/pt-BR/TimeSpanHumanizeTests.cs
@@ -6,6 +6,29 @@ namespace Humanizer.Tests.Localisation.ptBR
     [UseCulture("pt-BR")]
     public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 ano")]
+        [InlineData(731, "2 anos")]
+        [InlineData(1096, "3 anos")]
+        [InlineData(4018, "11 anos")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 mês")]
+        [InlineData(61, "2 meses")]
+        [InlineData(92, "3 meses")]
+        [InlineData(335, "11 meses")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Fact]
         public void TwoWeeks()
         {

--- a/src/Humanizer.Tests.Shared/Localisation/pt/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/pt/TimeSpanHumanizeTests.cs
@@ -6,6 +6,29 @@ namespace Humanizer.Tests.Localisation.pt
     [UseCulture("pt")]
     public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 ano")]
+        [InlineData(731, "2 anos")]
+        [InlineData(1096, "3 anos")]
+        [InlineData(4018, "11 anos")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 mês")]
+        [InlineData(61, "2 meses")]
+        [InlineData(92, "3 meses")]
+        [InlineData(335, "11 meses")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Fact]
         public void TwoWeeks()
         {

--- a/src/Humanizer.Tests.Shared/Localisation/ro-Ro/TimeSpanHumanizerTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/ro-Ro/TimeSpanHumanizerTests.cs
@@ -11,7 +11,7 @@ namespace Humanizer.Tests.Localisation.roRO
     /// There is no test for months since there are only 12 of them in a year.
     /// </summary>
     [UseCulture("ro-RO")]
-    public class TimeSpanHumanizerTests 
+    public class TimeSpanHumanizerTests
     {
 
         [Theory]
@@ -57,7 +57,7 @@ namespace Humanizer.Tests.Localisation.roRO
             var actual = TimeSpan.FromHours(hours).Humanize();
             Assert.Equal(expected, actual);
         }
-        
+
         [Theory]
         [InlineData(1, "1 zi")]
         [InlineData(6, "6 zile")]
@@ -78,6 +78,29 @@ namespace Humanizer.Tests.Localisation.roRO
         {
             var actual = TimeSpan.FromDays(7 * weeks).Humanize();
             Assert.Equal(expected, actual);
+        }
+
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 luna")]
+        [InlineData(61, "2 luni")]
+        [InlineData(92, "3 luni")]
+        [InlineData(335, "11 luni")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 ani")]
+        [InlineData(731, "2 ani")]
+        [InlineData(1096, "3 ani")]
+        [InlineData(4018, "11 ani")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
         }
     }
 }

--- a/src/Humanizer.Tests.Shared/Localisation/ru-RU/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/ru-RU/TimeSpanHumanizeTests.cs
@@ -4,8 +4,30 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.ruRU
 {
     [UseCulture("ru-RU")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(366, "один год")]
+        [InlineData(731, "2 года")]
+        [InlineData(1096, "3 года")]
+        [InlineData(4018, "11 лет")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(31, "один месяц")]
+        [InlineData(61, "2 месяца")]
+        [InlineData(92, "3 месяца")]
+        [InlineData(335, "11 месяцев")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Theory]
         [InlineData(7, "одна неделя")]

--- a/src/Humanizer.Tests.Shared/Localisation/sk/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/sk/TimeSpanHumanizeTests.cs
@@ -8,6 +8,28 @@ namespace Humanizer.Tests.Localisation.sk
     {
 
         [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 rok")]
+        [InlineData(731, "2 roky")]
+        [InlineData(1096, "3 roky")]
+        [InlineData(4018, "11 rokov")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 mesiac")]
+        [InlineData(61, "2 mesiace")]
+        [InlineData(92, "3 mesiace")]
+        [InlineData(335, "11 mesiacov")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
         [InlineData(1, "1 milisekunda")]
         [InlineData(2, "2 milisekundy")]
         [InlineData(3, "3 milisekundy")]
@@ -16,7 +38,7 @@ namespace Humanizer.Tests.Localisation.sk
         [InlineData(6, "6 milisekúnd")]
         [InlineData(10, "10 milisekúnd")]
         public void Milliseconds(int number, string expected)
-        {            
+        {
             Assert.Equal(expected, TimeSpan.FromMilliseconds(number).Humanize());
         }
 
@@ -29,7 +51,7 @@ namespace Humanizer.Tests.Localisation.sk
         [InlineData(6, "6 sekúnd")]
         [InlineData(10, "10 sekúnd")]
         public void Seconds(int number, string expected)
-        {            
+        {
             Assert.Equal(expected, TimeSpan.FromSeconds(number).Humanize());
         }
 
@@ -55,7 +77,7 @@ namespace Humanizer.Tests.Localisation.sk
         [InlineData(6, "6 hodín")]
         [InlineData(10, "10 hodín")]
         public void Hours(int number, string expected)
-        {            
+        {
             Assert.Equal(expected, TimeSpan.FromHours(number).Humanize());
         }
 
@@ -67,7 +89,7 @@ namespace Humanizer.Tests.Localisation.sk
         [InlineData(5, "5 dní")]
         [InlineData(6, "6 dní")]
         public void Days(int number, string expected)
-        {            
+        {
             Assert.Equal(expected, TimeSpan.FromDays(number).Humanize());
         }
 

--- a/src/Humanizer.Tests.Shared/Localisation/sl/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/sl/TimeSpanHumanizeTests.cs
@@ -4,8 +4,30 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.sl
 {
     [UseCulture("sl-SI")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 leto")]
+        [InlineData(731, "2 leti")]
+        [InlineData(1096, "3 leta")]
+        [InlineData(4018, "11 let")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 mesec")]
+        [InlineData(61, "2 meseca")]
+        [InlineData(92, "3 mesece")]
+        [InlineData(335, "11 mesecev")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Theory]
         [InlineData(7, "1 teden")]

--- a/src/Humanizer.Tests.Shared/Localisation/sr-Latn/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/sr-Latn/TimeSpanHumanizeTests.cs
@@ -4,8 +4,31 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.srLatn
 {
     [UseCulture("sr-Latn")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 godina")]
+        [InlineData(731, "2 godine")]
+        [InlineData(1096, "3 godine")]
+        [InlineData(4018, "11 godina")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 mesec")]
+        [InlineData(61, "2 meseca")]
+        [InlineData(92, "3 meseca")]
+        [InlineData(335, "11 meseci")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Theory]
         [InlineData(35, "5 nedelja")]
         [InlineData(14, "2 nedelje")]

--- a/src/Humanizer.Tests.Shared/Localisation/sr/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/sr/TimeSpanHumanizeTests.cs
@@ -4,8 +4,30 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.sr
 {
     [UseCulture("sr")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 година")]
+        [InlineData(731, "2 године")]
+        [InlineData(1096, "3 године")]
+        [InlineData(4018, "11 година")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 месец")]
+        [InlineData(61, "2 месеца")]
+        [InlineData(92, "3 месеца")]
+        [InlineData(335, "11 месеци")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Theory]
         [InlineData(35, "5 недеља")]

--- a/src/Humanizer.Tests.Shared/Localisation/sv/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/sv/TimeSpanHumanizeTests.cs
@@ -54,5 +54,28 @@ namespace Humanizer.Tests.Localisation.sv
         {
             Assert.Equal(expected, TimeSpan.FromDays(number * 7).Humanize());
         }
+
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(31, "en månad")]
+        [InlineData(61, "2 månader")]
+        [InlineData(92, "3 månader")]
+        [InlineData(335, "11 månader")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(366, "ett år")]
+        [InlineData(731, "2 år")]
+        [InlineData(1096, "3 år")]
+        [InlineData(4018, "11 år")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
     }
 }

--- a/src/Humanizer.Tests.Shared/Localisation/tr/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/tr/TimeSpanHumanizeTests.cs
@@ -4,8 +4,30 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.tr
 {
     [UseCulture("tr")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 yıl")]
+        [InlineData(731, "2 yıl")]
+        [InlineData(1096, "3 yıl")]
+        [InlineData(4018, "11 yıl")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 ay")]
+        [InlineData(61, "2 ay")]
+        [InlineData(92, "3 ay")]
+        [InlineData(335, "11 ay")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Theory]
         [InlineData(14, "2 hafta")]

--- a/src/Humanizer.Tests.Shared/Localisation/uk-UA/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/uk-UA/TimeSpanHumanizeTests.cs
@@ -4,8 +4,31 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.ukUA
 {
     [UseCulture("uk-UA")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "один рік")]
+        [InlineData(731, "2 роки")]
+        [InlineData(1096, "3 роки")]
+        [InlineData(4018, "11 років")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "один місяць")]
+        [InlineData(61, "2 місяці")]
+        [InlineData(92, "3 місяці")]
+        [InlineData(335, "11 місяців")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Theory]
         [InlineData(7, "один тиждень")]
         [InlineData(14, "2 тижні")]

--- a/src/Humanizer.Tests.Shared/Localisation/uz-Cyrl-UZ/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/uz-Cyrl-UZ/TimeSpanHumanizeTests.cs
@@ -4,8 +4,32 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.uzCyrl
 {
     [UseCulture("uz-Cyrl-UZ")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 йил")]
+        [InlineData(731, "2 йил")]
+        [InlineData(1096, "3 йил")]
+        [InlineData(4018, "11 йил")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 ой")]
+        [InlineData(61, "2 ой")]
+        [InlineData(92, "3 ой")]
+        [InlineData(335, "11 ой")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Theory]
         [InlineData(14, "2 ҳафта")]
         [InlineData(7, "1 ҳафта")]

--- a/src/Humanizer.Tests.Shared/Localisation/uz-Latn-UZ/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/uz-Latn-UZ/TimeSpanHumanizeTests.cs
@@ -4,9 +4,31 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.uzLatn
 {
     [UseCulture("uz-Latn-UZ")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
-        
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 yil")]
+        [InlineData(731, "2 yil")]
+        [InlineData(1096, "3 yil")]
+        [InlineData(4018, "11 yil")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 oy")]
+        [InlineData(61, "2 oy")]
+        [InlineData(92, "3 oy")]
+        [InlineData(335, "11 oy")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Theory]
         [InlineData(14, "2 hafta")]
         [InlineData(7, "1 hafta")]

--- a/src/Humanizer.Tests.Shared/Localisation/vi/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/vi/TimeSpanHumanizeTests.cs
@@ -4,8 +4,31 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.vi
 {
     [UseCulture("vi")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 năm")]
+        [InlineData(731, "2 năm")]
+        [InlineData(1096, "3 năm")]
+        [InlineData(4018, "11 năm")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1 tháng")]
+        [InlineData(61, "2 tháng")]
+        [InlineData(92, "3 tháng")]
+        [InlineData(335, "11 tháng")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Theory]
         [InlineData(14, "2 tuần")]
         [InlineData(7, "1 tuần")]

--- a/src/Humanizer.Tests.Shared/Localisation/zh-CN/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/zh-CN/TimeSpanHumanizeTests.cs
@@ -4,8 +4,31 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.zhCN
 {
     [UseCulture("zh-CN")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(366, "1 年")]
+        [InlineData(731, "2 年")]
+        [InlineData(1096, "3 年")]
+        [InlineData(4018, "11 年")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(31, "1 个月")]
+        [InlineData(61, "2 个月")]
+        [InlineData(92, "3 个月")]
+        [InlineData(335, "11 个月")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Theory]
         [InlineData(7, "1 周")]
         [InlineData(14, "2 周")]

--- a/src/Humanizer.Tests.Shared/Localisation/zh-Hans/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/zh-Hans/TimeSpanHumanizeTests.cs
@@ -4,8 +4,30 @@ using Xunit;
 namespace Humanizer.Tests.Localisation.zhHans
 {
     [UseCulture("zh-Hans")]
-    public class TimeSpanHumanizeTests 
+    public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(366, "1 年")]
+        [InlineData(731, "2 年")]
+        [InlineData(1096, "3 年")]
+        [InlineData(4018, "11 年")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(31, "1 个月")]
+        [InlineData(61, "2 个月")]
+        [InlineData(92, "3 个月")]
+        [InlineData(335, "11 个月")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
 
         [Theory]
         [InlineData(7, "1 周")]

--- a/src/Humanizer.Tests.Shared/Localisation/zh-Hant/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/zh-Hant/TimeSpanHumanizeTests.cs
@@ -6,6 +6,30 @@ namespace Humanizer.Tests.Localisation.zhHant
     [UseCulture("zh-Hant")]
     public class TimeSpanHumanizeTests
     {
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(366, "1 年")]
+        [InlineData(731, "2 年")]
+        [InlineData(1096, "3 年")]
+        [InlineData(4018, "11 年")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Native speaker")]
+        [InlineData(31, "1 個月")]
+        [InlineData(61, "2 個月")]
+        [InlineData(92, "3 個月")]
+        [InlineData(335, "11 個月")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
         [Theory]
         [InlineData(7, "1 周")]
         [InlineData(14, "2 周")]

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -61,15 +61,12 @@ namespace Humanizer.Localisation.Formatters
         /// <summary>
         /// Returns the string representation of the provided TimeSpan
         /// </summary>
-        /// <param name="timeUnit">Must be less than or equal to TimeUnit.Week</param>
+        /// <param name="timeUnit">A time unit to represent.</param>
         /// <param name="unit"></param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentOutOfRangeException">Is thrown when timeUnit is larger than TimeUnit.Week</exception>
         public virtual string TimeSpanHumanize(TimeUnit timeUnit, int unit)
         {
-            if (timeUnit > TimeUnit.Week)
-                throw new ArgumentOutOfRangeException(nameof(timeUnit), "There's no meaningful way to humanize passed timeUnit.");
-
             return GetResourceForTimeSpan(timeUnit, unit);
         }
 

--- a/src/Humanizer/Properties/Resources.af.resx
+++ b/src/Humanizer/Properties/Resources.af.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>oor 1 jaar</value>
   </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 maand</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} maande</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} jaar</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 jaar</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.ar.resx
+++ b/src/Humanizer/Properties/Resources.ar.resx
@@ -401,4 +401,28 @@
     <value>الآن</value>
     <comment>now</comment>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} أشهر</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Dual" xml:space="preserve">
+    <value>شهرين</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Plural" xml:space="preserve">
+    <value>{0} أشهر</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} سنة</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Dual" xml:space="preserve">
+    <value>سنتين</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Plural" xml:space="preserve">
+    <value>{0} سنة</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>شهر 1</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>السنة 1</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.bg.resx
+++ b/src/Humanizer/Properties/Resources.bg.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>след година</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} месеца</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} години</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>един месец</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>една година</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.bn-BD.resx
+++ b/src/Humanizer/Properties/Resources.bn-BD.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>এক বছর পর</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} মাস</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} বছর</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>এক মাসের</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>এক বছর</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.cs.resx
+++ b/src/Humanizer/Properties/Resources.cs.resx
@@ -285,4 +285,22 @@
   <data name="TimeSpanHumanize_MultipleWeeks_Paucal" xml:space="preserve">
     <value>{0} týdny</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} měsíců</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Paucal" xml:space="preserve">
+    <value>{0} měsíce</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} let</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Paucal" xml:space="preserve">
+    <value>{0} roky</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 měsíc</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 rok</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.da.resx
+++ b/src/Humanizer/Properties/Resources.da.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>et år fra nu</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} måneder</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} år</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>en måned</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>et år</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.de.resx
+++ b/src/Humanizer/Properties/Resources.de.resx
@@ -234,4 +234,16 @@
   <data name="DateHumanize_Never" xml:space="preserve">
     <value>nie</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} Monate</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} Jahre</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>Ein Monat</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>Ein Jahr</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.el.resx
+++ b/src/Humanizer/Properties/Resources.el.resx
@@ -117,40 +117,439 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="DateHumanize_SingleSecondAgo" xml:space="preserve">
-    <value>πριν από ένα δευτερόλεπτο</value>
+  <data name="DateHumanize_MultipleDaysAgo" xml:space="preserve">
+    <value>πριν από {0} ημέρες</value>
   </data>
-  <data name="DateHumanize_MultipleSecondsAgo" xml:space="preserve">
-    <value>πριν από {0} δευτερόλεπτα</value>
+  <data name="DateHumanize_MultipleDaysAgo_Above20" xml:space="preserve">
+    <value>πριν από {0} ημέρες</value>
   </data>
-  <data name="DateHumanize_SingleMinuteAgo" xml:space="preserve">
-    <value>πριν από ένα λεπτό</value>
+  <data name="DateHumanize_MultipleDaysAgo_Dual" xml:space="preserve">
+    <value>πριν από {0} ημέρες</value>
   </data>
-  <data name="DateHumanize_MultipleMinutesAgo" xml:space="preserve">
-    <value>πριν από {0} λεπτά</value>
+  <data name="DateHumanize_MultipleDaysAgo_Plural" xml:space="preserve">
+    <value>πριν από {0} ημέρες</value>
   </data>
-  <data name="DateHumanize_SingleHourAgo" xml:space="preserve">
-    <value>πριν από μία ώρα</value>
+  <data name="DateHumanize_MultipleDaysAgo_Singular" xml:space="preserve">
+    <value>πριν από {0} ημέρα</value>
+  </data>
+  <data name="DateHumanize_MultipleDaysAgo_TrialQuadral" xml:space="preserve">
+    <value>πριν από {0} ημέρες</value>
+  </data>
+  <data name="DateHumanize_MultipleDaysFromNow" xml:space="preserve">
+    <value>{0} ημέρες από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleDaysFromNow_Dual" xml:space="preserve">
+    <value>{0} ημέρες από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleDaysFromNow_Plural" xml:space="preserve">
+    <value>{0} ημέρες από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleDaysFromNow_Singular" xml:space="preserve">
+    <value>{0} ημέρα από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleDaysFromNow_TrialQuadral" xml:space="preserve">
+    <value>{0} ημέρες από τώρα</value>
   </data>
   <data name="DateHumanize_MultipleHoursAgo" xml:space="preserve">
     <value>πριν από {0} ώρες</value>
   </data>
-  <data name="DateHumanize_SingleDayAgo" xml:space="preserve">
-    <value>χθες</value>
+  <data name="DateHumanize_MultipleHoursAgo_Above20" xml:space="preserve">
+    <value>πριν από {0} ώρες</value>
   </data>
-  <data name="DateHumanize_MultipleDaysAgo" xml:space="preserve">
-    <value>πριν από {0} ημέρες</value>
+  <data name="DateHumanize_MultipleHoursAgo_Dual" xml:space="preserve">
+    <value>πριν από {0} ώρες</value>
   </data>
-  <data name="DateHumanize_SingleMonthAgo" xml:space="preserve">
-    <value>πριν από έναν μήνα</value>
+  <data name="DateHumanize_MultipleHoursAgo_DualTrialQuadral" xml:space="preserve">
+    <value>πριν από {0} ώρες</value>
+  </data>
+  <data name="DateHumanize_MultipleHoursAgo_Plural" xml:space="preserve">
+    <value>πριν από {0} ώρες</value>
+  </data>
+  <data name="DateHumanize_MultipleHoursAgo_Singular" xml:space="preserve">
+    <value>πριν από {0} ώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleHoursAgo_TrialQuadral" xml:space="preserve">
+    <value>πριν από {0} ώρες</value>
+  </data>
+  <data name="DateHumanize_MultipleHoursFromNow" xml:space="preserve">
+    <value>{0} ώρες από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleHoursFromNow_Dual" xml:space="preserve">
+    <value>{0} ώρες από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleHoursFromNow_DualTrialQuadral" xml:space="preserve">
+    <value>{0} ώρες από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleHoursFromNow_Plural" xml:space="preserve">
+    <value>{0} ώρες από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleHoursFromNow_Singular" xml:space="preserve">
+    <value>{0} ώρα από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleHoursFromNow_TrialQuadral" xml:space="preserve">
+    <value>{0} ώρες από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesAgo" xml:space="preserve">
+    <value>πριν από {0} λεπτά</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesAgo_Above20" xml:space="preserve">
+    <value>πριν από {0} λεπτά</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesAgo_Dual" xml:space="preserve">
+    <value>πριν από {0} λεπτά</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesAgo_DualTrialQuadral" xml:space="preserve">
+    <value>πριν από {0} λεπτά</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesAgo_Plural" xml:space="preserve">
+    <value>πριν από {0} λεπτά</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesAgo_Singular" xml:space="preserve">
+    <value>πριν από {0} λεπτό</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesAgo_TrialQuadral" xml:space="preserve">
+    <value>πριν από {0} λεπτά</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesFromNow" xml:space="preserve">
+    <value>{0} λεπτά από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesFromNow_Dual" xml:space="preserve">
+    <value>{0} λεπτά από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesFromNow_DualTrialQuadral" xml:space="preserve">
+    <value>{0} λεπτά από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesFromNow_Plural" xml:space="preserve">
+    <value>{0} λεπτά από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesFromNow_Singular" xml:space="preserve">
+    <value>{0} λεπτό από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesFromNow_TrialQuadral" xml:space="preserve">
+    <value>{0} λεπτά από τώρα</value>
   </data>
   <data name="DateHumanize_MultipleMonthsAgo" xml:space="preserve">
     <value>πριν από {0} μήνες</value>
   </data>
-  <data name="DateHumanize_SingleYearAgo" xml:space="preserve">
-    <value>πριν από έναν χρόνο</value>
+  <data name="DateHumanize_MultipleMonthsAgo_Dual" xml:space="preserve">
+    <value>πριν από {0} μήνες</value>
+  </data>
+  <data name="DateHumanize_MultipleMonthsAgo_DualTrialQuadral" xml:space="preserve">
+    <value>πριν από {0} μήνες</value>
+  </data>
+  <data name="DateHumanize_MultipleMonthsAgo_Plural" xml:space="preserve">
+    <value>πριν από {0} μήνες</value>
+  </data>
+  <data name="DateHumanize_MultipleMonthsAgo_Singular" xml:space="preserve">
+    <value>πριν από {0} μήνα</value>
+  </data>
+  <data name="DateHumanize_MultipleMonthsAgo_TrialQuadral" xml:space="preserve">
+    <value>πριν από {0} μήνες</value>
+  </data>
+  <data name="DateHumanize_MultipleMonthsFromNow" xml:space="preserve">
+    <value>{0} μήνες από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleMonthsFromNow_Dual" xml:space="preserve">
+    <value>{0} μήνες από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleMonthsFromNow_DualTrialQuadral" xml:space="preserve">
+    <value>{0} μήνες από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleMonthsFromNow_Plural" xml:space="preserve">
+    <value>{0} μήνες από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleMonthsFromNow_Singular" xml:space="preserve">
+    <value>{0} μήνα από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleMonthsFromNow_TrialQuadral" xml:space="preserve">
+    <value>{0} μήνες από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsAgo" xml:space="preserve">
+    <value>πριν από {0} δευτερόλεπτα</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsAgo_Above20" xml:space="preserve">
+    <value>πριν από {0} δευτερόλεπτα</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsAgo_Dual" xml:space="preserve">
+    <value>πριν από {0} δευτερόλεπτα</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsAgo_DualTrialQuadral" xml:space="preserve">
+    <value>πριν από {0} δευτερόλεπτα</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsAgo_Plural" xml:space="preserve">
+    <value>πριν από {0} δευτερόλεπτα</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsAgo_Singular" xml:space="preserve">
+    <value>πριν από {0} δευτερόλεπτο</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsAgo_TrialQuadral" xml:space="preserve">
+    <value>πριν από {0} δευτερόλεπτα</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsFromNow" xml:space="preserve">
+    <value>{0} δευτερόλεπτα από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsFromNow_Dual" xml:space="preserve">
+    <value>{0} δευτερόλεπτα από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsFromNow_DualTrialQuadral" xml:space="preserve">
+    <value>{0} δευτερόλεπτα από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsFromNow_Plural" xml:space="preserve">
+    <value>{0} δευτερόλεπτο από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsFromNow_Singular" xml:space="preserve">
+    <value>{0} δευτερόλεπτα από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsFromNow_TrialQuadral" xml:space="preserve">
+    <value>{0} δευτερόλεπτα από τώρα</value>
   </data>
   <data name="DateHumanize_MultipleYearsAgo" xml:space="preserve">
     <value>πριν από {0} χρόνια</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsAgo_Above20" xml:space="preserve">
+    <value>πριν από {0} χρόνια</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsAgo_Dual" xml:space="preserve">
+    <value>πριν από {0} χρόνια</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsAgo_DualTrialQuadral" xml:space="preserve">
+    <value>πριν από {0} χρόνια</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsAgo_Plural" xml:space="preserve">
+    <value>πριν από {0} χρόνια</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsAgo_Singular" xml:space="preserve">
+    <value>πριν από {0} χρόνο</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsAgo_TrialQuadral" xml:space="preserve">
+    <value>πριν από {0} χρόνια</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsFromNow" xml:space="preserve">
+    <value>{0} χρόνια από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsFromNow_Dual" xml:space="preserve">
+    <value>{0} χρόνια από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsFromNow_DualTrialQuadral" xml:space="preserve">
+    <value>{0} χρόνια από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsFromNow_Plural" xml:space="preserve">
+    <value>{0} χρόνια από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsFromNow_Singular" xml:space="preserve">
+    <value>{0} χρόνο από τώρα</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsFromNow_TrialQuadral" xml:space="preserve">
+    <value>{0} χρόνια από τώρα</value>
+  </data>
+  <data name="DateHumanize_Never" xml:space="preserve">
+    <value>ποτέ</value>
+  </data>
+  <data name="DateHumanize_Now" xml:space="preserve">
+    <value>τώρα</value>
+  </data>
+  <data name="DateHumanize_SingleDayAgo" xml:space="preserve">
+    <value>χθες</value>
+  </data>
+  <data name="DateHumanize_SingleDayFromNow" xml:space="preserve">
+    <value>αύριο</value>
+  </data>
+  <data name="DateHumanize_SingleHourAgo" xml:space="preserve">
+    <value>πριν από μία ώρα</value>
+  </data>
+  <data name="DateHumanize_SingleHourFromNow" xml:space="preserve">
+    <value>πρίν από μία ώρα από τώρα</value>
+  </data>
+  <data name="DateHumanize_SingleMinuteAgo" xml:space="preserve">
+    <value>πριν από ένα λεπτό</value>
+  </data>
+  <data name="DateHumanize_SingleMinuteFromNow" xml:space="preserve">
+    <value>πρίν από ένα λεπτό από τώρα</value>
+  </data>
+  <data name="DateHumanize_SingleMonthAgo" xml:space="preserve">
+    <value>πριν από έναν μήνα</value>
+  </data>
+  <data name="DateHumanize_SingleMonthFromNow" xml:space="preserve">
+    <value>πριν από έναν μήνα από τώρα</value>
+  </data>
+  <data name="DateHumanize_SingleSecondAgo" xml:space="preserve">
+    <value>πριν από ένα δευτερόλεπτο</value>
+  </data>
+  <data name="DateHumanize_SingleSecondFromNow" xml:space="preserve">
+    <value>πριν από ένα δευτερόλεπτο από τώρα</value>
+  </data>
+  <data name="DateHumanize_SingleYearAgo" xml:space="preserve">
+    <value>πριν από έναν χρόνο</value>
+  </data>
+  <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
+    <value>πριν από έναν χρόνο από τώρα</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleDays" xml:space="preserve">
+    <value>{0} μέρες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleDays_Dual" xml:space="preserve">
+    <value>{0} μέρες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleDays_Plural" xml:space="preserve">
+    <value>{0} μέρες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleDays_Singular" xml:space="preserve">
+    <value>{0} μέρα</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleDays_TrialQuadral" xml:space="preserve">
+    <value>{0} days</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleHours" xml:space="preserve">
+    <value>{0} ώρες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleHours_Dual" xml:space="preserve">
+    <value>{0} ώρες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleHours_DualTrialQuadral" xml:space="preserve">
+    <value>{0} ώρες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleHours_Plural" xml:space="preserve">
+    <value>{0} ώρες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleHours_Singular" xml:space="preserve">
+    <value>{0} ώρα</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleHours_TrialQuadral" xml:space="preserve">
+    <value>{0} ώρες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMilliseconds" xml:space="preserve">
+    <value>{0} χιλιοστά του δευτερολέπτου</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMilliseconds_Dual" xml:space="preserve">
+    <value>{0} χιλιοστά του δευτερολέπτου</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMilliseconds_DualTrialQuadral" xml:space="preserve">
+    <value>{0} χιλιοστά του δευτερολέπτου</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMilliseconds_Plural" xml:space="preserve">
+    <value>{0} χιλιοστά του δευτερολέπτου</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMilliseconds_Singular" xml:space="preserve">
+    <value>{0} χιλιοσtό του δευτερολέπτου</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMilliseconds_TrialQuadral" xml:space="preserve">
+    <value>{0} χιλιοστά του δευτερολέπτου</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMinutes" xml:space="preserve">
+    <value>{0} λεπτά</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMinutes_Dual" xml:space="preserve">
+    <value>{0} λεπτά</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMinutes_DualTrialQuadral" xml:space="preserve">
+    <value>{0} λεπτά</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMinutes_Plural" xml:space="preserve">
+    <value>{0} λεπτά</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMinutes_Singular" xml:space="preserve">
+    <value>{0} λεπτό</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMinutes_TrialQuadral" xml:space="preserve">
+    <value>{0} λεπτά</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} μήνες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Dual" xml:space="preserve">
+    <value>{0} μήνες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_DualTrialQuadral" xml:space="preserve">
+    <value>{0} μήνες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Plural" xml:space="preserve">
+    <value>{0} μήνες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Singular" xml:space="preserve">
+    <value>{0} μήνα</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_TrialQuadral" xml:space="preserve">
+    <value>{0} μήνες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleSeconds" xml:space="preserve">
+    <value>{0} δευτερόλεπτα</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleSeconds_Dual" xml:space="preserve">
+    <value>{0} δευτερόλεπτα</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleSeconds_DualTrialQuadral" xml:space="preserve">
+    <value>{0} δευτερόλεπτα</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleSeconds_Plural" xml:space="preserve">
+    <value>{0} δευτερόλεπτα</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleSeconds_Singular" xml:space="preserve">
+    <value>{0} δευτερόλεπτο</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleSeconds_TrialQuadral" xml:space="preserve">
+    <value>{0} δευτερόλεπτα</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleWeeks" xml:space="preserve">
+    <value>{0} βδομάδες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleWeeks_Dual" xml:space="preserve">
+    <value>{0} βδομάδες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleWeeks_DualTrialQuadral" xml:space="preserve">
+    <value>{0} βδομάδες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleWeeks_Plural" xml:space="preserve">
+    <value>{0} βδομάδες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleWeeks_Singular" xml:space="preserve">
+    <value>{0} βδομάδα</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleWeeks_TrialQuadral" xml:space="preserve">
+    <value>{0} βδομάδες</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} χρόνια</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Dual" xml:space="preserve">
+    <value>{0} χρόνια</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_DualTrialQuadral" xml:space="preserve">
+    <value>{0} χρόνια</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Plural" xml:space="preserve">
+    <value>{0} χρόνια</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Singular" xml:space="preserve">
+    <value>{0} χρόνο</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_TrialQuadral" xml:space="preserve">
+    <value>{0} χρόνια</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleDay" xml:space="preserve">
+    <value>1 μέρα</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleHour" xml:space="preserve">
+    <value>1 ώρα</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMillisecond" xml:space="preserve">
+    <value>1 χιλιοσtό του δευτερολέπτου</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMinute" xml:space="preserve">
+    <value>1 λεπτό</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 μήνα</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleSecond" xml:space="preserve">
+    <value>1 δευτερόλεπτο</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleWeek" xml:space="preserve">
+    <value>1 βδομάδα</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 χρόνο</value>
+  </data>
+  <data name="TimeSpanHumanize_Zero" xml:space="preserve">
+    <value>μηδέν χρόνος</value>
   </data>
 </root>

--- a/src/Humanizer/Properties/Resources.es.resx
+++ b/src/Humanizer/Properties/Resources.es.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_Now" xml:space="preserve">
     <value>ahora</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} meses</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} años</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>un mes</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>un año</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.fa.resx
+++ b/src/Humanizer/Properties/Resources.fa.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>یک سال بعد</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} ماه</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} سال</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>یک ماه</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>یک سال</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.fr-BE.resx
+++ b/src/Humanizer/Properties/Resources.fr-BE.resx
@@ -231,4 +231,16 @@
   <data name="TimeSpanHumanize_Zero" xml:space="preserve">
     <value>pas de temps</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} mois</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} ans</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 mois</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 année</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.fr.resx
+++ b/src/Humanizer/Properties/Resources.fr.resx
@@ -234,4 +234,16 @@
   <data name="DateHumanize_Never" xml:space="preserve">
     <value>jamais</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} mois</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} ans</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 mois</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 année</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.he.resx
+++ b/src/Humanizer/Properties/Resources.he.resx
@@ -413,4 +413,28 @@
     <value>בעוד שנייה</value>
     <comment>in a second</comment>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} חודשים</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Dual" xml:space="preserve">
+    <value>חודשיים</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Plural" xml:space="preserve">
+    <value>{0} חודשים</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} שנים</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Dual" xml:space="preserve">
+    <value>שנתיים</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Plural" xml:space="preserve">
+    <value>{0} שנים</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>חודש</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>שנה</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.hr.resx
+++ b/src/Humanizer/Properties/Resources.hr.resx
@@ -279,4 +279,22 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>za godinu dana</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} mjeseci</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_DualTrialQuadral" xml:space="preserve">
+    <value>{0} mjeseca</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} godina</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_DualTrialQuadral" xml:space="preserve">
+    <value>{0} godine</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 mjesec</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 godina</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.hu.resx
+++ b/src/Humanizer/Properties/Resources.hu.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>egy év múlva</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} hónap</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} év</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>egy hónap</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>egy év</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.id.resx
+++ b/src/Humanizer/Properties/Resources.id.resx
@@ -269,4 +269,16 @@
     <value>setahun dari sekarang</value>
     <comment>one year from now</comment>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} bulan</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} tahun</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 bulan</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 tahun</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.it.resx
+++ b/src/Humanizer/Properties/Resources.it.resx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
+  <!-- 
     Microsoft ResX Schema 
     
     Version 2.0
@@ -59,176 +59,188 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="metadata">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" />
-							</xsd:sequence>
-							<xsd:attribute name="name" use="required" type="xsd:string" />
-							<xsd:attribute name="type" type="xsd:string" />
-							<xsd:attribute name="mimetype" type="xsd:string" />
-							<xsd:attribute ref="xml:space" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="assembly">
-						<xsd:complexType>
-							<xsd:attribute name="alias" type="xsd:string" />
-							<xsd:attribute name="name" type="xsd:string" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-							<xsd:attribute ref="xml:space" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>2.0</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<data name="DateHumanize_SingleSecondAgo" xml:space="preserve">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DateHumanize_SingleSecondAgo" xml:space="preserve">
     <value>un secondo fa</value>
   </data>
-	<data name="DateHumanize_MultipleSecondsAgo" xml:space="preserve">
+  <data name="DateHumanize_MultipleSecondsAgo" xml:space="preserve">
     <value>{0} secondi fa</value>
   </data>
-	<data name="DateHumanize_SingleMinuteAgo" xml:space="preserve">
+  <data name="DateHumanize_SingleMinuteAgo" xml:space="preserve">
     <value>un minuto fa</value>
   </data>
-	<data name="DateHumanize_MultipleMinutesAgo" xml:space="preserve">
+  <data name="DateHumanize_MultipleMinutesAgo" xml:space="preserve">
     <value>{0} minuti fa</value>
   </data>
-	<data name="DateHumanize_SingleHourAgo" xml:space="preserve">
+  <data name="DateHumanize_SingleHourAgo" xml:space="preserve">
     <value>un'ora fa</value>
   </data>
-	<data name="DateHumanize_MultipleHoursAgo" xml:space="preserve">
+  <data name="DateHumanize_MultipleHoursAgo" xml:space="preserve">
     <value>{0} ore fa</value>
   </data>
-	<data name="DateHumanize_SingleDayAgo" xml:space="preserve">
+  <data name="DateHumanize_SingleDayAgo" xml:space="preserve">
     <value>ieri</value>
   </data>
-	<data name="DateHumanize_MultipleDaysAgo" xml:space="preserve">
+  <data name="DateHumanize_MultipleDaysAgo" xml:space="preserve">
     <value>{0} giorni fa</value>
   </data>
-	<data name="DateHumanize_SingleMonthAgo" xml:space="preserve">
+  <data name="DateHumanize_SingleMonthAgo" xml:space="preserve">
     <value>un mese fa</value>
   </data>
-	<data name="DateHumanize_MultipleMonthsAgo" xml:space="preserve">
+  <data name="DateHumanize_MultipleMonthsAgo" xml:space="preserve">
     <value>{0} mesi fa</value>
   </data>
-	<data name="DateHumanize_SingleYearAgo" xml:space="preserve">
+  <data name="DateHumanize_SingleYearAgo" xml:space="preserve">
     <value>un anno fa</value>
   </data>
-	<data name="DateHumanize_MultipleYearsAgo" xml:space="preserve">
+  <data name="DateHumanize_MultipleYearsAgo" xml:space="preserve">
     <value>{0} anni fa</value>
   </data>
-	<data name="TimeSpanHumanize_MultipleDays" xml:space="preserve">
+  <data name="TimeSpanHumanize_MultipleDays" xml:space="preserve">
     <value>{0} giorni</value>
   </data>
-	<data name="TimeSpanHumanize_MultipleHours" xml:space="preserve">
+  <data name="TimeSpanHumanize_MultipleHours" xml:space="preserve">
     <value>{0} ore</value>
   </data>
-	<data name="TimeSpanHumanize_MultipleMilliseconds" xml:space="preserve">
+  <data name="TimeSpanHumanize_MultipleMilliseconds" xml:space="preserve">
     <value>{0} millisecondi</value>
   </data>
-	<data name="TimeSpanHumanize_MultipleMinutes" xml:space="preserve">
+  <data name="TimeSpanHumanize_MultipleMinutes" xml:space="preserve">
     <value>{0} minuti</value>
   </data>
-	<data name="TimeSpanHumanize_MultipleSeconds" xml:space="preserve">
+  <data name="TimeSpanHumanize_MultipleSeconds" xml:space="preserve">
     <value>{0} secondi</value>
   </data>
-	<data name="TimeSpanHumanize_SingleDay" xml:space="preserve">
+  <data name="TimeSpanHumanize_SingleDay" xml:space="preserve">
     <value>1 giorno</value>
   </data>
-	<data name="TimeSpanHumanize_SingleHour" xml:space="preserve">
+  <data name="TimeSpanHumanize_SingleHour" xml:space="preserve">
     <value>1 ora</value>
   </data>
-	<data name="TimeSpanHumanize_SingleMillisecond" xml:space="preserve">
+  <data name="TimeSpanHumanize_SingleMillisecond" xml:space="preserve">
     <value>1 millisecondo</value>
   </data>
-	<data name="TimeSpanHumanize_SingleMinute" xml:space="preserve">
+  <data name="TimeSpanHumanize_SingleMinute" xml:space="preserve">
     <value>1 minuto</value>
   </data>
-	<data name="TimeSpanHumanize_SingleSecond" xml:space="preserve">
+  <data name="TimeSpanHumanize_SingleSecond" xml:space="preserve">
     <value>1 secondo</value>
   </data>
-	<data name="TimeSpanHumanize_Zero" xml:space="preserve">
+  <data name="TimeSpanHumanize_Zero" xml:space="preserve">
     <value>0 secondi</value>
   </data>
-	<data name="TimeSpanHumanize_MultipleWeeks" xml:space="preserve">
+  <data name="TimeSpanHumanize_MultipleWeeks" xml:space="preserve">
     <value>{0} settimane</value>
   </data>
-	<data name="TimeSpanHumanize_SingleWeek" xml:space="preserve">
+  <data name="TimeSpanHumanize_SingleWeek" xml:space="preserve">
     <value>1 settimana</value>
   </data>
-	<data name="DateHumanize_MultipleDaysFromNow" xml:space="preserve">
+  <data name="DateHumanize_MultipleDaysFromNow" xml:space="preserve">
     <value>tra {0} giorni</value>
   </data>
-	<data name="DateHumanize_MultipleHoursFromNow" xml:space="preserve">
+  <data name="DateHumanize_MultipleHoursFromNow" xml:space="preserve">
     <value>tra {0} ore</value>
   </data>
-	<data name="DateHumanize_MultipleMinutesFromNow" xml:space="preserve">
+  <data name="DateHumanize_MultipleMinutesFromNow" xml:space="preserve">
     <value>tra {0} minuti</value>
   </data>
-	<data name="DateHumanize_MultipleMonthsFromNow" xml:space="preserve">
+  <data name="DateHumanize_MultipleMonthsFromNow" xml:space="preserve">
     <value>tra {0} mesi</value>
   </data>
-	<data name="DateHumanize_MultipleSecondsFromNow" xml:space="preserve">
+  <data name="DateHumanize_MultipleSecondsFromNow" xml:space="preserve">
     <value>tra {0} secondi</value>
   </data>
-	<data name="DateHumanize_MultipleYearsFromNow" xml:space="preserve">
+  <data name="DateHumanize_MultipleYearsFromNow" xml:space="preserve">
     <value>tra {0} anni</value>
   </data>
-	<data name="DateHumanize_Now" xml:space="preserve">
+  <data name="DateHumanize_Now" xml:space="preserve">
     <value>adesso</value>
   </data>
-	<data name="DateHumanize_SingleDayFromNow" xml:space="preserve">
+  <data name="DateHumanize_SingleDayFromNow" xml:space="preserve">
     <value>domani</value>
   </data>
-	<data name="DateHumanize_SingleHourFromNow" xml:space="preserve">
+  <data name="DateHumanize_SingleHourFromNow" xml:space="preserve">
     <value>tra un'ora</value>
   </data>
-	<data name="DateHumanize_SingleMinuteFromNow" xml:space="preserve">
+  <data name="DateHumanize_SingleMinuteFromNow" xml:space="preserve">
     <value>tra un minuto</value>
   </data>
-	<data name="DateHumanize_SingleMonthFromNow" xml:space="preserve">
+  <data name="DateHumanize_SingleMonthFromNow" xml:space="preserve">
     <value>tra un mese</value>
   </data>
-	<data name="DateHumanize_SingleSecondFromNow" xml:space="preserve">
+  <data name="DateHumanize_SingleSecondFromNow" xml:space="preserve">
     <value>tra un secondo</value>
   </data>
-	<data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
+  <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>tra un anno</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} mesi</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} anni</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 mese</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 anno</value>
   </data>
 </root>

--- a/src/Humanizer/Properties/Resources.ja.resx
+++ b/src/Humanizer/Properties/Resources.ja.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>来年</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} ヶ月</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} 年</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 ヶ月</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 年間の</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.nb-NO.resx
+++ b/src/Humanizer/Properties/Resources.nb-NO.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>ett år fra nå</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} måneder</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} år</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>en måned</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>ett år</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.nb.resx
+++ b/src/Humanizer/Properties/Resources.nb.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>ett år fra nå</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} måneder</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} år</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>en måned</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>ett år</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.nl.resx
+++ b/src/Humanizer/Properties/Resources.nl.resx
@@ -192,43 +192,55 @@
   <data name="TimeSpanHumanize_Zero" xml:space="preserve">
     <value>geen tijd</value>
   </data>
-  <data name="DateHumanize_MultipleDaysFromNow">
+  <data name="DateHumanize_MultipleDaysFromNow" xml:space="preserve">
     <value>over {0} dagen</value>
   </data>
-  <data name="DateHumanize_MultipleHoursFromNow">
+  <data name="DateHumanize_MultipleHoursFromNow" xml:space="preserve">
     <value>over {0} uur</value>
   </data>
-  <data name="DateHumanize_MultipleMinutesFromNow">
+  <data name="DateHumanize_MultipleMinutesFromNow" xml:space="preserve">
     <value>over {0} minuten</value>
   </data>
-  <data name="DateHumanize_MultipleMonthsFromNow">
+  <data name="DateHumanize_MultipleMonthsFromNow" xml:space="preserve">
     <value>over {0} maanden</value>
   </data>
-  <data name="DateHumanize_MultipleSecondsFromNow">
+  <data name="DateHumanize_MultipleSecondsFromNow" xml:space="preserve">
     <value>over {0} seconden</value>
   </data>
-  <data name="DateHumanize_MultipleYearsFromNow">
+  <data name="DateHumanize_MultipleYearsFromNow" xml:space="preserve">
     <value>over {0} jaar</value>
   </data>
-  <data name="DateHumanize_Now">
+  <data name="DateHumanize_Now" xml:space="preserve">
     <value>nu</value>
   </data>
-  <data name="DateHumanize_SingleDayFromNow">
+  <data name="DateHumanize_SingleDayFromNow" xml:space="preserve">
     <value>morgen</value>
   </data>
-  <data name="DateHumanize_SingleHourFromNow">
+  <data name="DateHumanize_SingleHourFromNow" xml:space="preserve">
     <value>over 1 uur</value>
   </data>
-  <data name="DateHumanize_SingleMinuteFromNow">
+  <data name="DateHumanize_SingleMinuteFromNow" xml:space="preserve">
     <value>over 1 minuut</value>
   </data>
-  <data name="DateHumanize_SingleMonthFromNow">
+  <data name="DateHumanize_SingleMonthFromNow" xml:space="preserve">
     <value>over 1 maand</value>
   </data>
-  <data name="DateHumanize_SingleSecondFromNow">
+  <data name="DateHumanize_SingleSecondFromNow" xml:space="preserve">
     <value>over 1 seconde</value>
   </data>
-  <data name="DateHumanize_SingleYearFromNow">
+  <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>over 1 jaar</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} maanden</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} jaar</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 maand</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 jaar</value>
   </data>
 </root>

--- a/src/Humanizer/Properties/Resources.pl.resx
+++ b/src/Humanizer/Properties/Resources.pl.resx
@@ -285,4 +285,22 @@
   <data name="TimeSpanHumanize_MultipleWeeks_Paucal" xml:space="preserve">
     <value>{0} tygodnie</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} miesięcy</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Paucal" xml:space="preserve">
+    <value>{0} miesiące</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} lat</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Paucal" xml:space="preserve">
+    <value>{0} lata</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 miesiąc</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 rok</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.pt.resx
+++ b/src/Humanizer/Properties/Resources.pt.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_Now" xml:space="preserve">
     <value>agora</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} meses</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} anos</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 mês</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 ano</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.resx
+++ b/src/Humanizer/Properties/Resources.resx
@@ -522,4 +522,34 @@
   <data name="DateHumanize_Never" xml:space="preserve">
     <value>never</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Dual" xml:space="preserve">
+    <value>{0} months</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_DualTrialQuadral" xml:space="preserve">
+    <value>{0} months</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Plural" xml:space="preserve">
+    <value>{0} months</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Singular" xml:space="preserve">
+    <value>{0} months</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_TrialQuadral" xml:space="preserve">
+    <value>{0} months</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Dual" xml:space="preserve">
+    <value>{0} years</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_DualTrialQuadral" xml:space="preserve">
+    <value>{0} years</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Plural" xml:space="preserve">
+    <value>{0} years</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Singular" xml:space="preserve">
+    <value>{0} years</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_TrialQuadral" xml:space="preserve">
+    <value>{0} years</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.ro.resx
+++ b/src/Humanizer/Properties/Resources.ro.resx
@@ -231,4 +231,16 @@
   <data name="TimeSpanHumanize_Zero" xml:space="preserve">
     <value>niciun timp</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0}{1} luni</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0}{1} ani</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 luna</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 ani</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.ru.resx
+++ b/src/Humanizer/Properties/Resources.ru.resx
@@ -339,4 +339,28 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>через год</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} месяцев</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Paucal" xml:space="preserve">
+    <value>{0} месяца</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Singular" xml:space="preserve">
+    <value>{0} месяц</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} лет</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Paucal" xml:space="preserve">
+    <value>{0} года</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Singular" xml:space="preserve">
+    <value>{0} год</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>один месяц</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>один год</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.sk.resx
+++ b/src/Humanizer/Properties/Resources.sk.resx
@@ -285,4 +285,22 @@
   <data name="TimeSpanHumanize_MultipleWeeks_Paucal" xml:space="preserve">
     <value>{0} týždne</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} mesiacov</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Paucal" xml:space="preserve">
+    <value>{0} mesiace</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} rokov</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Paucal" xml:space="preserve">
+    <value>{0} roky</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 mesiac</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 rok</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.sl.resx
+++ b/src/Humanizer/Properties/Resources.sl.resx
@@ -342,4 +342,28 @@
   <data name="DateHumanize_Never" xml:space="preserve">
     <value>nikoli</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} mesecev</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Dual" xml:space="preserve">
+    <value>{0} meseca</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_TrialQuadral" xml:space="preserve">
+    <value>{0} mesece</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} let</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Dual" xml:space="preserve">
+    <value>{0} leti</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_TrialQuadral" xml:space="preserve">
+    <value>{0} leta</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 mesec</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 leto</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.sr-Latn.resx
+++ b/src/Humanizer/Properties/Resources.sr-Latn.resx
@@ -117,172 +117,190 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-	<data name="DateHumanize_SingleSecondAgo" xml:space="preserve">
-<value>pre sekund</value>
-</data>
-	<data name="DateHumanize_MultipleSecondsAgo" xml:space="preserve">
-<value>pre {0} sekundi</value>
-</data>
-	<data name="DateHumanize_SingleMinuteAgo" xml:space="preserve">
-<value>pre minut</value>
-</data>
-	<data name="DateHumanize_MultipleMinutesAgo" xml:space="preserve">
-<value>pre {0} minuta</value>
-</data>
-	<data name="DateHumanize_SingleHourAgo" xml:space="preserve">
-<value>pre sat vremena</value>
-</data>
-	<data name="DateHumanize_MultipleHoursAgo" xml:space="preserve">
-<value>pre {0} sati</value>
-</data>
-	<data name="DateHumanize_SingleDayAgo" xml:space="preserve">
-<value>juče</value>
-</data>
-	<data name="DateHumanize_MultipleDaysAgo" xml:space="preserve">
-<value>pre {0} dana</value>
-</data>
-	<data name="DateHumanize_SingleMonthAgo" xml:space="preserve">
-<value>pre mesec dana</value>
-</data>
-	<data name="DateHumanize_MultipleMonthsAgo" xml:space="preserve">
-<value>pre {0} meseci</value>
-</data>
-	<data name="DateHumanize_SingleYearAgo" xml:space="preserve">
-<value>pre godinu dana</value>
-</data>
-	<data name="DateHumanize_MultipleYearsAgo" xml:space="preserve">
-<value>pre {0} godina</value>
-</data>
-	<data name="TimeSpanHumanize_MultipleDays" xml:space="preserve">
-<value>{0} dana</value>
-</data>
-	<data name="TimeSpanHumanize_MultipleHours" xml:space="preserve">
-<value>{0} sati</value>
-</data>
-	<data name="TimeSpanHumanize_MultipleMilliseconds" xml:space="preserve">
-<value>{0} milisekundi</value>
-</data>
-	<data name="TimeSpanHumanize_MultipleMinutes" xml:space="preserve">
-<value>{0} minuta</value>
-</data>
-	<data name="TimeSpanHumanize_MultipleSeconds" xml:space="preserve">
-<value>{0} sekundi</value>
-</data>
-	<data name="TimeSpanHumanize_SingleDay" xml:space="preserve">
-<value>1 dan</value>
-</data>
-	<data name="TimeSpanHumanize_SingleHour" xml:space="preserve">
-<value>1 sat</value>
-</data>
-	<data name="TimeSpanHumanize_SingleMillisecond" xml:space="preserve">
-<value>1 milisekunda</value>
-</data>
-	<data name="TimeSpanHumanize_SingleMinute" xml:space="preserve">
-<value>1 minut</value>
-</data>
-	<data name="TimeSpanHumanize_SingleSecond" xml:space="preserve">
-<value>1 sekunda</value>
-</data>
-	<data name="TimeSpanHumanize_Zero" xml:space="preserve">
-<value>bez proteklog vremena</value>
-</data>
-	<data name="TimeSpanHumanize_MultipleWeeks" xml:space="preserve">
-<value>{0} nedelja</value>
-</data>
-	<data name="TimeSpanHumanize_SingleWeek" xml:space="preserve">
-<value>1 nedelja</value>
-</data>
-	<data name="DateHumanize_MultipleDaysFromNow" xml:space="preserve">
-<value>za {0} dana</value>
-</data>
-	<data name="DateHumanize_MultipleHoursFromNow" xml:space="preserve">
-<value>za {0} sati</value>
-</data>
-	<data name="DateHumanize_MultipleMinutesFromNow" xml:space="preserve">
-<value>za {0} minuta</value>
-</data>
-	<data name="DateHumanize_MultipleMonthsFromNow" xml:space="preserve">
-<value>za {0} meseci</value>
-</data>
-	<data name="DateHumanize_MultipleSecondsFromNow" xml:space="preserve">
-<value>za {0} sekundi</value>
-</data>
-	<data name="DateHumanize_MultipleYearsFromNow" xml:space="preserve">
-<value>za {0} godina</value>
-</data>
-	<data name="DateHumanize_Now" xml:space="preserve">
-<value>sada</value>
-</data>
-	<data name="DateHumanize_SingleDayFromNow" xml:space="preserve">
-<value>sutra</value>
-</data>
-	<data name="DateHumanize_SingleHourFromNow" xml:space="preserve">
-<value>za sat vremena</value>
-</data>
-	<data name="DateHumanize_SingleMinuteFromNow" xml:space="preserve">
-<value>za minut</value>
-</data>
-	<data name="DateHumanize_SingleMonthFromNow" xml:space="preserve">
-<value>za mesec dana</value>
-</data>
-	<data name="DateHumanize_SingleSecondFromNow" xml:space="preserve">
-<value>za sekund</value>
-</data>
-	<data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
-<value>za godinu dana</value>
-</data>
-	<data name="DateHumanize_MultipleDaysAgo_Paucal" xml:space="preserve">
-<value>pre {0} dana</value>
-</data>
-	<data name="DateHumanize_MultipleDaysFromNow_Paucal" xml:space="preserve">
-<value>za {0} dana</value>
-</data>
-	<data name="DateHumanize_MultipleHoursAgo_Paucal" xml:space="preserve">
-<value>pre {0} sata</value>
-</data>
-	<data name="DateHumanize_MultipleHoursFromNow_Paucal" xml:space="preserve">
-<value>za {0} sata</value>
-</data>
-	<data name="DateHumanize_MultipleMinutesAgo_Paucal" xml:space="preserve">
-<value>pre {0} minuta</value>
-</data>
-	<data name="DateHumanize_MultipleMinutesFromNow_Paucal" xml:space="preserve">
-<value>za {0} minuta</value>
-</data>
-	<data name="DateHumanize_MultipleMonthsAgo_Paucal" xml:space="preserve">
-<value>pre {0} meseca</value>
-</data>
-	<data name="DateHumanize_MultipleMonthsFromNow_Paucal" xml:space="preserve">
-<value>za {0} meseca</value>
-</data>
-	<data name="DateHumanize_MultipleSecondsAgo_Paucal" xml:space="preserve">
-<value>pre {0} sekunde</value>
-</data>
-	<data name="DateHumanize_MultipleSecondsFromNow_Paucal" xml:space="preserve">
-<value>za {0} sekunde</value>
-</data>
-	<data name="DateHumanize_MultipleYearsAgo_Paucal" xml:space="preserve">
-<value>pre {0} godine</value>
-</data>
-	<data name="DateHumanize_MultipleYearsFromNow_Paucal" xml:space="preserve">
-<value>za {0} godine</value>
-</data>
-	<data name="TimeSpanHumanize_MultipleDays_Paucal" xml:space="preserve">
-<value>{0} dana</value>
-</data>
-	<data name="TimeSpanHumanize_MultipleHours_Paucal" xml:space="preserve">
-<value>{0} sata</value>
-</data>
-	<data name="TimeSpanHumanize_MultipleMilliseconds_Paucal" xml:space="preserve">
-<value>{0} milisekunde</value>
-</data>
-	<data name="TimeSpanHumanize_MultipleMinutes_Paucal" xml:space="preserve">
-<value>{0} minuta</value>
-</data>
-	<data name="TimeSpanHumanize_MultipleSeconds_Paucal" xml:space="preserve">
-<value>{0} sekunde</value>
-</data>
-	<data name="TimeSpanHumanize_MultipleWeeks_Paucal" xml:space="preserve">
-<value>{0} nedelje</value>
-</data>
+  <data name="DateHumanize_SingleSecondAgo" xml:space="preserve">
+    <value>pre sekund</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsAgo" xml:space="preserve">
+    <value>pre {0} sekundi</value>
+  </data>
+  <data name="DateHumanize_SingleMinuteAgo" xml:space="preserve">
+    <value>pre minut</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesAgo" xml:space="preserve">
+    <value>pre {0} minuta</value>
+  </data>
+  <data name="DateHumanize_SingleHourAgo" xml:space="preserve">
+    <value>pre sat vremena</value>
+  </data>
+  <data name="DateHumanize_MultipleHoursAgo" xml:space="preserve">
+    <value>pre {0} sati</value>
+  </data>
+  <data name="DateHumanize_SingleDayAgo" xml:space="preserve">
+    <value>juče</value>
+  </data>
+  <data name="DateHumanize_MultipleDaysAgo" xml:space="preserve">
+    <value>pre {0} dana</value>
+  </data>
+  <data name="DateHumanize_SingleMonthAgo" xml:space="preserve">
+    <value>pre mesec dana</value>
+  </data>
+  <data name="DateHumanize_MultipleMonthsAgo" xml:space="preserve">
+    <value>pre {0} meseci</value>
+  </data>
+  <data name="DateHumanize_SingleYearAgo" xml:space="preserve">
+    <value>pre godinu dana</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsAgo" xml:space="preserve">
+    <value>pre {0} godina</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleDays" xml:space="preserve">
+    <value>{0} dana</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleHours" xml:space="preserve">
+    <value>{0} sati</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMilliseconds" xml:space="preserve">
+    <value>{0} milisekundi</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMinutes" xml:space="preserve">
+    <value>{0} minuta</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleSeconds" xml:space="preserve">
+    <value>{0} sekundi</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleDay" xml:space="preserve">
+    <value>1 dan</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleHour" xml:space="preserve">
+    <value>1 sat</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMillisecond" xml:space="preserve">
+    <value>1 milisekunda</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMinute" xml:space="preserve">
+    <value>1 minut</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleSecond" xml:space="preserve">
+    <value>1 sekunda</value>
+  </data>
+  <data name="TimeSpanHumanize_Zero" xml:space="preserve">
+    <value>bez proteklog vremena</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleWeeks" xml:space="preserve">
+    <value>{0} nedelja</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleWeek" xml:space="preserve">
+    <value>1 nedelja</value>
+  </data>
+  <data name="DateHumanize_MultipleDaysFromNow" xml:space="preserve">
+    <value>za {0} dana</value>
+  </data>
+  <data name="DateHumanize_MultipleHoursFromNow" xml:space="preserve">
+    <value>za {0} sati</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesFromNow" xml:space="preserve">
+    <value>za {0} minuta</value>
+  </data>
+  <data name="DateHumanize_MultipleMonthsFromNow" xml:space="preserve">
+    <value>za {0} meseci</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsFromNow" xml:space="preserve">
+    <value>za {0} sekundi</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsFromNow" xml:space="preserve">
+    <value>za {0} godina</value>
+  </data>
+  <data name="DateHumanize_Now" xml:space="preserve">
+    <value>sada</value>
+  </data>
+  <data name="DateHumanize_SingleDayFromNow" xml:space="preserve">
+    <value>sutra</value>
+  </data>
+  <data name="DateHumanize_SingleHourFromNow" xml:space="preserve">
+    <value>za sat vremena</value>
+  </data>
+  <data name="DateHumanize_SingleMinuteFromNow" xml:space="preserve">
+    <value>za minut</value>
+  </data>
+  <data name="DateHumanize_SingleMonthFromNow" xml:space="preserve">
+    <value>za mesec dana</value>
+  </data>
+  <data name="DateHumanize_SingleSecondFromNow" xml:space="preserve">
+    <value>za sekund</value>
+  </data>
+  <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
+    <value>za godinu dana</value>
+  </data>
+  <data name="DateHumanize_MultipleDaysAgo_Paucal" xml:space="preserve">
+    <value>pre {0} dana</value>
+  </data>
+  <data name="DateHumanize_MultipleDaysFromNow_Paucal" xml:space="preserve">
+    <value>za {0} dana</value>
+  </data>
+  <data name="DateHumanize_MultipleHoursAgo_Paucal" xml:space="preserve">
+    <value>pre {0} sata</value>
+  </data>
+  <data name="DateHumanize_MultipleHoursFromNow_Paucal" xml:space="preserve">
+    <value>za {0} sata</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesAgo_Paucal" xml:space="preserve">
+    <value>pre {0} minuta</value>
+  </data>
+  <data name="DateHumanize_MultipleMinutesFromNow_Paucal" xml:space="preserve">
+    <value>za {0} minuta</value>
+  </data>
+  <data name="DateHumanize_MultipleMonthsAgo_Paucal" xml:space="preserve">
+    <value>pre {0} meseca</value>
+  </data>
+  <data name="DateHumanize_MultipleMonthsFromNow_Paucal" xml:space="preserve">
+    <value>za {0} meseca</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsAgo_Paucal" xml:space="preserve">
+    <value>pre {0} sekunde</value>
+  </data>
+  <data name="DateHumanize_MultipleSecondsFromNow_Paucal" xml:space="preserve">
+    <value>za {0} sekunde</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsAgo_Paucal" xml:space="preserve">
+    <value>pre {0} godine</value>
+  </data>
+  <data name="DateHumanize_MultipleYearsFromNow_Paucal" xml:space="preserve">
+    <value>za {0} godine</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleDays_Paucal" xml:space="preserve">
+    <value>{0} dana</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleHours_Paucal" xml:space="preserve">
+    <value>{0} sata</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMilliseconds_Paucal" xml:space="preserve">
+    <value>{0} milisekunde</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMinutes_Paucal" xml:space="preserve">
+    <value>{0} minuta</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleSeconds_Paucal" xml:space="preserve">
+    <value>{0} sekunde</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleWeeks_Paucal" xml:space="preserve">
+    <value>{0} nedelje</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} meseci</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Paucal" xml:space="preserve">
+    <value>{0} meseca</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} godina</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Paucal" xml:space="preserve">
+    <value>{0} godine</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 mesec</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 godina</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.sr.resx
+++ b/src/Humanizer/Properties/Resources.sr.resx
@@ -285,4 +285,22 @@
   <data name="TimeSpanHumanize_MultipleWeeks_Paucal" xml:space="preserve">
     <value>{0} недеље</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} месеци</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Paucal" xml:space="preserve">
+    <value>{0} месеца</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} година</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Paucal" xml:space="preserve">
+    <value>{0} године</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 месец</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 година</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.sv.resx
+++ b/src/Humanizer/Properties/Resources.sv.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>om ett år</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} månader</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} år</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>en månad</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>ett år</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.tr.resx
+++ b/src/Humanizer/Properties/Resources.tr.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>bir yıl sonra</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} ay</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} yıl</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 ay</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 yıl</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.uk.resx
+++ b/src/Humanizer/Properties/Resources.uk.resx
@@ -339,4 +339,28 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>через рік</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} місяців</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Paucal" xml:space="preserve">
+    <value>{0} місяці</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Singular" xml:space="preserve">
+    <value>{0} місяць</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} років</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Paucal" xml:space="preserve">
+    <value>{0} роки</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Singular" xml:space="preserve">
+    <value>{0} рік</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>один місяць</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>один рік</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.uz-Cyrl-UZ.resx
+++ b/src/Humanizer/Properties/Resources.uz-Cyrl-UZ.resx
@@ -204,11 +204,17 @@
   <data name="TimeSpanHumanize_MultipleMinutes" xml:space="preserve">
     <value>{0} минут</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} ой</value>
+  </data>
   <data name="TimeSpanHumanize_MultipleSeconds" xml:space="preserve">
     <value>{0} секунд</value>
   </data>
   <data name="TimeSpanHumanize_MultipleWeeks" xml:space="preserve">
     <value>{0} ҳафта</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} йил</value>
   </data>
   <data name="TimeSpanHumanize_SingleDay" xml:space="preserve">
     <value>1 кун</value>
@@ -222,11 +228,17 @@
   <data name="TimeSpanHumanize_SingleMinute" xml:space="preserve">
     <value>1 минут</value>
   </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 ой</value>
+  </data>
   <data name="TimeSpanHumanize_SingleSecond" xml:space="preserve">
     <value>1 секунд</value>
   </data>
   <data name="TimeSpanHumanize_SingleWeek" xml:space="preserve">
     <value>1 ҳафта</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 йил</value>
   </data>
   <data name="TimeSpanHumanize_Zero" xml:space="preserve">
     <value>вақт йўқ</value>

--- a/src/Humanizer/Properties/Resources.uz-Latn-UZ.resx
+++ b/src/Humanizer/Properties/Resources.uz-Latn-UZ.resx
@@ -204,11 +204,17 @@
   <data name="TimeSpanHumanize_MultipleMinutes" xml:space="preserve">
     <value>{0} minut</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} oy</value>
+  </data>
   <data name="TimeSpanHumanize_MultipleSeconds" xml:space="preserve">
     <value>{0} sekund</value>
   </data>
   <data name="TimeSpanHumanize_MultipleWeeks" xml:space="preserve">
     <value>{0} hafta</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} yil</value>
   </data>
   <data name="TimeSpanHumanize_SingleDay" xml:space="preserve">
     <value>1 kun</value>
@@ -222,11 +228,17 @@
   <data name="TimeSpanHumanize_SingleMinute" xml:space="preserve">
     <value>1 minut</value>
   </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 oy</value>
+  </data>
   <data name="TimeSpanHumanize_SingleSecond" xml:space="preserve">
     <value>1 sekund</value>
   </data>
   <data name="TimeSpanHumanize_SingleWeek" xml:space="preserve">
     <value>1 hafta</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 yil</value>
   </data>
   <data name="TimeSpanHumanize_Zero" xml:space="preserve">
     <value>vaqt yo`q</value>

--- a/src/Humanizer/Properties/Resources.vi.resx
+++ b/src/Humanizer/Properties/Resources.vi.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>một năm nữa</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} tháng</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} năm</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 tháng</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 năm</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.zh-CN.resx
+++ b/src/Humanizer/Properties/Resources.zh-CN.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>明年</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} 个月</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} 年</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 个月</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 年</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.zh-Hans.resx
+++ b/src/Humanizer/Properties/Resources.zh-Hans.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>明年</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} 个月</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} 年</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 个月</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 年</value>
+  </data>
 </root>

--- a/src/Humanizer/Properties/Resources.zh-Hant.resx
+++ b/src/Humanizer/Properties/Resources.zh-Hant.resx
@@ -231,4 +231,16 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>明年</value>
   </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} 個月</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} 年</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>1 個月</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>1 年</value>
+  </data>
 </root>


### PR DESCRIPTION
This is a continuation of #632 that @MaStr11 started. It's here to serve as a base branch for other languages to PR into.

Fixes #583
This change now allows calls to `TimeSpanHumanizeExtensions.Humanize` with the parameter `maxUnit` and `minUnit` set to `TimeUnit.Month` or `maxUnit: TimeUnit.Year`. The duration in month and years is approximated based on 365.2425 days a year (length of the [gregorian calendar](https://en.wikipedia.org/wiki/Gregorian_calendar)). Therefore the month are alternating between 30 and 31 days and the years are alternating between 365 and 366 days.

The existing default value for `maxUnit=TimeUnit.Week` is kept because weeks are precise while month and year are not.

Most of the changes are related to the translation of the month and year identifiers. All text were translated with google translator except:

* *German* I'm a native German.
* *Russian* Reviewed by a native speaker.
* *fi-FI* Tests and translations for timespan were already missing.
* *el* Tests and translations for timespan were already missing.

I marked the test related to translations with the `[Trait("Translation", "Google")]` attribute to make clear which translations are of poor quality.

Checklist for the Translation Reviews:

- [ ] af
- [ ] ar
- [ ] bg
- [ ] bn-BD
- [ ] cs
- [x] da @khellang
- [x] de @MaStr11
- [x] el @cmatskas 
- [ ] es
- [x] fa @ctyar 
- [ ] fi-FI
- [ ] fr-BE
- [ ] fr
- [x] he @M-Zuber 
- [ ] hr
- [ ] hu
- [ ] id
- [ ] it
- [ ] ja
- [ ] lv
- [x] nb-NO @khellang 
- [x] nb @khellang 
- [x] nl @NinoFloris
- [ ] pl
- [ ] pt
- [ ] ro
- [x] ru @herecydev 
- [ ] sk
- [ ] sl
- [ ] sr-Latn
- [ ] sr
- [x] sv @khellang 
- [ ] tr
- [ ] uk
- [ ] uz-Cyrl-UZ
- [ ] uz-Latn-UZ
- [ ] vi
- [x] zh-CN @jeremymeng 
- [x] zh-Hans @jeremymeng 
- [x] zh-Hant @jeremymeng 