### PR TITLE
Change Pascalize to remove spaces fix #774

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -219,7 +219,7 @@ If passed a fewer number for arguments, it'll throw `String.FormatException` exc
 You also can specify the culture to use explicitly as the first parameter for the `FormatWith()` method:
 
 ```c#
-"{0:N2}".FormatWith(new CultureInfo("ru-RU"), 6666.66) => "6 666,66"
+"{0:N2}".FormatWith(new CultureInfo("ru-RU"), 6666.66) => "6 666,66"
 ```
 
 If a culture is not specified, current thread's current culture is used.
@@ -639,17 +639,17 @@ Obviously this only applies to some cultures. For others passing gender in or no
 `Titleize` converts the input words to Title casing; equivalent to `"some title".Humanize(LetterCasing.Title)`
 
 #### <a id="pascalize">Pascalize</a>
-`Pascalize` converts the input words to UpperCamelCase, also removing underscores:
+`Pascalize` converts the input words to UpperCamelCase, also removing underscores and spaces:
 
 ```C#
-"some_title".Pascalize() => "SomeTitle"
+"some_title for something".Pascalize() => "SomeTitleForSomething"
 ```
 
 #### <a id="camelize">Camelize</a>
 `Camelize` behaves identically to `Pascalize`, except that the first character is lower case:
 
 ```C#
-"some_title".Camelize() => "someTitle"
+"some_title for something".Camelize() => "someTitleForSomething"
 ```
 
 #### <a id="underscore">Underscore</a>

--- a/src/Humanizer.Tests.Shared/InflectorTests.cs
+++ b/src/Humanizer.Tests.Shared/InflectorTests.cs
@@ -100,8 +100,8 @@ namespace Humanizer.Tests
         [InlineData("CUStomer", "CUStomer")]
         [InlineData("customer_name", "CustomerName")]
         [InlineData("customer_first_name", "CustomerFirstName")]
-        [InlineData("customer_first_name_goes_here", "CustomerFirstNameGoesHere")]
-        [InlineData("customer name", "Customer name")]
+        [InlineData("customer_first_name goes here", "CustomerFirstNameGoesHere")]
+        [InlineData("customer name", "CustomerName")]
         public void Pascalize(string input, string expectedOutput)
         {
             Assert.Equal(expectedOutput, input.Pascalize());
@@ -114,8 +114,8 @@ namespace Humanizer.Tests
         [InlineData("CUStomer", "cUStomer")]
         [InlineData("customer_name", "customerName")]
         [InlineData("customer_first_name", "customerFirstName")]
-        [InlineData("customer_first_name_goes_here", "customerFirstNameGoesHere")]
-        [InlineData("customer name", "customer name")]
+        [InlineData("customer_first_name goes here", "customerFirstNameGoesHere")]
+        [InlineData("customer name", "customerName")]
         [InlineData("", "")]
         public void Camelize(string input, string expectedOutput)
         {

--- a/src/Humanizer.Tests.Shared/InflectorTests.cs
+++ b/src/Humanizer.Tests.Shared/InflectorTests.cs
@@ -102,6 +102,7 @@ namespace Humanizer.Tests
         [InlineData("customer_first_name", "CustomerFirstName")]
         [InlineData("customer_first_name goes here", "CustomerFirstNameGoesHere")]
         [InlineData("customer name", "CustomerName")]
+        [InlineData("customer   name", "CustomerName")]
         public void Pascalize(string input, string expectedOutput)
         {
             Assert.Equal(expectedOutput, input.Pascalize());
@@ -116,6 +117,7 @@ namespace Humanizer.Tests
         [InlineData("customer_first_name", "customerFirstName")]
         [InlineData("customer_first_name goes here", "customerFirstNameGoesHere")]
         [InlineData("customer name", "customerName")]
+        [InlineData("customer   name", "customerName")]
         [InlineData("", "")]
         public void Camelize(string input, string expectedOutput)
         {

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -72,7 +72,7 @@ namespace Humanizer
         public static string Pascalize(this string input)
         {
             
-            return Regex.Replace(input, "(?:^|_| )(.)", match => match.Groups[1].Value.ToUpper());
+            return Regex.Replace(input, "(?:^|_| +)(.)", match => match.Groups[1].Value.ToUpper());
             
             //return Regex.Replace(input, @"\s+", "");
         }

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -70,11 +70,8 @@ namespace Humanizer
         /// <param name="removeWhiteSpace">"This has a space" -> "ThisHasASpace" if true</param>
         /// <returns></returns>
         public static string Pascalize(this string input)
-        {
-            
+        {   
             return Regex.Replace(input, "(?:^|_| +)(.)", match => match.Groups[1].Value.ToUpper());
-            
-            //return Regex.Replace(input, @"\s+", "");
         }
 
         /// <summary>

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -67,20 +67,25 @@ namespace Humanizer
         /// By default, pascalize converts strings to UpperCamelCase also removing underscores
         /// </summary>
         /// <param name="input"></param>
+        /// <param name="removeWhiteSpace">"This has a space" -> "ThisHasASpace" if true</param>
         /// <returns></returns>
         public static string Pascalize(this string input)
         {
-            return Regex.Replace(input, "(?:^|_)(.)", match => match.Groups[1].Value.ToUpper());
+            
+            input = Regex.Replace(input, "(?:^|_| )(.)", match => match.Groups[1].Value.ToUpper());
+            
+            return Regex.Replace(input, @"\s+", "");
         }
 
         /// <summary>
         /// Same as Pascalize except that the first character is lower case
         /// </summary>
         /// <param name="input"></param>
+        /// <param name="removeWhiteSpace">"This has a space" -> "thisHasASpace" if true</param>
         /// <returns></returns>
         public static string Camelize(this string input)
         {
-            var word = Pascalize(input);
+            var word = input.Pascalize();
             return word.Length > 0 ? word.Substring(0, 1).ToLower() + word.Substring(1) : word;
         }
 

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -72,9 +72,9 @@ namespace Humanizer
         public static string Pascalize(this string input)
         {
             
-            input = Regex.Replace(input, "(?:^|_| )(.)", match => match.Groups[1].Value.ToUpper());
+            return Regex.Replace(input, "(?:^|_| )(.)", match => match.Groups[1].Value.ToUpper());
             
-            return Regex.Replace(input, @"\s+", "");
+            //return Regex.Replace(input, @"\s+", "");
         }
 
         /// <summary>


### PR DESCRIPTION
This is a PR to change to fix #774 that changes Pascalize (and therefore Camelize too) to treat spaces in the same way it treats underscores.

I wasn't sure whether to have this as an optional change, or a change to the method itself, so I've chosen to just change the method and create this PR as a way to generate conversation around the issue.

Let me know if you have any thoughts.