### PR TITLE
Updated Regex pattern in ToTitleCase method to handle apostrophes

### DIFF
--- a/src/Humanizer.Tests.Shared/TransformersTests.cs
+++ b/src/Humanizer.Tests.Shared/TransformersTests.cs
@@ -1,4 +1,4 @@
-using Xunit;
+﻿using Xunit;
 
 namespace Humanizer.Tests
 {
@@ -12,6 +12,8 @@ namespace Humanizer.Tests
         [InlineData("Can deal w 1 letter words as i do", "Can Deal W 1 Letter Words As I Do")]
         [InlineData("  random spaces   are HONORED    too ", "  Random Spaces   Are HONORED    Too ")]
         [InlineData("Title Case", "Title Case")]
+        [InlineData("apostrophe's aren't capitalized", "Apostrophe's Aren't Capitalized")]
+        [InlineData("titles with, commas work too", "Titles With, Commas Work Too")]
         public void TransformToTitleCase(string input, string expectedOutput)
         {
             Assert.Equal(expectedOutput, input.Transform(To.TitleCase));

--- a/src/Humanizer/Transformer/ToTitleCase.cs
+++ b/src/Humanizer/Transformer/ToTitleCase.cs
@@ -8,7 +8,7 @@ namespace Humanizer
         public string Transform(string input)
         {
             var result = input;
-            var matches = Regex.Matches(input, "([A-Za-z]|[^\u0000-\u007F])+('[A-Za-z]|[^\u0000-\u007F]+)*");
+            var matches = Regex.Matches(input, @"(\w|[^\u0000-\u007F])+'?\w*");
             foreach (Match word in matches)
             {
                 if (!AllCapitals(word.Value))

--- a/src/Humanizer/Transformer/ToTitleCase.cs
+++ b/src/Humanizer/Transformer/ToTitleCase.cs
@@ -8,7 +8,7 @@ namespace Humanizer
         public string Transform(string input)
         {
             var result = input;
-            var matches = Regex.Matches(input, @"\w+");
+            var matches = Regex.Matches(input, "[A-Za-z]+('[A-Za-z]+)?");
             foreach (Match word in matches)
             {
                 if (!AllCapitals(word.Value))

--- a/src/Humanizer/Transformer/ToTitleCase.cs
+++ b/src/Humanizer/Transformer/ToTitleCase.cs
@@ -8,7 +8,7 @@ namespace Humanizer
         public string Transform(string input)
         {
             var result = input;
-            var matches = Regex.Matches(input, "[A-Za-z]+('[A-Za-z]+)?");
+            var matches = Regex.Matches(input, "([A-Za-z]|[^\u0000-\u007F])+('[A-Za-z]|[^\u0000-\u007F]+)*");
             foreach (Match word in matches)
             {
                 if (!AllCapitals(word.Value))


### PR DESCRIPTION
I updated the Regex pattern in the `ToTitleCase` method to handle words with apostrophes, as mentioned in issue #584.

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No ReSharper warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `dev` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures

Fixes #584.

Side note, the code as is can't differentiate between contractions and names like "O'Connell". So for example, if you write code like this:

    "Mc'Donald".Transform(To.LowerCase).Transform(To.TitleCase)
it will return `Mc'donald` instead of `Mc'Donald` like some people might expect. That's probably a pretty uncommon case, but it's worth mentioning.