### PR TITLE
allow TimeSpan humanizations with numbers converted to words

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -454,6 +454,11 @@ TimeSpan.FromMilliseconds(1299630020).Humanize(3, collectionSeparator: null) => 
 TimeSpan.FromMilliseconds(1299630020).Humanize(3, collectionSeparator: null) => "2 Wochen, Ein Tag und Eine Stunde"
 ```
 
+If words are preferred to numbers, a `toWords: true` parameter can be set to convert the numbers in a humanized TimeSpan to words:
+```C#
+TimeSpan.FromMilliseconds(1299630020).Humanize(3, toWords: true) => "two weeks, one day, one hour"
+````
+
 ### <a id="humanize-collections">Humanize Collections</a>
 You can call `Humanize` on any `IEnumerable` to get a nicely formatted string representing the objects in the collection. By default `ToString()` will be called on each item to get its representation but a formatting function may be passed to `Humanize` instead. Additionally, a default separator is provided ("and" in English), but a different separator may be passed into `Humanize`.
 

--- a/src/Humanizer.Tests.Shared/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/TimeSpanHumanizeTests.cs
@@ -380,7 +380,7 @@ namespace Humanizer.Tests
         [InlineData(1299630020, 5, "two weeks, one day, one hour, thirty seconds, twenty milliseconds")]
         public void TimeSpanWithNumbersConvertedToWords(int milliseconds, int precision, string expected)
         {
-            var actual = TimeSpan.FromMilliseconds(milliseconds).Humanize(precision, numbersToWords: true);
+            var actual = TimeSpan.FromMilliseconds(milliseconds).Humanize(precision, toWords: true);
             Assert.Equal(expected, actual);
         }
 

--- a/src/Humanizer.Tests.Shared/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/TimeSpanHumanizeTests.cs
@@ -348,6 +348,42 @@ namespace Humanizer.Tests
             Assert.Equal(expected, actual);
         }
 
+        [Theory]
+        [InlineData(0, 3, "no time")]
+        [InlineData(0, 2, "no time")]
+        [InlineData(10, 2, "ten milliseconds")]
+        [InlineData(1400, 2, "one second, four hundred milliseconds")]
+        [InlineData(2500, 2, "two seconds, five hundred milliseconds")]
+        [InlineData(120000, 2, "two minutes")]
+        [InlineData(62000, 2, "one minute, two seconds")]
+        [InlineData(62020, 2, "one minute, two seconds")]
+        [InlineData(62020, 3, "one minute, two seconds, twenty milliseconds")]
+        [InlineData(3600020, 4, "one hour, twenty milliseconds")]
+        [InlineData(3600020, 3, "one hour, twenty milliseconds")]
+        [InlineData(3600020, 2, "one hour, twenty milliseconds")]
+        [InlineData(3600020, 1, "one hour")]
+        [InlineData(3603001, 2, "one hour, three seconds")]
+        [InlineData(3603001, 3, "one hour, three seconds, one millisecond")]
+        [InlineData(86400000, 3, "one day")]
+        [InlineData(86400000, 2, "one day")]
+        [InlineData(86400000, 1, "one day")]
+        [InlineData(86401000, 1, "one day")]
+        [InlineData(86401000, 2, "one day, one second")]
+        [InlineData(86401200, 2, "one day, one second")]
+        [InlineData(86401200, 3, "one day, one second, two hundred milliseconds")]
+        [InlineData(1296000000, 1, "two weeks")]
+        [InlineData(1296000000, 2, "two weeks, one day")]
+        [InlineData(1299600000, 2, "two weeks, one day")]
+        [InlineData(1299600000, 3, "two weeks, one day, one hour")]
+        [InlineData(1299630020, 3, "two weeks, one day, one hour")]
+        [InlineData(1299630020, 4, "two weeks, one day, one hour, thirty seconds")]
+        [InlineData(1299630020, 5, "two weeks, one day, one hour, thirty seconds, twenty milliseconds")]
+        public void TimeSpanWithNumbersConvertedToWords(int milliseconds, int precision, string expected)
+        {
+            var actual = TimeSpan.FromMilliseconds(milliseconds).Humanize(precision, numbersToWords: true);
+            Assert.Equal(expected, actual);
+        }
+
         [Fact]
         public void NoTime()
         {

--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
@@ -979,8 +979,8 @@ namespace Humanizer
     }
     public class static TimeSpanHumanizeExtensions
     {
-        public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo culture = null, Humanizer.Localisation.TimeUnit maxUnit = 5, Humanizer.Localisation.TimeUnit minUnit = 0, string collectionSeparator = ", ") { }
-        public static string Humanize(this System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo culture = null, Humanizer.Localisation.TimeUnit maxUnit = 5, Humanizer.Localisation.TimeUnit minUnit = 0, string collectionSeparator = ", ") { }
+        public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo culture = null, Humanizer.Localisation.TimeUnit maxUnit = 5, Humanizer.Localisation.TimeUnit minUnit = 0, string collectionSeparator = ", ", bool toWords = False) { }
+        public static string Humanize(this System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo culture = null, Humanizer.Localisation.TimeUnit maxUnit = 5, Humanizer.Localisation.TimeUnit minUnit = 0, string collectionSeparator = ", ", bool toWords = False) { }
     }
     public class static To
     {
@@ -1120,10 +1120,10 @@ namespace Humanizer.Localisation.Formatters
         public virtual string DateHumanize_Never() { }
         public virtual string DateHumanize_Now() { }
         protected virtual string Format(string resourceKey) { }
-        protected virtual string Format(string resourceKey, int number) { }
+        protected virtual string Format(string resourceKey, int number, bool toWords = False) { }
         protected virtual string GetResourceKey(string resourceKey, int number) { }
         protected virtual string GetResourceKey(string resourceKey) { }
-        public virtual string TimeSpanHumanize(Humanizer.Localisation.TimeUnit timeUnit, int unit) { }
+        public virtual string TimeSpanHumanize(Humanizer.Localisation.TimeUnit timeUnit, int unit, bool toWords = False) { }
         public virtual string TimeSpanHumanize_Zero() { }
     }
     public interface IFormatter
