### PR TITLE
Fix 1>Localisation\NumberToWords\SwedishNumberToWordsConverter.cs(30,…

### DIFF
--- a/src/Humanizer/Localisation/NumberToWords/GenderlessNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/GenderlessNumberToWordsConverter.cs
@@ -15,7 +15,7 @@
         /// <param name="number"></param>
         /// <param name="gender"></param>
         /// <returns></returns>
-        public string Convert(long number, GrammaticalGender gender)
+        public virtual string Convert(long number, GrammaticalGender gender)
         {
             return Convert(number);
         }

--- a/src/Humanizer/Localisation/NumberToWords/SwedishNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/SwedishNumberToWordsConverter.cs
@@ -27,7 +27,7 @@ namespace Humanizer.Localisation.NumberToWords
             new Fact {Value = 100,        Name = "hundra", Prefix = "",  Postfix = "",  DisplayOneUnit = false}
         };
 
-        public string Convert(long input, GrammaticalGender gender)
+        public override string Convert(long input, GrammaticalGender gender)
         {
             if (input > Int32.MaxValue || input < Int32.MinValue)
             {


### PR DESCRIPTION
…23,30,30): warning CS0108: 'SwedishNumberToWordsConverter.Convert(long, GrammaticalGender)' hides inherited member 'GenderlessNumberToWordsConverter.Convert(long, GrammaticalGender)'. Use the new keyword if hiding was intended.

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No ReSharper warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `dev` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
