### PR TITLE
Fix ByteSize not handling default formatting correctly

### DIFF
--- a/src/Humanizer.Tests.Shared/Bytes/ToStringTests.cs
+++ b/src/Humanizer.Tests.Shared/Bytes/ToStringTests.cs
@@ -21,7 +21,6 @@
 //THE SOFTWARE.
 
 using Humanizer.Bytes;
-
 using Xunit;
 
 namespace Humanizer.Tests.Bytes

--- a/src/Humanizer.Tests.Shared/Bytes/ToStringTests.cs
+++ b/src/Humanizer.Tests.Shared/Bytes/ToStringTests.cs
@@ -21,6 +21,7 @@
 //THE SOFTWARE.
 
 using Humanizer.Bytes;
+
 using Xunit;
 
 namespace Humanizer.Tests.Bytes
@@ -103,7 +104,7 @@ namespace Humanizer.Tests.Bytes
         [Fact]
         public void ReturnsBytesViaGeneralFormat()
         {
-            Assert.Equal("10 B", $"{10.Bytes()}");
+            Assert.Equal("10 B", $"{ByteSize.FromBytes(10)}");
         }
     }
 }

--- a/src/Humanizer.Tests.Shared/Bytes/ToStringTests.cs
+++ b/src/Humanizer.Tests.Shared/Bytes/ToStringTests.cs
@@ -99,5 +99,11 @@ namespace Humanizer.Tests.Bytes
         {
             Assert.Equal("-512 KB", ByteSize.FromMegabytes(-.5).ToString("#.#"));
         }
+
+        [Fact]
+        public void ReturnsBytesViaGeneralFormat()
+        {
+            Assert.Equal("10 B", $"{10.Bytes()}");
+        }
     }
 }

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -220,9 +220,7 @@ namespace Humanizer.Bytes
         public string ToString(IFormatProvider provider)
         {
             if (provider == null)
-            {
-                throw new ArgumentNullException(nameof(provider));
-            }
+                provider = CultureInfo.CurrentCulture;
 
             return string.Format("{0} {1}", LargestWholeNumberValue.ToString(provider), LargestWholeNumberSymbol);
         }
@@ -235,9 +233,13 @@ namespace Humanizer.Bytes
         public string ToString(string format, IFormatProvider provider)
         {
             if (format == null)
-                throw new ArgumentNullException(nameof(format));
+                format = "G";
+
             if (provider == null)
-                throw new ArgumentNullException(nameof(provider));
+                provider = CultureInfo.CurrentCulture;
+
+            if (format == "G")
+                format = "0.##";
 
             if (!format.Contains("#") && !format.Contains("0"))
             {


### PR DESCRIPTION
Fixes #953 

 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No ReSharper warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `dev` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures

Turns out that Humanizer was handling formatting wrong in two ways, unlike the issue mentions.

1. The .NET spec [requires the "G" format to be handled](https://docs.microsoft.com/en-us/dotnet/api/system.iformattable?view=netcore-3.1#notes-to-implementers). I'm not sure if what I've chosen is the correct default, please advise if not.
2. Similarly the class inadequately handled the `null` provider. The same MSDN article defaults to the current culture in its samples, which I'd say is a sane default.

The added test will test both of these scenarios, by providing `("G", null)` as args.