### PR TITLE
Fixes issue #819 (ByteSize with no overload for subtraction) with Unit test

### DIFF
--- a/src/Humanizer.Tests.Shared/Bytes/ArithmeticTests.cs
+++ b/src/Humanizer.Tests.Shared/Bytes/ArithmeticTests.cs
@@ -99,7 +99,7 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Fact]
-        public void MinusOperator()
+        public void NegativeOperator()
         {
             var size = ByteSize.FromBytes(2);
 
@@ -128,6 +128,17 @@ namespace Humanizer.Tests.Bytes
             var result = size1 + size2;
 
             Assert.Equal(2, result.Bytes);
+        }
+
+        [Fact]
+        public void MinusOperator()
+        {
+            var size1 = ByteSize.FromBytes(2);
+            var size2 = ByteSize.FromBytes(1);
+
+            var result = size1 - size2;
+
+            Assert.Equal(1, result.Bytes);
         }
     }
 }

--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
@@ -68,8 +68,8 @@ namespace Humanizer.Bytes
         public static bool !=(Humanizer.Bytes.ByteSize b1, Humanizer.Bytes.ByteSize b2) { }
         public static bool <(Humanizer.Bytes.ByteSize b1, Humanizer.Bytes.ByteSize b2) { }
         public static bool <=(Humanizer.Bytes.ByteSize b1, Humanizer.Bytes.ByteSize b2) { }
-        public static Humanizer.Bytes.ByteSize -(Humanizer.Bytes.ByteSize b) { }
         public static Humanizer.Bytes.ByteSize -(Humanizer.Bytes.ByteSize b1, Humanizer.Bytes.ByteSize b2) { }
+        public static Humanizer.Bytes.ByteSize -(Humanizer.Bytes.ByteSize b) { }
         public static Humanizer.Bytes.ByteSize Parse(string s) { }
         public Humanizer.Bytes.ByteSize Subtract(Humanizer.Bytes.ByteSize bs) { }
         public string ToFullWords() { }

--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
@@ -69,6 +69,7 @@ namespace Humanizer.Bytes
         public static bool <(Humanizer.Bytes.ByteSize b1, Humanizer.Bytes.ByteSize b2) { }
         public static bool <=(Humanizer.Bytes.ByteSize b1, Humanizer.Bytes.ByteSize b2) { }
         public static Humanizer.Bytes.ByteSize -(Humanizer.Bytes.ByteSize b) { }
+        public static Humanizer.Bytes.ByteSize -(Humanizer.Bytes.ByteSize b1, Humanizer.Bytes.ByteSize b2) { }
         public static Humanizer.Bytes.ByteSize Parse(string s) { }
         public Humanizer.Bytes.ByteSize Subtract(Humanizer.Bytes.ByteSize bs) { }
         public string ToFullWords() { }

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -398,6 +398,11 @@ namespace Humanizer.Bytes
             return new ByteSize(b1.Bytes + b2.Bytes);
         }
 
+        public static ByteSize operator -(ByteSize b1, ByteSize b2)
+        {
+            return new ByteSize(b1.Bytes - b2.Bytes);
+        }
+
         public static ByteSize operator ++(ByteSize b)
         {
             return new ByteSize(b.Bytes + 1);


### PR DESCRIPTION
Add new overload for Minus Operator, fix issue 819
https://github.com/Humanizr/Humanizer/issues/819

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No ReSharper warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `dev` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