@@ -1131,7 +1131,7 @@ namespace Humanizer.Localisation.Formatters
         string DateHumanize(Humanizer.Localisation.TimeUnit timeUnit, Humanizer.Localisation.Tense timeUnitTense, int unit);
         string DateHumanize_Never();
         string DateHumanize_Now();
-        string TimeSpanHumanize(Humanizer.Localisation.TimeUnit timeUnit, int unit);
+        string TimeSpanHumanize(Humanizer.Localisation.TimeUnit timeUnit, int unit, bool toWords = False);
         string TimeSpanHumanize_Zero();
     }
 }

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -63,11 +63,12 @@ namespace Humanizer.Localisation.Formatters
         /// </summary>
         /// <param name="timeUnit">A time unit to represent.</param>
         /// <param name="unit"></param>
+        /// <param name="numbersToWords"></param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentOutOfRangeException">Is thrown when timeUnit is larger than TimeUnit.Week</exception>
-        public virtual string TimeSpanHumanize(TimeUnit timeUnit, int unit)
+        public virtual string TimeSpanHumanize(TimeUnit timeUnit, int unit, bool numbersToWords = false)
         {
-            return GetResourceForTimeSpan(timeUnit, unit);
+            return GetResourceForTimeSpan(timeUnit, unit, numbersToWords);
         }
 
         private string GetResourceForDate(TimeUnit unit, Tense timeUnitTense, int count)
@@ -76,10 +77,10 @@ namespace Humanizer.Localisation.Formatters
             return count == 1 ? Format(resourceKey) : Format(resourceKey, count);
         }
 
-        private string GetResourceForTimeSpan(TimeUnit unit, int count)
+        private string GetResourceForTimeSpan(TimeUnit unit, int count, bool numbersToWords = false)
         {
             var resourceKey = ResourceKeys.TimeSpanHumanize.GetResourceKey(unit, count);
-            return count == 1 ? Format(resourceKey) : Format(resourceKey, count);
+            return count == 1 ? Format(resourceKey + (numbersToWords ? "_Words" : "")) : Format(resourceKey, count, numbersToWords);
         }
 
         /// <summary>
@@ -103,16 +104,19 @@ namespace Humanizer.Localisation.Formatters
         /// </summary>
         /// <param name="resourceKey">The resource key.</param>
         /// <param name="number">The number.</param>
