### PR TITLE
fix: include weeks in Month and Year TimeSpan ranges

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -313,8 +313,8 @@ TimeSpan.FromMilliseconds(2000).Humanize(maxUnit: TimeUnit.Millisecond) => "2000
 ```
 The default maxUnit is `TimeUnit.Week` because it gives exact results. You can increase this value to `TimeUnit.Month` or `TimeUnit.Year` which will give you an approximation based on 365.2425 days a year and 30.436875 days a month. Therefore, the months are alternating between 30 and 31 days in length and every fourth year is 366 days long.
 ```csharp
-TimeSpan.FromDays(486).Humanize(maxUnit: TimeUnit.Year, precision: 7) => "1 year, 3 months, 29 days" // One day further is 1 year, 4 months
-TimeSpan.FromDays(517).Humanize(maxUnit: TimeUnit.Year, precision: 7) => "1 year, 4 months, 30 days" // This month has 30 days and one day further is 1 year, 5 months
+TimeSpan.FromDays(486).Humanize(maxUnit: TimeUnit.Year, precision: 7) => "1 year, 3 months, 4 weeks, 1 day" // One day further is 1 year, 4 months
+TimeSpan.FromDays(517).Humanize(maxUnit: TimeUnit.Year, precision: 7) => "1 year, 4 months, 4 weeks, 2 days" // This month has 30 days and one day further is 1 year, 5 months
 ```
 
 When there are multiple time units, they are combined using the `", "` string:

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -162,7 +162,7 @@ public static class TimeSpanHumanizeExtensions
             TimeUnit.Minute => GetNormalCaseTimeAsInteger(timespan.Minutes, timespan.TotalMinutes, isTimeUnitToGetTheMaximumTimeUnit),
             TimeUnit.Hour => GetNormalCaseTimeAsInteger(timespan.Hours, timespan.TotalHours, isTimeUnitToGetTheMaximumTimeUnit),
             TimeUnit.Day => GetSpecialCaseDaysAsInteger(timespan, maximumTimeUnit),
-            TimeUnit.Week => GetSpecialCaseWeeksAsInteger(timespan, isTimeUnitToGetTheMaximumTimeUnit),
+            TimeUnit.Week => GetSpecialCaseWeeksAsInteger(timespan, maximumTimeUnit),
             TimeUnit.Month => GetSpecialCaseMonthAsInteger(timespan, isTimeUnitToGetTheMaximumTimeUnit),
             TimeUnit.Year => GetSpecialCaseYearAsInteger(timespan),
             _ => 0
@@ -183,14 +183,14 @@ public static class TimeSpanHumanizeExtensions
     static int GetSpecialCaseYearAsInteger(TimeSpan timespan) =>
         (int)(timespan.Days / DaysInAYear);
 
-    static int GetSpecialCaseWeeksAsInteger(TimeSpan timespan, bool isTimeUnitToGetTheMaximumTimeUnit)
+    static int GetSpecialCaseWeeksAsInteger(TimeSpan timespan, TimeUnit maximumTimeUnit)
     {
-        if (isTimeUnitToGetTheMaximumTimeUnit || timespan.Days < DaysInAMonth)
+        if (maximumTimeUnit == TimeUnit.Week)
         {
             return timespan.Days / DaysInAWeek;
         }
 
-        return 0;
+        return (int)(timespan.Days % DaysInAMonth) / DaysInAWeek;
     }
 
     static int GetSpecialCaseDaysAsInteger(TimeSpan timespan, TimeUnit maximumTimeUnit)
@@ -200,13 +200,13 @@ public static class TimeSpanHumanizeExtensions
             return timespan.Days;
         }
 
-        if (timespan.Days < DaysInAMonth || maximumTimeUnit == TimeUnit.Week)
+        if (maximumTimeUnit == TimeUnit.Week)
         {
             var remainingDays = timespan.Days % DaysInAWeek;
             return remainingDays;
         }
 
-        return (int)(timespan.Days % DaysInAMonth);
+        return (int)(timespan.Days % DaysInAMonth) % DaysInAWeek;
     }
 
     static int GetNormalCaseTimeAsInteger(int timeNumberOfUnits, double totalTimeNumberOfUnits, bool isTimeUnitToGetTheMaximumTimeUnit)

--- a/tests/Humanizer.Tests/Localisation/ResourceBackedPhraseTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ResourceBackedPhraseTests.cs
@@ -127,7 +127,7 @@ public class ResourceBackedPhraseTests
         var culture = GetCulture(localeName);
         var query = from day in Enumerable.Range(0, 100000)
                     let timeSpan = TimeSpan.FromDays(day)
-                    let text = timeSpan.Humanize(precision: 3, culture: culture, maxUnit: TimeUnit.Year)
+                    let text = timeSpan.Humanize(precision: 4, culture: culture, maxUnit: TimeUnit.Year)
                     select text;
         var grouping = from text in query
                        group text by text into g

--- a/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
@@ -490,6 +490,21 @@ public class TimeSpanHumanizeTests
     }
 
     [Theory]
+    [InlineData(30, "4 weeks, 2 days")]
+    [InlineData(-30, "4 weeks, 2 days")]
+    [InlineData(31, "1 month")]
+    [InlineData(-31, "1 month")]
+    [InlineData(32, "1 month, 1 day")]
+    [InlineData(-32, "1 month, 1 day")]
+    [InlineData(60, "1 month, 4 weeks, 1 day")]
+    [InlineData(-60, "1 month, 4 weeks, 1 day")]
+    public void PositiveAndNegativeMonthsUseTheSameDecomposition(int days, string expected)
+    {
+        var actual = TimeSpan.FromDays(days).Humanize(precision: 3, maxUnit: TimeUnit.Month, minUnit: TimeUnit.Minute);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
     [InlineData(TimeUnit.Month, 109, 2, "3 months, 2 weeks")]
     [InlineData(TimeUnit.Year, 474, 3, "1 year, 3 months, 2 weeks")]
     public void CanRequestWeeksBelowMonthOrYear(TimeUnit maxUnit, int days, int precision, string expected)

--- a/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
@@ -7,7 +7,7 @@ public class TimeSpanHumanizeTests
         var culture = new CultureInfo("en-US");
         var qry = from i in Enumerable.Range(0, 100000)
                   let ts = TimeSpan.FromDays(i)
-                  let text = ts.Humanize(precision: 3, culture: culture, maxUnit: TimeUnit.Year)
+                  let text = ts.Humanize(precision: 4, culture: culture, maxUnit: TimeUnit.Year)
                   select text;
         var grouping = from t in qry
                        group t by t into g
@@ -17,15 +17,15 @@ public class TimeSpanHumanizeTests
     }
 
     [Theory]
-    [InlineData(365, "11 months, 30 days")]
+    [InlineData(365, "11 months, 4 weeks, 2 days")]
     [InlineData(365 + 1, "1 year")]
-    [InlineData(365 + 365, "1 year, 11 months, 29 days")]
+    [InlineData(365 + 365, "1 year, 11 months, 4 weeks, 1 day")]
     [InlineData(365 + 365 + 1, "2 years")]
-    [InlineData(365 + 365 + 365, "2 years, 11 months, 29 days")]
+    [InlineData(365 + 365 + 365, "2 years, 11 months, 4 weeks, 1 day")]
     [InlineData(365 + 365 + 365 + 1, "3 years")]
-    [InlineData(365 + 365 + 365 + 365, "3 years, 11 months, 29 days")]
+    [InlineData(365 + 365 + 365 + 365, "3 years, 11 months, 4 weeks, 1 day")]
     [InlineData(365 + 365 + 365 + 365 + 1, "4 years")]
-    [InlineData(365 + 365 + 365 + 365 + 366, "4 years, 11 months, 30 days")]
+    [InlineData(365 + 365 + 365 + 365 + 366, "4 years, 11 months, 4 weeks, 2 days")]
     [InlineData(365 + 365 + 365 + 365 + 366 + 1, "5 years")]
     public void Years(int days, string expected)
     {
@@ -36,15 +36,15 @@ public class TimeSpanHumanizeTests
     [Theory]
     [InlineData(30, "4 weeks, 2 days")]
     [InlineData(30 + 1, "1 month")]
-    [InlineData(30 + 30, "1 month, 29 days")]
+    [InlineData(30 + 30, "1 month, 4 weeks, 1 day")]
     [InlineData(30 + 30 + 1, "2 months")]
-    [InlineData(30 + 30 + 31, "2 months, 30 days")]
+    [InlineData(30 + 30 + 31, "2 months, 4 weeks, 2 days")]
     [InlineData(30 + 30 + 31 + 1, "3 months")]
-    [InlineData(30 + 30 + 31 + 30, "3 months, 29 days")]
+    [InlineData(30 + 30 + 31 + 30, "3 months, 4 weeks, 1 day")]
     [InlineData(30 + 30 + 31 + 30 + 1, "4 months")]
-    [InlineData(30 + 30 + 31 + 30 + 31, "4 months, 30 days")]
+    [InlineData(30 + 30 + 31 + 30 + 31, "4 months, 4 weeks, 2 days")]
     [InlineData(30 + 30 + 31 + 30 + 31 + 1, "5 months")]
-    [InlineData(365, "11 months, 30 days")]
+    [InlineData(365, "11 months, 4 weeks, 2 days")]
     [InlineData(366, "1 year")]
     public void Months(int days, string expected)
     {
@@ -459,8 +459,8 @@ public class TimeSpanHumanizeTests
 
     [Theory]
     [InlineData(31 * 4, 1, "en-US", "four months")]
-    [InlineData(236, 2, "ar", "سبعة أشهر, اثنان و عشرون يوم")]
-    [InlineData(321, 2, "es", "diez meses, dieciséis días")]
+    [InlineData(236, 2, "ar", "سبعة أشهر, ثلاثة أسابيع")]
+    [InlineData(321, 2, "es", "diez meses, dos semanas")]
     public void CanSpecifyCultureExplicitlyToWords(int days, int precision, string culture, string expected)
     {
         var timeSpan = new TimeSpan(days, 0, 0, 0);
@@ -476,5 +476,25 @@ public class TimeSpanHumanizeTests
     {
         Assert.Equal(expected, TimeSpan.MaxValue.Humanize(maxUnit: unit, minUnit: unit));
         Assert.Equal(expected, TimeSpan.MinValue.Humanize(maxUnit: unit, minUnit: unit));
+    }
+
+    [Theory]
+    [InlineData(109, TimeUnit.Month, "3 months, 2 weeks, 3 days, 4 hours")]
+    [InlineData(-109, TimeUnit.Month, "3 months, 2 weeks, 3 days, 4 hours")]
+    [InlineData(474, TimeUnit.Year, "1 year, 3 months, 2 weeks, 3 days, 4 hours")]
+    [InlineData(-474, TimeUnit.Year, "1 year, 3 months, 2 weeks, 3 days, 4 hours")]
+    public void MonthAndYearRangesIncludeWeeks(int days, TimeUnit maxUnit, string expected)
+    {
+        var actual = new TimeSpan(days, days < 0 ? -4 : 4, 0, 0).Humanize(5, maxUnit: maxUnit);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(TimeUnit.Month, 109, 2, "3 months, 2 weeks")]
+    [InlineData(TimeUnit.Year, 474, 3, "1 year, 3 months, 2 weeks")]
+    public void CanRequestWeeksBelowMonthOrYear(TimeUnit maxUnit, int days, int precision, string expected)
+    {
+        var actual = TimeSpan.FromDays(days).Humanize(precision, maxUnit: maxUnit, minUnit: TimeUnit.Week);
+        Assert.Equal(expected, actual);
     }
 }


### PR DESCRIPTION
## Summary

Month/Year `TimeSpan.Humanize` ranges now emit non-zero Week parts between larger and smaller requested units. An 86-day span can therefore produce `2 months, 3 weeks, 4 days`, and equivalent positive and negative spans share the same decomposition instead of overlapping total months with total weeks/days.

The refreshed implementation preserves Alex Knight's original contribution while correcting negative and long Month-range edge cases. Current locale parity supplies Week duration phrases for every shipped locale.

Fixes #862.
Fixes #1031.

## Validation

- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 57,051 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 57,051 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 57,051 passed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp>` — warning-free package created for all targets
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — 0 of 2,535 files changed

## Checklist

- [x] The implementation is clean and focused.
- [x] The code adheres to the project's coding standards.
- [x] The change introduces no code-analysis warnings.
- [x] Tests cover the functional change, including positive/negative symmetry.
- [x] No implementation code was copied from Stack Overflow; the linked report is provenance only.
- [x] The code remains self-documenting without unnecessary comments.
- [x] Public API is unchanged and existing XML documentation remains accurate.
- [x] The branch is rebased onto current `main`.
- [x] Related issues are linked above.
- [x] README examples reflect the changed Month/Year output.
- [x] The supported test targets, package build, and formatter verification pass.
