### PR TITLE
fix humanizing of Flags enum

### DIFF
--- a/src/Humanizer.Tests.Shared/BitFieldEnumHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/BitFieldEnumHumanizeTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace Humanizer.Tests
 {
     [UseCulture("en")]
-    public class BitFieldEnumHumanizeTests 
+    public class BitFieldEnumHumanizeTests
     {
         [Fact]
         public void CanHumanizeSingleWordDescriptionAttribute()
@@ -46,6 +46,12 @@ namespace Humanizer.Tests
         {
             var xoredBitFlag = (ShortBitFieldEnumUnderTest.RED | ShortBitFieldEnumUnderTest.DARK_GRAY);
             Assert.Equal(BitFlagEnumTestsResources.ExpectedResultWhenBothValuesXored, xoredBitFlag.Humanize());
+        }
+
+        [Fact]
+        public void CanHumanizeBitFieldEnumWithZeroValue()
+        {
+            Assert.Equal(BitFlagEnumTestsResources.None, BitFieldEnumUnderTest.NONE.Humanize());
         }
     }
 }

--- a/src/Humanizer.Tests.Shared/BitFieldEnumUnderTest.cs
+++ b/src/Humanizer.Tests.Shared/BitFieldEnumUnderTest.cs
@@ -11,23 +11,26 @@ namespace Humanizer.Tests
     [Flags]
     public enum BitFieldEnumUnderTest : int
     {
-        [Display( Description = BitFlagEnumTestsResources.MemberWithSingleWordDisplayAttribute)]
+        [Display(Description = BitFlagEnumTestsResources.None)]
+        NONE = 0,
+        [Display(Description = BitFlagEnumTestsResources.MemberWithSingleWordDisplayAttribute)]
         RED = 1,
-        [Display( Description = BitFlagEnumTestsResources.MemberWithMultipleWordDisplayAttribute)]
+        [Display(Description = BitFlagEnumTestsResources.MemberWithMultipleWordDisplayAttribute)]
         DARK_GRAY = 2
     }
 
     [Flags]
     public enum ShortBitFieldEnumUnderTest : short
     {
-        [Display( Description = BitFlagEnumTestsResources.MemberWithSingleWordDisplayAttribute)]
+        [Display(Description = BitFlagEnumTestsResources.MemberWithSingleWordDisplayAttribute)]
         RED = 1,
-        [Display( Description = BitFlagEnumTestsResources.MemberWithMultipleWordDisplayAttribute)]
+        [Display(Description = BitFlagEnumTestsResources.MemberWithMultipleWordDisplayAttribute)]
         DARK_GRAY = 2
     }
 
     public class BitFlagEnumTestsResources
     {
+        public const string None = "None";
         public const string MemberWithSingleWordDisplayAttribute = "Red";
         public const string MemberWithMultipleWordDisplayAttribute = "Dark Gray";
 

--- a/src/Humanizer/EnumHumanizeExtensions.cs
+++ b/src/Humanizer/EnumHumanizeExtensions.cs
@@ -31,7 +31,8 @@ namespace Humanizer
             {
                 return Enum.GetValues(enumType)
                            .Cast<Enum>()
-                           .Where(e => input.HasFlag(e))
+                           .Where(e => e.CompareTo(Convert.ChangeType(Enum.ToObject(enumType, 0), enumType)) != 0)
+                           .Where(input.HasFlag)
                            .Select(e => e.Humanize())
                            .Humanize();
             }
@@ -108,5 +109,5 @@ namespace Humanizer
 
             return humanizedEnum.ApplyCase(casing);
         }
-   }
+    }
 }


### PR DESCRIPTION
Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No ReSharper warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `dev` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures


fixes #683 

When a Flags enum with a None value is Humanized and multiple values are set, the None Value is now ignored.

```c#
[Flags]
enum Test {
    None = 0,
    First = 1,
    Second = 2
}
```

`Enum.First | Enum.Second` now gets turned into `First and Second` instead of `None, First and Second`