+        /// <param name="numbersToWords"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentException">If the resource not exists on the specified culture.</exception>
-        protected virtual string Format(string resourceKey, int number)
+        protected virtual string Format(string resourceKey, int number, bool numbersToWords = false)
         {
             var resourceString = Resources.GetResource(GetResourceKey(resourceKey, number), _culture);
 
             if (string.IsNullOrEmpty(resourceString))
                 throw new ArgumentException($"The resource object with key '{resourceKey}' was not found", nameof(resourceKey));
 
-            return resourceString.FormatWith(number);
+            return numbersToWords
+                ? resourceString.FormatWith(number.ToWords())
+                : resourceString.FormatWith(number);
         }
 
         /// <summary>

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -63,12 +63,12 @@ namespace Humanizer.Localisation.Formatters
         /// </summary>
         /// <param name="timeUnit">A time unit to represent.</param>
         /// <param name="unit"></param>
-        /// <param name="numbersToWords"></param>
+        /// <param name="toWords"></param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentOutOfRangeException">Is thrown when timeUnit is larger than TimeUnit.Week</exception>
-        public virtual string TimeSpanHumanize(TimeUnit timeUnit, int unit, bool numbersToWords = false)
+        public virtual string TimeSpanHumanize(TimeUnit timeUnit, int unit, bool toWords = false)
         {
-            return GetResourceForTimeSpan(timeUnit, unit, numbersToWords);
+            return GetResourceForTimeSpan(timeUnit, unit, toWords);
         }
 
         private string GetResourceForDate(TimeUnit unit, Tense timeUnitTense, int count)
@@ -77,10 +77,10 @@ namespace Humanizer.Localisation.Formatters
             return count == 1 ? Format(resourceKey) : Format(resourceKey, count);
         }
 
-        private string GetResourceForTimeSpan(TimeUnit unit, int count, bool numbersToWords = false)
+        private string GetResourceForTimeSpan(TimeUnit unit, int count, bool toWords = false)
         {
             var resourceKey = ResourceKeys.TimeSpanHumanize.GetResourceKey(unit, count);
-            return count == 1 ? Format(resourceKey + (numbersToWords ? "_Words" : "")) : Format(resourceKey, count, numbersToWords);
+            return count == 1 ? Format(resourceKey + (toWords ? "_Words" : "")) : Format(resourceKey, count, toWords);
         }
 
         /// <summary>
@@ -104,17 +104,17 @@ namespace Humanizer.Localisation.Formatters
         /// </summary>
         /// <param name="resourceKey">The resource key.</param>
         /// <param name="number">The number.</param>
-        /// <param name="numbersToWords"></param>
+        /// <param name="toWords"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentException">If the resource not exists on the specified culture.</exception>
-        protected virtual string Format(string resourceKey, int number, bool numbersToWords = false)
+        protected virtual string Format(string resourceKey, int number, bool toWords = false)
         {
             var resourceString = Resources.GetResource(GetResourceKey(resourceKey, number), _culture);
 
             if (string.IsNullOrEmpty(resourceString))
                 throw new ArgumentException($"The resource object with key '{resourceKey}' was not found", nameof(resourceKey));
 
-            return numbersToWords
+            return toWords
                 ? resourceString.FormatWith(number.ToWords())
                 : resourceString.FormatWith(number);
         }

--- a/src/Humanizer/Localisation/Formatters/IFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/IFormatter.cs
@@ -39,8 +39,8 @@
         /// </summary>
         /// <param name="timeUnit"></param>
         /// <param name="unit"></param>
-        /// <param name="numbersToWords"></param>
+        /// <param name="toWords"></param>
         /// <returns></returns>
-        string TimeSpanHumanize(TimeUnit timeUnit, int unit, bool numbersToWords = false);
+        string TimeSpanHumanize(TimeUnit timeUnit, int unit, bool toWords = false);
     }
 }

--- a/src/Humanizer/Localisation/Formatters/IFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/IFormatter.cs
@@ -39,7 +39,8 @@
         /// </summary>
         /// <param name="timeUnit"></param>
         /// <param name="unit"></param>
+        /// <param name="numbersToWords"></param>
         /// <returns></returns>
-        string TimeSpanHumanize(TimeUnit timeUnit, int unit);
+        string TimeSpanHumanize(TimeUnit timeUnit, int unit, bool numbersToWords = false);
     }
 }

--- a/src/Humanizer/Localisation/Formatters/RomanianFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/RomanianFormatter.cs
@@ -21,7 +21,7 @@
             _romanianCulture = new CultureInfo(RomanianCultureCode);
         }
 
