### PR TITLE
Fixed wording for '8000' in Hebrew

### DIFF
--- a/src/Humanizer/Localisation/NumberToWords/HebrewNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/HebrewNumberToWordsConverter.cs
@@ -160,6 +160,10 @@ namespace Humanizer.Localisation.NumberToWords
             {
                 parts.Add("אלפיים");
             }
+            else if (thousands == 8)
+            {
+                parts.Add("שמונת אלפים");
+            }
             else if (thousands <= 10)
             {
                 parts.Add(UnitsFeminine[thousands] + "ת" + " אלפים");


### PR DESCRIPTION
Should be "שמונת" instead of "שמונהת" (which isn't a word).
