### PR TITLE
Fix #709

### DIFF
--- a/src/Humanizer.Tests.Shared/ToQuantityTests.cs
+++ b/src/Humanizer.Tests.Shared/ToQuantityTests.cs
@@ -19,6 +19,10 @@ namespace Humanizer.Tests
         [InlineData("process", 1, "1 process")]
         [InlineData("processes", 2, "2 processes")]
         [InlineData("processes", 1, "1 process")]
+        [InlineData("slice", 1, "1 slice")]
+        [InlineData("slice", 2, "2 slices")]
+        [InlineData("slices", 1, "1 slice")]
+        [InlineData("slices", 2, "2 slices")]
         public void ToQuantity(string word, int quantity, string expected)
         {
             Assert.Equal(expected, word.ToQuantity(quantity));

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 
 namespace Humanizer.Inflections
@@ -39,7 +39,7 @@ namespace Humanizer.Inflections
             _default.AddPlural("([^aeiouy]|qu)y$", "$1ies");
             _default.AddPlural("(x|ch|ss|sh)$", "$1es");
             _default.AddPlural("(matr|vert|ind|d)ix|ex$", "$1ices");
-            _default.AddPlural("([m|l])ouse$", "$1ice");
+            _default.AddPlural("(^[m|l])ouse$", "$1ice");
             _default.AddPlural("^(ox)$", "$1en");
             _default.AddPlural("(quiz)$", "$1zes");
             _default.AddPlural("(buz|blit|walt)z$", "$1zes");
@@ -59,7 +59,7 @@ namespace Humanizer.Inflections
             _default.AddSingular("(s)eries$", "$1eries");
             _default.AddSingular("(m)ovies$", "$1ovie");
             _default.AddSingular("(x|ch|ss|sh)es$", "$1");
-            _default.AddSingular("([m|l])ice$", "$1ouse");
+            _default.AddSingular("(^[m|l])ice$", "$1ouse");
             _default.AddSingular("(o)es$", "$1");
             _default.AddSingular("(shoe)s$", "$1");
             _default.AddSingular("(cris|ax|test)es$", "$1is");


### PR DESCRIPTION
Just changes *ice and *ouse to only match the one letter before we have listed. Not all. (Without the ^ it would match slice and slouse)