### PR TITLE
Add string.Replace to fix #811

### DIFF
--- a/src/Humanizer.Tests.Shared/Bytes/ByteSizeExtensionsTests.cs
+++ b/src/Humanizer.Tests.Shared/Bytes/ByteSizeExtensionsTests.cs
@@ -345,6 +345,7 @@ namespace Humanizer.Tests.Bytes
         [Theory]
         [InlineData(0, null, "0 b")]
         [InlineData(0, "#.##", "0 b")]
+        [InlineData(0, "#.## B", "0 B")]
         [InlineData(0, "B", "0 B")]
         [InlineData(2, null, "2 B")]
         [InlineData(2000, "KB", "1.95 KB")]

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace Humanizer.Bytes
 {
@@ -242,6 +243,8 @@ namespace Humanizer.Bytes
             {
                 format = "0.## " + format;
             }
+
+            format = format.Replace("#.##", "0.##");
 
             bool has(string s) => format.IndexOf(s, StringComparison.CurrentCultureIgnoreCase) != -1;
             string output(double n) => n.ToString(format, provider);


### PR DESCRIPTION
Fix #811.
This replaces the format from #.## to 0.## to make sure we return 0 B instead of just B.