### PR TITLE
Remove redundant ToQuantity methods

### DIFF
--- a/src/Humanizer.Tests.Shared/ToQuantityTests.cs
+++ b/src/Humanizer.Tests.Shared/ToQuantityTests.cs
@@ -22,7 +22,6 @@ namespace Humanizer.Tests
         public void ToQuantity(string word, int quantity, string expected)
         {
             Assert.Equal(expected, word.ToQuantity(quantity));
-            Assert.Equal(expected, word.ToQuantity((long)quantity));
         }
 
         [Theory]
@@ -40,7 +39,6 @@ namespace Humanizer.Tests
         public void ToQuantityWithNoQuantity(string word, int quantity, string expected)
         {
             Assert.Equal(expected, word.ToQuantity(quantity, ShowQuantityAs.None));
-            Assert.Equal(expected, word.ToQuantity((long)quantity, ShowQuantityAs.None));
         }
 
         [Theory]
@@ -57,9 +55,7 @@ namespace Humanizer.Tests
         [InlineData("processes", 1, "1 process")]
         public void ToQuantityNumeric(string word, int quantity, string expected)
         {
-            // ReSharper disable once RedundantArgumentDefaultValue
             Assert.Equal(expected, word.ToQuantity(quantity, ShowQuantityAs.Numeric));
-            Assert.Equal(expected, word.ToQuantity((long)quantity, ShowQuantityAs.Numeric));
         }
 
         [Theory]
@@ -78,7 +74,6 @@ namespace Humanizer.Tests
         public void ToQuantityWords(string word, int quantity, string expected)
         {
             Assert.Equal(expected, word.ToQuantity(quantity, ShowQuantityAs.Words));
-            Assert.Equal(expected, word.ToQuantity((long)quantity, ShowQuantityAs.Words));
         }
 
         [Theory]
@@ -96,7 +91,6 @@ namespace Humanizer.Tests
         public void ToQuantityWordsWithCurrentCultureFormatting(string word, int quantity, string format, string expected)
         {
             Assert.Equal(expected, word.ToQuantity(quantity, format));
-            Assert.Equal(expected, word.ToQuantity((long)quantity, format));
         }
 
         [Theory]
@@ -114,7 +108,6 @@ namespace Humanizer.Tests
             var culture = new CultureInfo(cultureCode);
 
             Assert.Equal(expected, word.ToQuantity(quantity, format, culture), GetStringComparer(culture));
-            Assert.Equal(expected, word.ToQuantity((long)quantity, format, culture), GetStringComparer(culture));
         }
 
         internal static StringComparer GetStringComparer(CultureInfo culture)

--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
@@ -1010,8 +1010,6 @@ namespace Humanizer
     }
     public class static ToQuantityExtensions
     {
-        public static string ToQuantity(this string input, int quantity, Humanizer.ShowQuantityAs showQuantityAs = 1) { }
-        public static string ToQuantity(this string input, int quantity, string format, System.IFormatProvider formatProvider = null) { }
         public static string ToQuantity(this string input, long quantity, Humanizer.ShowQuantityAs showQuantityAs = 1) { }
         public static string ToQuantity(this string input, long quantity, string format, System.IFormatProvider formatProvider = null) { }
     }

--- a/src/Humanizer/ToQuantityExtensions.cs
+++ b/src/Humanizer/ToQuantityExtensions.cs
@@ -30,43 +30,7 @@ namespace Humanizer
     /// </summary>
     public static class ToQuantityExtensions
     {
-        /// <summary>
-        /// Prefixes the provided word with the number and accordingly pluralizes or singularizes the word
-        /// </summary>
-        /// <param name="input">The word to be prefixed</param>
-        /// <param name="quantity">The quantity of the word</param>
-        /// <param name="showQuantityAs">How to show the quantity. Numeric by default</param>
-        /// <example>
-        /// "request".ToQuantity(0) => "0 requests"
-        /// "request".ToQuantity(1) => "1 request"
-        /// "request".ToQuantity(2) => "2 requests"
-        /// "men".ToQuantity(2) => "2 men"
-        /// "process".ToQuantity(1200, ShowQuantityAs.Words) => "one thousand two hundred processes"
-        /// </example>
-        /// <returns></returns>
-        public static string ToQuantity(this string input, int quantity, ShowQuantityAs showQuantityAs = ShowQuantityAs.Numeric)
-        {
-            return input.ToQuantity(quantity, showQuantityAs, format: null, formatProvider: null);
-        }
-
-        /// <summary>
-        /// Prefixes the provided word with the number and accordingly pluralizes or singularizes the word
-        /// </summary>
-        /// <param name="input">The word to be prefixed</param>
-        /// <param name="quantity">The quantity of the word</param>
-        /// <param name="format">A standard or custom numeric format string.</param>
-        /// <param name="formatProvider">An object that supplies culture-specific formatting information.</param>
-        /// <example>
-        /// "request".ToQuantity(0) => "0 requests"
-        /// "request".ToQuantity(10000, format: "N0") => "10,000 requests"
-        /// "request".ToQuantity(1, format: "N0") => "1 request"
-        /// </example>
-        /// <returns></returns>
-        public static string ToQuantity(this string input, int quantity, string format, IFormatProvider formatProvider = null)
-        {
-            return input.ToQuantity(quantity, showQuantityAs: ShowQuantityAs.Numeric, format: format, formatProvider: formatProvider);
-        }
-
+        
         /// <summary>
         /// Prefixes the provided word with the number and accordingly pluralizes or singularizes the word
         /// </summary>


### PR DESCRIPTION
This PR removes the ToQuantity methods that accept an int as a parameter and leaves the ones that accept a long.

As all the methods call the same method linked below, that only accepts a long, we already box everything down to a long to begin with: https://github.com/Humanizr/Humanizer/blob/d5b3cf3fd081733dd2ccb3e13a35af8ffe987415/src/Humanizer/ToQuantityExtensions.cs#L107 

Also remove unneeded AssertEquals that box ints to longs