-        protected override string Format(string resourceKey, int number)
+        protected override string Format(string resourceKey, int number, bool numbersToWords = false)
         {
             var format = Resources.GetResource(GetResourceKey(resourceKey, number), _romanianCulture);
             var preposition = ShouldUsePreposition(number)

--- a/src/Humanizer/Localisation/Formatters/RomanianFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/RomanianFormatter.cs
@@ -21,7 +21,7 @@
             _romanianCulture = new CultureInfo(RomanianCultureCode);
         }
 
-        protected override string Format(string resourceKey, int number, bool numbersToWords = false)
+        protected override string Format(string resourceKey, int number, bool toWords = false)
         {
             var format = Resources.GetResource(GetResourceKey(resourceKey, number), _romanianCulture);
             var preposition = ShouldUsePreposition(number)

--- a/src/Humanizer/Properties/Resources.resx
+++ b/src/Humanizer/Properties/Resources.resx
@@ -552,4 +552,28 @@
   <data name="TimeSpanHumanize_MultipleYears_TrialQuadral" xml:space="preserve">
     <value>{0} years</value>
   </data>
+  <data name="TimeSpanHumanize_SingleDay_Words" xml:space="preserve">
+    <value>one day</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleHour_Words" xml:space="preserve">
+    <value>one hour</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMillisecond_Words" xml:space="preserve">
+    <value>one millisecond</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMinute_Words" xml:space="preserve">
+    <value>one minute</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth_Words" xml:space="preserve">
+    <value>one month</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleSecond_Words" xml:space="preserve">
+    <value>one second</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleWeek_Words" xml:space="preserve">
+    <value>one week</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear_Words" xml:space="preserve">
+    <value>one year</value>
+  </data>
 </root>

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -27,9 +27,9 @@ namespace Humanizer
         /// <param name="minUnit">The minimum unit of time to output.</param>
         /// <param name="collectionSeparator">The separator to use when combining humanized time parts. If null, the default collection formatter for the current culture is used.</param>
         /// <returns></returns>
-        public static string Humanize(this TimeSpan timeSpan, int precision = 1, CultureInfo culture = null, TimeUnit maxUnit = TimeUnit.Week, TimeUnit minUnit = TimeUnit.Millisecond, string collectionSeparator = ", ")
+        public static string Humanize(this TimeSpan timeSpan, int precision = 1, CultureInfo culture = null, TimeUnit maxUnit = TimeUnit.Week, TimeUnit minUnit = TimeUnit.Millisecond, string collectionSeparator = ", ", bool numbersToWords = false)
         {
-            return Humanize(timeSpan, precision, false, culture, maxUnit, minUnit, collectionSeparator);
+            return Humanize(timeSpan, precision, false, culture, maxUnit, minUnit, collectionSeparator, numbersToWords);
         }
 
         /// <summary>
@@ -43,15 +43,15 @@ namespace Humanizer
         /// <param name="minUnit">The minimum unit of time to output.</param>
         /// <param name="collectionSeparator">The separator to use when combining humanized time parts. If null, the default collection formatter for the current culture is used.</param>
         /// <returns></returns>
-        public static string Humanize(this TimeSpan timeSpan, int precision, bool countEmptyUnits, CultureInfo culture = null, TimeUnit maxUnit = TimeUnit.Week, TimeUnit minUnit = TimeUnit.Millisecond, string collectionSeparator = ", ")
+        public static string Humanize(this TimeSpan timeSpan, int precision, bool countEmptyUnits, CultureInfo culture = null, TimeUnit maxUnit = TimeUnit.Week, TimeUnit minUnit = TimeUnit.Millisecond, string collectionSeparator = ", ", bool numbersToWords = false)
         {
-            var timeParts = CreateTheTimePartsWithUpperAndLowerLimits(timeSpan, culture, maxUnit, minUnit);
+            var timeParts = CreateTheTimePartsWithUpperAndLowerLimits(timeSpan, culture, maxUnit, minUnit, numbersToWords);
             timeParts = SetPrecisionOfTimeSpan(timeParts, precision, countEmptyUnits);
 
             return ConcatenateTimeSpanParts(timeParts, collectionSeparator);
         }
 
-        private static IEnumerable<string> CreateTheTimePartsWithUpperAndLowerLimits(TimeSpan timespan, CultureInfo culture, TimeUnit maxUnit, TimeUnit minUnit)
+        private static IEnumerable<string> CreateTheTimePartsWithUpperAndLowerLimits(TimeSpan timespan, CultureInfo culture, TimeUnit maxUnit, TimeUnit minUnit, bool numbersToWords = false)
         {
             var cultureFormatter = Configurator.GetFormatter(culture);
             var firstValueFound = false;
@@ -60,7 +60,7 @@ namespace Humanizer
 
             foreach (var timeUnitType in timeUnitsEnumTypes)
             {
-                var timepart = GetTimeUnitPart(timeUnitType, timespan, culture, maxUnit, minUnit, cultureFormatter);
+                var timepart = GetTimeUnitPart(timeUnitType, timespan, culture, maxUnit, minUnit, cultureFormatter, numbersToWords);
 
                 if (timepart != null || firstValueFound)
                 {
@@ -82,13 +82,13 @@ namespace Humanizer
             return enumTypeEnumerator.Reverse();
         }
 
-        private static string GetTimeUnitPart(TimeUnit timeUnitToGet, TimeSpan timespan, CultureInfo culture, TimeUnit maximumTimeUnit, TimeUnit minimumTimeUnit, IFormatter cultureFormatter)
+        private static string GetTimeUnitPart(TimeUnit timeUnitToGet, TimeSpan timespan, CultureInfo culture, TimeUnit maximumTimeUnit, TimeUnit minimumTimeUnit, IFormatter cultureFormatter, bool numbersToWords = false)
         {
             if (timeUnitToGet <= maximumTimeUnit && timeUnitToGet >= minimumTimeUnit)
             {
                 var isTimeUnitToGetTheMaximumTimeUnit = (timeUnitToGet == maximumTimeUnit);
                 var numberOfTimeUnits = GetTimeUnitNumericalValue(timeUnitToGet, timespan, isTimeUnitToGetTheMaximumTimeUnit);
-                return BuildFormatTimePart(cultureFormatter, timeUnitToGet, numberOfTimeUnits);
+                return BuildFormatTimePart(cultureFormatter, timeUnitToGet, numberOfTimeUnits, numbersToWords);
             }
             return null;
         }
@@ -176,11 +176,11 @@ namespace Humanizer
             return timeNumberOfUnits;
         }
 
-        private static string BuildFormatTimePart(IFormatter cultureFormatter, TimeUnit timeUnitType, int amountOfTimeUnits)
+        private static string BuildFormatTimePart(IFormatter cultureFormatter, TimeUnit timeUnitType, int amountOfTimeUnits, bool numbersToWords = false)
         {
             // Always use positive units to account for negative timespans
             return amountOfTimeUnits != 0
-                ? cultureFormatter.TimeSpanHumanize(timeUnitType, Math.Abs(amountOfTimeUnits))
+                ? cultureFormatter.TimeSpanHumanize(timeUnitType, Math.Abs(amountOfTimeUnits), numbersToWords)
                 : null;
         }
 

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -27,9 +27,9 @@ namespace Humanizer
         /// <param name="minUnit">The minimum unit of time to output.</param>
         /// <param name="collectionSeparator">The separator to use when combining humanized time parts. If null, the default collection formatter for the current culture is used.</param>
         /// <returns></returns>
-        public static string Humanize(this TimeSpan timeSpan, int precision = 1, CultureInfo culture = null, TimeUnit maxUnit = TimeUnit.Week, TimeUnit minUnit = TimeUnit.Millisecond, string collectionSeparator = ", ", bool numbersToWords = false)
+        public static string Humanize(this TimeSpan timeSpan, int precision = 1, CultureInfo culture = null, TimeUnit maxUnit = TimeUnit.Week, TimeUnit minUnit = TimeUnit.Millisecond, string collectionSeparator = ", ", bool toWords = false)
         {
-            return Humanize(timeSpan, precision, false, culture, maxUnit, minUnit, collectionSeparator, numbersToWords);
+            return Humanize(timeSpan, precision, false, culture, maxUnit, minUnit, collectionSeparator, toWords);
         }
 
         /// <summary>
@@ -43,15 +43,15 @@ namespace Humanizer
         /// <param name="minUnit">The minimum unit of time to output.</param>
         /// <param name="collectionSeparator">The separator to use when combining humanized time parts. If null, the default collection formatter for the current culture is used.</param>
         /// <returns></returns>
-        public static string Humanize(this TimeSpan timeSpan, int precision, bool countEmptyUnits, CultureInfo culture = null, TimeUnit maxUnit = TimeUnit.Week, TimeUnit minUnit = TimeUnit.Millisecond, string collectionSeparator = ", ", bool numbersToWords = false)
+        public static string Humanize(this TimeSpan timeSpan, int precision, bool countEmptyUnits, CultureInfo culture = null, TimeUnit maxUnit = TimeUnit.Week, TimeUnit minUnit = TimeUnit.Millisecond, string collectionSeparator = ", ", bool toWords = false)
         {
-            var timeParts = CreateTheTimePartsWithUpperAndLowerLimits(timeSpan, culture, maxUnit, minUnit, numbersToWords);
+            var timeParts = CreateTheTimePartsWithUpperAndLowerLimits(timeSpan, culture, maxUnit, minUnit, toWords);
             timeParts = SetPrecisionOfTimeSpan(timeParts, precision, countEmptyUnits);
 
             return ConcatenateTimeSpanParts(timeParts, collectionSeparator);
         }
 
-        private static IEnumerable<string> CreateTheTimePartsWithUpperAndLowerLimits(TimeSpan timespan, CultureInfo culture, TimeUnit maxUnit, TimeUnit minUnit, bool numbersToWords = false)
+        private static IEnumerable<string> CreateTheTimePartsWithUpperAndLowerLimits(TimeSpan timespan, CultureInfo culture, TimeUnit maxUnit, TimeUnit minUnit, bool toWords = false)
         {
             var cultureFormatter = Configurator.GetFormatter(culture);
             var firstValueFound = false;
@@ -60,7 +60,7 @@ namespace Humanizer
 
             foreach (var timeUnitType in timeUnitsEnumTypes)
             {
-                var timepart = GetTimeUnitPart(timeUnitType, timespan, culture, maxUnit, minUnit, cultureFormatter, numbersToWords);
+                var timepart = GetTimeUnitPart(timeUnitType, timespan, culture, maxUnit, minUnit, cultureFormatter, toWords);
 
                 if (timepart != null || firstValueFound)
                 {
@@ -82,13 +82,13 @@ namespace Humanizer
             return enumTypeEnumerator.Reverse();
         }
 
-        private static string GetTimeUnitPart(TimeUnit timeUnitToGet, TimeSpan timespan, CultureInfo culture, TimeUnit maximumTimeUnit, TimeUnit minimumTimeUnit, IFormatter cultureFormatter, bool numbersToWords = false)
+        private static string GetTimeUnitPart(TimeUnit timeUnitToGet, TimeSpan timespan, CultureInfo culture, TimeUnit maximumTimeUnit, TimeUnit minimumTimeUnit, IFormatter cultureFormatter, bool toWords = false)
         {
             if (timeUnitToGet <= maximumTimeUnit && timeUnitToGet >= minimumTimeUnit)
             {
                 var isTimeUnitToGetTheMaximumTimeUnit = (timeUnitToGet == maximumTimeUnit);
                 var numberOfTimeUnits = GetTimeUnitNumericalValue(timeUnitToGet, timespan, isTimeUnitToGetTheMaximumTimeUnit);
-                return BuildFormatTimePart(cultureFormatter, timeUnitToGet, numberOfTimeUnits, numbersToWords);
+                return BuildFormatTimePart(cultureFormatter, timeUnitToGet, numberOfTimeUnits, toWords);
             }
             return null;
         }
@@ -176,11 +176,11 @@ namespace Humanizer
             return timeNumberOfUnits;
         }
 
-        private static string BuildFormatTimePart(IFormatter cultureFormatter, TimeUnit timeUnitType, int amountOfTimeUnits, bool numbersToWords = false)
+        private static string BuildFormatTimePart(IFormatter cultureFormatter, TimeUnit timeUnitType, int amountOfTimeUnits, bool toWords = false)
         {
             // Always use positive units to account for negative timespans
             return amountOfTimeUnits != 0
-                ? cultureFormatter.TimeSpanHumanize(timeUnitType, Math.Abs(amountOfTimeUnits), numbersToWords)
+                ? cultureFormatter.TimeSpanHumanize(timeUnitType, Math.Abs(amountOfTimeUnits), toWords)
                 : null;
         }
 


### PR DESCRIPTION
Since #405 appears abandoned, this covers the `TimeSpan` part of #290. I went with adding an optional `numbersToWords` parameter to it's `Humanize()` method as opposed to adding a `ToWords()` method, based on the consistency argument from the issue.

e.g. `TimeSpan.FromSeconds(2).Humanize(numbersToWords: true)` => `two seconds`

The `numbersToWords` param proliferated a little deeper than I would have liked, so I'm open to discussing other options if that's preferred.