### PR TITLE
Use correct CollectionFormatter for humanizing TimeSpan

### DIFF
--- a/src/Humanizer.Tests.Shared/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/TimeSpanHumanizeTests.cs
@@ -357,12 +357,13 @@ namespace Humanizer.Tests
         }
 
         [Theory]
-        [InlineData(1, "en-US", "1 millisecond")]
-        [InlineData(6 * 24 * 60 * 60 * 1000, "ru-RU", "6 дней")]
-        [InlineData(11 * 60 * 60 * 1000, "ar", "11 ساعة")]
-        public void CanSpecifyCultureExplicitly(int ms, string culture, string expected)
+        [InlineData(1, 1, "en-US", "1 millisecond", ", ")]
+        [InlineData(6 * 24 * 60 * 60 * 1000, 1, "ru-RU", "6 дней", ", ")]
+        [InlineData(11 * 60 * 60 * 1000, 1, "ar", "11 ساعة", ", ")]
+        [InlineData(3603001, 2, "it-IT", "1 ora e 3 secondi", null)]
+        public void CanSpecifyCultureExplicitly(int ms, int precision, string culture, string expected, string collectionSeparator)
         {
-            var actual = TimeSpan.FromMilliseconds(ms).Humanize(culture: new CultureInfo(culture));
+            var actual = TimeSpan.FromMilliseconds(ms).Humanize(precision: precision, culture: new CultureInfo(culture), collectionSeparator: collectionSeparator);
             Assert.Equal(expected, actual);
         }
     }

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -48,7 +48,7 @@ namespace Humanizer
             var timeParts = CreateTheTimePartsWithUpperAndLowerLimits(timeSpan, culture, maxUnit, minUnit);
             timeParts = SetPrecisionOfTimeSpan(timeParts, precision, countEmptyUnits);
 
-            return ConcatenateTimeSpanParts(timeParts, collectionSeparator);
+            return ConcatenateTimeSpanParts(timeParts, culture, collectionSeparator);
         }
 
         private static IEnumerable<string> CreateTheTimePartsWithUpperAndLowerLimits(TimeSpan timespan, CultureInfo culture, TimeUnit maxUnit, TimeUnit minUnit)
@@ -205,11 +205,11 @@ namespace Humanizer
             return timeParts;
         }
 
-        private static string ConcatenateTimeSpanParts(IEnumerable<string> timeSpanParts, string collectionSeparator)
+        private static string ConcatenateTimeSpanParts(IEnumerable<string> timeSpanParts, CultureInfo culture, string collectionSeparator)
         {
             if (collectionSeparator == null)
             {
-                return Configurator.CollectionFormatter.Humanize(timeSpanParts);
+                return Configurator.CollectionFormatters.ResolveForCulture(culture).Humanize(timeSpanParts);
             }
 
             return string.Join(collectionSeparator, timeSpanParts);


### PR DESCRIPTION
Previously, the CurrentUICulture's CollectionFormatter would be used, even though a specific culture was specified when calling `TimeSpanHumanizeExtensions.Humanize`. This change now uses the specified culture's CollectionFormatter, so that "and" can be translated to the specified language (ie. "e" in `it-IT` culture, see #655).