### PR TITLE
Fix ArgumentOutOfRangeException for Camelize

### DIFF
--- a/src/Humanizer.Tests.Shared/InflectorTests.cs
+++ b/src/Humanizer.Tests.Shared/InflectorTests.cs
@@ -116,6 +116,7 @@ namespace Humanizer.Tests
         [InlineData("customer_first_name", "customerFirstName")]
         [InlineData("customer_first_name_goes_here", "customerFirstNameGoesHere")]
         [InlineData("customer name", "customer name")]
+        [InlineData("", "")]
         public void Camelize(string input, string expectedOutput)
         {
             Assert.Equal(expectedOutput, input.Camelize());

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -82,7 +82,7 @@ namespace Humanizer
         public static string Camelize(this string input)
         {
             var word = Pascalize(input);
-            return word.Substring(0, 1).ToLower() + word.Substring(1);
+            return word.Length > 0 ? word.Substring(0, 1).ToLower() + word.Substring(1) : word;
         }
 
         /// <summary>


### PR DESCRIPTION
This ensures that Camelize does not throw an unexpected ArgumentOutOfRangeException if the input string is empty. See #663.