### PR TITLE
remove special case for 0 to fix "hasSpace: true"

### DIFF
--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -135,11 +135,6 @@ namespace Humanizer
         /// <returns>A valid Metric representation</returns>
         public static string ToMetric(this double input, bool hasSpace = false, bool useSymbol = true, int? decimals = null)
         {
-            if (input.Equals(0))
-            {
-                return input.ToString();
-            }
-
             if (input.IsOutOfRange())
             {
                 throw new ArgumentOutOfRangeException(nameof(input));


### PR DESCRIPTION
See: https://dotnetfiddle.net/NHTOam

Console.WriteLine(0.ToMetric(hasSpace: true) + "Wh");
Console.WriteLine(1.ToMetric(hasSpace: true) + "Wh");
Console.WriteLine(1000.ToMetric(hasSpace: true) + "Wh");

outputs

0Wh
1 Wh
1 kWh