### PR TITLE
Use DiffPlex reporter to avoid NRE on build

### DIFF
--- a/src/Humanizer.Tests/ApiApprover/DiffPlexReporter.cs
+++ b/src/Humanizer.Tests/ApiApprover/DiffPlexReporter.cs
@@ -1,4 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿#if NET46
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information. 
 
@@ -45,3 +46,4 @@ namespace Humanizer.Tests.ApiApprover
         }
     }
 }
+#endif

--- a/src/Humanizer.Tests/ApiApprover/DiffPlexReporter.cs
+++ b/src/Humanizer.Tests/ApiApprover/DiffPlexReporter.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information. 
+
+using ApprovalTests.Core;
+using DiffPlex;
+using DiffPlex.DiffBuilder;
+using DiffPlex.DiffBuilder.Model;
+using System.IO;
+using Xunit.Abstractions;
+
+namespace Humanizer.Tests.ApiApprover
+{
+    public class DiffPlexReporter : IApprovalFailureReporter
+    {
+        public static readonly DiffPlexReporter Instance = new DiffPlexReporter();
+
+        public ITestOutputHelper Output { get; set; }
+
+        public void Report(string approved, string received)
+        {
+            var approvedText = File.Exists(approved) ? File.ReadAllText(approved) : string.Empty;
+            var receivedText = File.ReadAllText(received);
+
+            var diffBuilder = new InlineDiffBuilder(new Differ());
+            var diff = diffBuilder.BuildDiffModel(approvedText, receivedText);
+
+            foreach (var line in diff.Lines)
+            {
+                if (line.Type == ChangeType.Unchanged) continue;
+
+                var prefix = "  ";
+                switch (line.Type)
+                {
+                    case ChangeType.Inserted:
+                        prefix = "+ ";
+                        break;
+                    case ChangeType.Deleted:
+                        prefix = "- ";
+                        break;
+                }
+
+                Output.WriteLine("{0}{1}", prefix, line.Text);
+            }
+        }
+    }
+}

--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.cs
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.cs
@@ -5,15 +5,25 @@ using ApprovalTests;
 using ApprovalTests.Reporters;
 using PublicApiGenerator;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Humanizer.Tests.ApiApprover
 {
 
     public class PublicApiApprovalTest
     {
+        public PublicApiApprovalTest(ITestOutputHelper output)
+        {
+            DiffPlexReporter.Instance.Output = output;
+        }
+
         [Fact]
         [UseCulture("en-US")]
-        [UseReporter(typeof(DiffReporter))] 
+#if DEBUG
+        [UseReporter(typeof(DiffReporter))]
+#else
+        [UseReporter(typeof(DiffPlexReporter))]
+#endif
         [IgnoreLineEndings(true)]
         public void approve_public_api()
         {

--- a/src/Humanizer.Tests/Humanizer.Tests.csproj
+++ b/src/Humanizer.Tests/Humanizer.Tests.csproj
@@ -16,6 +16,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <PackageReference Include="PublicApiGenerator" Version="7.0.1" />
     <PackageReference Include="ApiApprover" Version="7.0.1" />
+    <PackageReference Include="DiffPlex" Version="1.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Humanizer.Tests.Shared\**\*.cs">


### PR DESCRIPTION
Fixes NRE if api approvals fails on the build server