### PR TITLE
Timespan fixes for Romanian (ref. #632)

### DIFF
--- a/src/Humanizer.Tests.Shared/Localisation/ro-Ro/DateHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/ro-Ro/DateHumanizeTests.cs
@@ -42,17 +42,17 @@ namespace Humanizer.Tests.Localisation.roRO
         [Theory]
         [InlineData(10, "acum 10 zile")]
         [InlineData(23, "acum 23 de zile")]
-        public void DaysAgo(int seconds, string expected)
+        public void DaysAgo(int days, string expected)
         {
-            DateHumanize.Verify(expected, seconds, TimeUnit.Day, Tense.Past);
+            DateHumanize.Verify(expected, days, TimeUnit.Day, Tense.Past);
         }
         
         [Theory]
         [InlineData(119, "acum 119 ani")]
         [InlineData(100, "acum 100 de ani")]
-        public void YearsAgo(int seconds, string expected)
+        public void YearsAgo(int years, string expected)
         {
-            DateHumanize.Verify(expected, seconds, TimeUnit.Year, Tense.Past);
+            DateHumanize.Verify(expected, years, TimeUnit.Year, Tense.Past);
         }
         
         [Theory]

--- a/src/Humanizer.Tests.Shared/Localisation/ro-Ro/TimeSpanHumanizerTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/ro-Ro/TimeSpanHumanizerTests.cs
@@ -83,7 +83,7 @@ namespace Humanizer.Tests.Localisation.roRO
 
         [Theory]
         [Trait("Translation", "Native speaker")]
-        [InlineData(31, "1 luna")]
+        [InlineData(31, "1 lună")]
         [InlineData(61, "2 luni")]
         [InlineData(92, "3 luni")]
         [InlineData(335, "11 luni")]

--- a/src/Humanizer.Tests.Shared/Localisation/ro-Ro/TimeSpanHumanizerTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/ro-Ro/TimeSpanHumanizerTests.cs
@@ -26,6 +26,7 @@ namespace Humanizer.Tests.Localisation.roRO
         }
 
         [Theory]
+        [InlineData(0, "0 secunde")]
         [InlineData(1, "1 secundă")]
         [InlineData(14, "14 secunde")]
         [InlineData(21, "21 de secunde")]
@@ -102,6 +103,14 @@ namespace Humanizer.Tests.Localisation.roRO
         public void Years(int days, string expected)
         {
             Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Fact, CustomDescription("The name of this test is confusing because has no sense. Instead should be read as an interval with duration zero and not the absence of time.")]
+        public void NoTime()
+        {
+            // Usage in Romanian: "Timp execuție: 0 secunde."
+            // Should be equivalent with TimeSpan.FromSeconds(0).Humanize()
+            Assert.Equal("0 secunde", TimeSpan.Zero.Humanize());
         }
     }
 }

--- a/src/Humanizer.Tests.Shared/Localisation/ro-Ro/TimeSpanHumanizerTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/ro-Ro/TimeSpanHumanizerTests.cs
@@ -19,9 +19,9 @@ namespace Humanizer.Tests.Localisation.roRO
         [InlineData(14, "14 milisecunde")]
         [InlineData(21, "21 de milisecunde")]
         [InlineData(3000, "3 secunde")]
-        public void Milliseconds(int millisSeconds, string expected)
+        public void Milliseconds(int milliseconds, string expected)
         {
-            var actual = TimeSpan.FromMilliseconds(millisSeconds).Humanize();
+            var actual = TimeSpan.FromMilliseconds(milliseconds).Humanize();
             Assert.Equal(expected, actual);
         }
 

--- a/src/Humanizer.Tests.Shared/Localisation/ro-Ro/TimeSpanHumanizerTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/ro-Ro/TimeSpanHumanizerTests.cs
@@ -98,6 +98,7 @@ namespace Humanizer.Tests.Localisation.roRO
         [InlineData(731, "2 ani")]
         [InlineData(1096, "3 ani")]
         [InlineData(4018, "11 ani")]
+        [InlineData(7500, "20 de ani")]
         public void Years(int days, string expected)
         {
             Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));

--- a/src/Humanizer/Properties/Resources.ro.resx
+++ b/src/Humanizer/Properties/Resources.ro.resx
@@ -238,7 +238,7 @@
     <value>{0}{1} ani</value>
   </data>
   <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
-    <value>1 luna</value>
+    <value>1 lună</value>
   </data>
   <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
     <value>1 an</value>

--- a/src/Humanizer/Properties/Resources.ro.resx
+++ b/src/Humanizer/Properties/Resources.ro.resx
@@ -229,7 +229,7 @@
     <value>1 săptămână</value>
   </data>
   <data name="TimeSpanHumanize_Zero" xml:space="preserve">
-    <value>niciun timp</value>
+    <value>0 secunde</value>
   </data>
   <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
     <value>{0}{1} luni</value>


### PR DESCRIPTION
Fixes #632 for Romanian (ro).
Added NoTime test and changed to '0 seconds' for Romanian.
Also added few more test cases.