### PR TITLE
Add "cache" => "caches" as as irregular words. Fixes #789

### DIFF
--- a/src/Humanizer.Tests.Shared/InflectorTests.cs
+++ b/src/Humanizer.Tests.Shared/InflectorTests.cs
@@ -349,6 +349,9 @@ namespace Humanizer.Tests
             yield return new object[] { "rookie", "rookies" };
             yield return new object[] { "roomie", "roomies" };
             yield return new object[] { "smoothie", "smoothies" };
+            
+            //Issue #789
+            yield return new object[] { "cache", "caches" };
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -89,6 +89,8 @@ namespace Humanizer.Inflections
             _default.AddIrregular("database", "databases");
             _default.AddIrregular("zombie", "zombies");
             _default.AddIrregular("personnel", "personnel");
+            //Fix #789
+            _default.AddIrregular("cache", "caches");
 
             _default.AddIrregular("is", "are", matchEnding: false);
             _default.AddIrregular("that", "those", matchEnding: false);


### PR DESCRIPTION
This PR adds "cache" and "caches" as irregular words to fix calling "caches".Singularize().

It fixes #789 
