### PR TITLE
Add Tupleize extension. Fixes #709

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@ Humanizer meets all your .NET needs for manipulating and displaying strings, enu
    - [Metric numerals](#metric-numerals)
    - [ByteSize](#bytesize)
    - [Heading to words](#heading-to-words)
+   - [Tupleize](#tupleize)
  - [Mix this into your framework to simplify your life](#mix-this-into-your-framework-to-simplify-your-life) - 
  - [How to contribute?](#how-to-contribute)
  - [Continuous Integration from AppVeyor](#continuous-integration)
@@ -1078,6 +1079,20 @@ In order to retrieve a heading based on the short text representation (e.g. N, E
 "SW".FromShortHeading();
 // 225
 ```
+
+### <a id="tupleize">Tupleize</a>
+Humanizer can change whole numbers into their 'tuple'  using `Tupleize`. For example:
+
+```C#
+1.Tupleize();
+// single
+3.Tupleize();
+// triple
+100.Tupleize();
+// centuple
+```
+
+The numbers 1-10, 100 and 1000 will be converted into a 'named' tuple (i.e. "single", "double" etc.). Any other number "n" will be converted to "n-tuple".
 
 ## <a id="mix-this-into-your-framework-to-simplify-your-life">Mix this into your framework to simplify your life</a>
 This is just a baseline and you can use this to simplify your day to day job. For example, in Asp.Net MVC we keep chucking `Display` attribute on ViewModel properties so `HtmlHelper` can generate correct labels for us; but, just like enums, in vast majority of cases we just need a space between the words in property name - so why not use `"string".Humanize` for that?!

--- a/src/Humanizer.Tests.Shared/TupleizeTests.cs
+++ b/src/Humanizer.Tests.Shared/TupleizeTests.cs
@@ -1,0 +1,37 @@
+using Xunit;
+// ReSharper disable IdentifierTypo 
+// ReSharper disable StringLiteralTypo
+
+namespace Humanizer.Tests
+{
+    public class TupleizeTests
+    {
+        [Theory]
+        [InlineData(1, "single")]
+        [InlineData(2, "double")]
+        [InlineData(3, "triple")]
+        [InlineData(4, "quadruple")]
+        [InlineData(5, "quintuple")]
+        [InlineData(6, "sextuple")]
+        [InlineData(7, "septuple")]
+        [InlineData(8, "octuple")]
+        [InlineData(9, "nonuple")]
+        [InlineData(10, "decuple")]
+        [InlineData(100, "centuple")]
+        [InlineData(1000, "milluple")]
+        public void Given_int_with_named_tuple_gives_correct_result(int n, string expected)
+        {
+            Assert.Equal(expected, n.Tupleize());
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(int.MinValue)]
+        [InlineData(int.MaxValue)]
+        public void Given_other_number_returns_n_tuple(int n)
+        {
+            Assert.Equal($"{n}-tuple", n.Tupleize());
+        }
+    }
+}

--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
@@ -1025,6 +1025,10 @@ namespace Humanizer
         public static Humanizer.ITruncator FixedNumberOfCharacters { get; }
         public static Humanizer.ITruncator FixedNumberOfWords { get; }
     }
+    public class static TupleizeExtensions
+    {
+        public static string Tupleize(this int input) { }
+    }
 }
 namespace Humanizer.Configuration
 {

--- a/src/Humanizer/TupleizeExtensions.cs
+++ b/src/Humanizer/TupleizeExtensions.cs
@@ -1,0 +1,49 @@
+// ReSharper disable IdentifierTypo 
+// ReSharper disable StringLiteralTypo
+namespace Humanizer
+{
+    /// <summary>
+    /// Convert int to named tuple strings (1 -> 'single', 2-> 'double' etc.).
+    /// Only values 1-10, 100, and 1000 have specific names. All others will return 'n-tuple'.
+    /// </summary>
+    public static class TupleizeExtensions
+    {
+        /// <summary>
+        /// Converts integer to named tuple (e.g. 'single', 'double' etc.).
+        /// </summary>
+        /// <param name="input">Integer</param>
+        /// <returns>Named tuple</returns>
+        public static string Tupleize(this int input)
+        {
+            switch (input)
+            {
+                case 1:
+                    return "single";
+                case 2:
+                    return "double";
+                case 3:
+                    return "triple";
+                case 4:
+                    return "quadruple";
+                case 5:
+                    return "quintuple";
+                case 6:
+                    return "sextuple";
+                case 7:
+                    return "septuple";
+                case 8:
+                    return "octuple";
+                case 9:
+                    return "nonuple";
+                case 10:
+                    return "decuple";
+                case 100:
+                    return "centuple";
+                case 1000:
+                    return "milluple";
+                default:
+                    return $"{input}-tuple";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add extension method to convert ints to 'named tuples', i.e. "single",
"double", "triple" etc..

Here is a checklist you should tick through before submitting a pull request: 
 - [X] Implementation is clean
 - [X] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [X] No ReSharper warnings
 - [X] There is proper unit test coverage
 - [X] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [X] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [X] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `dev` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [X] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
