### PR TITLE
Fixes #585. Plus adding singulars for other words of the same suffix.

### DIFF
--- a/src/Humanizer.Tests.Shared/InflectorTests.cs
+++ b/src/Humanizer.Tests.Shared/InflectorTests.cs
@@ -335,11 +335,11 @@ namespace Humanizer.Tests
             yield return new object[] {"waltz","waltzes"};
             yield return new object[] {"zombie","zombies"};
 
-            yield return new object[] { "cookie", "cookies" };
-            yield return new object[] { "bookie", "bookies" };
-            yield return new object[] { "rookie", "rookies" };
-            yield return new object[] { "roomie", "roomies" };
-            yield return new object[] { "smoothie", "smoothies" };
+            yield return new object[] {"cookie","cookies"};
+            yield return new object[] {"bookie","bookies"};
+            yield return new object[] {"rookie","rookies"};
+            yield return new object[] {"roomie","roomies"};
+            yield return new object[] {"smoothie","smoothies"};
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/Humanizer.Tests.Shared/InflectorTests.cs
+++ b/src/Humanizer.Tests.Shared/InflectorTests.cs
@@ -334,6 +334,12 @@ namespace Humanizer.Tests
             yield return new object[] {"walrus","walruses"};
             yield return new object[] {"waltz","waltzes"};
             yield return new object[] {"zombie","zombies"};
+
+            yield return new object[] { "cookie", "cookies" };
+            yield return new object[] { "bookie", "bookies" };
+            yield return new object[] { "rookie", "rookies" };
+            yield return new object[] { "roomie", "roomies" };
+            yield return new object[] { "smoothie", "smoothies" };
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -72,6 +72,7 @@ namespace Humanizer.Inflections
             _default.AddSingular("(buz|blit|walt)zes$", "$1z");
             _default.AddSingular("(alumn|alg|larv|vertebr)ae$", "$1a");
             _default.AddSingular("(criteri|phenomen)a$", "$1on");
+            _default.AddSingular("([b|r|c]ook|room|smooth)ies$", "$1ie");
 
             _default.AddIrregular("person", "people");
             _default.AddIrregular("man", "men");


### PR DESCRIPTION
Adding fix for #585 - "Singularize("cookies") returns cooky"
Plus, adding singulars and tests for words with the same suffix form:

bookie
rookie
cookie
roomie
smoothie