### PR TITLE
Fix #950  Timespan.Humanize( toWords: true) incorrect culture

### DIFF
--- a/src/Humanizer.Tests.Shared/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/TimeSpanHumanizeTests.cs
@@ -364,7 +364,7 @@ namespace Humanizer.Tests
         [InlineData(1299630020, 3, "2 weeks, 1 day, and 1 hour")]
         [InlineData(1299630020, 4, "2 weeks, 1 day, 1 hour, and 30 seconds")]
         [InlineData(1299630020, 5, "2 weeks, 1 day, 1 hour, 30 seconds, and 20 milliseconds")]
-        public void TimeSpanWithPrecisionAndAlternativeCollectionFormatter(int milliseconds, int precision, 
+        public void TimeSpanWithPrecisionAndAlternativeCollectionFormatter(int milliseconds, int precision,
             string expected, bool toWords = false)
         {
             var actual = TimeSpan.FromMilliseconds(milliseconds).Humanize(precision, collectionSeparator: null, toWords: toWords);
@@ -432,6 +432,16 @@ namespace Humanizer.Tests
         {
             var actual = TimeSpan.FromMilliseconds(ms).Humanize(precision: precision, culture: new CultureInfo(culture), collectionSeparator: collectionSeparator);
             Assert.Equal(expected, actual);
+        }
+        [Theory]
+        [InlineData(31 * 4, 1, "en-US", "four months")]
+        [InlineData(236,2,"ar", "سبعة أشهر, اثنان و عشرون يوم")]
+        [InlineData(321, 2,"es", "diez meses, dieciséis días")]
+        public void CanSpecifyCultureExplicitlyToWords(int days, int precision,string culture, string expected)
+        {
+            var timeSpan = new TimeSpan(days, 0, 0, 0);
+            var actual = timeSpan.Humanize(precision: precision, culture: new CultureInfo(culture), maxUnit: TimeUnit.Year, toWords: true);
+            Assert.Equal(expected: expected, actual);
         }
     }
 }

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -119,7 +119,7 @@ namespace Humanizer.Localisation.Formatters
             }
 
             return toWords
-                ? resourceString.FormatWith(number.ToWords())
+                ? resourceString.FormatWith(number.ToWords(_culture))
                 : resourceString.FormatWith(number);
         }
 

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -62,7 +62,7 @@ namespace Humanizer
 
             foreach (var timeUnitType in timeUnitsEnumTypes)
             {
-                var timepart = GetTimeUnitPart(timeUnitType, timespan, culture, maxUnit, minUnit, cultureFormatter, toWords);
+                var timepart = GetTimeUnitPart(timeUnitType,culture, timespan, maxUnit, minUnit, cultureFormatter, toWords); 
 
                 if (timepart != null || firstValueFound)
                 {
@@ -85,7 +85,7 @@ namespace Humanizer
             return enumTypeEnumerator.Reverse();
         }
 
-        private static string GetTimeUnitPart(TimeUnit timeUnitToGet, TimeSpan timespan, CultureInfo culture, TimeUnit maximumTimeUnit, TimeUnit minimumTimeUnit, IFormatter cultureFormatter, bool toWords = false)
+        private static string GetTimeUnitPart(TimeUnit timeUnitToGet,CultureInfo culture, TimeSpan timespan, TimeUnit maximumTimeUnit, TimeUnit minimumTimeUnit, IFormatter cultureFormatter, bool toWords = false)
         {
             if (timeUnitToGet <= maximumTimeUnit && timeUnitToGet >= minimumTimeUnit)
             {

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -62,7 +62,7 @@ namespace Humanizer
 
             foreach (var timeUnitType in timeUnitsEnumTypes)
             {
-                var timepart = GetTimeUnitPart(timeUnitType,culture, timespan, maxUnit, minUnit, cultureFormatter, toWords); 
+                var timepart = GetTimeUnitPart(timeUnitType,timespan, maxUnit, minUnit, cultureFormatter, toWords); 
 
                 if (timepart != null || firstValueFound)
                 {
@@ -85,7 +85,7 @@ namespace Humanizer
             return enumTypeEnumerator.Reverse();
         }
 
-        private static string GetTimeUnitPart(TimeUnit timeUnitToGet,CultureInfo culture, TimeSpan timespan, TimeUnit maximumTimeUnit, TimeUnit minimumTimeUnit, IFormatter cultureFormatter, bool toWords = false)
+        private static string GetTimeUnitPart(TimeUnit timeUnitToGet, TimeSpan timespan, TimeUnit maximumTimeUnit, TimeUnit minimumTimeUnit, IFormatter cultureFormatter, bool toWords = false)
         {
             if (timeUnitToGet <= maximumTimeUnit && timeUnitToGet >= minimumTimeUnit)
             {


### PR DESCRIPTION
Fixes #950 
 fixed an issue where  Timespan.Humanize( toWords: true) failed to convert the numbers to the specified culture.
Provided tests that test scenarios where the specified culture is Arabic/ar , Spanish/en & english-us.

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No ReSharper warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [ ] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `dev` branch (more info below)
 - [ ] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [ ] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
