### PR TITLE
Fix TimeSpan-related humanization for French culture

### DIFF
--- a/src/Humanizer.Tests.Shared/Localisation/fr-BE/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/fr-BE/TimeSpanHumanizeTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Humanizer.Localisation;
+
 using Xunit;
 
 namespace Humanizer.Tests.Localisation.frBE
@@ -9,13 +11,13 @@ namespace Humanizer.Tests.Localisation.frBE
 
         [Theory]
         [Trait("Translation", "Google")]
-        [InlineData(366, "1 année")]
+        [InlineData(366, "1 an")]
         [InlineData(731, "2 ans")]
         [InlineData(1096, "3 ans")]
         [InlineData(4018, "11 ans")]
         public void Years(int days, string expected)
         {
-            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: TimeUnit.Year));
         }
 
         [Theory]
@@ -26,7 +28,7 @@ namespace Humanizer.Tests.Localisation.frBE
         [InlineData(335, "11 mois")]
         public void Months(int days, string expected)
         {
-            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: TimeUnit.Year));
         }
 
         [Theory]
@@ -83,12 +85,20 @@ namespace Humanizer.Tests.Localisation.frBE
             Assert.Equal(expected, actual);
         }
 
-        [Fact]
-        public void NoTime()
+        [Theory]
+        [InlineData(TimeUnit.Year, "0 an")]
+        [InlineData(TimeUnit.Month, "0 mois")]
+        [InlineData(TimeUnit.Week, "0 semaine")]
+        [InlineData(TimeUnit.Day, "0 jour")]
+        [InlineData(TimeUnit.Hour, "0 heure")]
+        [InlineData(TimeUnit.Minute, "0 minute")]
+        [InlineData(TimeUnit.Second, "0 seconde")]
+        [InlineData(TimeUnit.Millisecond, "0 milliseconde")]
+        public void NoTime(TimeUnit minUnit, string expected)
         {
             var noTime = TimeSpan.Zero;
-            var actual = noTime.Humanize();
-            Assert.Equal("0 millisecondes", actual);
+            var actual = noTime.Humanize(minUnit: minUnit);
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
@@ -96,7 +106,7 @@ namespace Humanizer.Tests.Localisation.frBE
         {
             var noTime = TimeSpan.Zero;
             var actual = noTime.Humanize(toWords: true);
-            Assert.Equal("pas de temps", actual);
+            Assert.Equal("temps nul", actual);
         }
     }
 }

--- a/src/Humanizer.Tests.Shared/Localisation/fr/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/fr/TimeSpanHumanizeTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Humanizer.Localisation;
+
 using Xunit;
 
 namespace Humanizer.Tests.Localisation.fr
@@ -7,15 +9,15 @@ namespace Humanizer.Tests.Localisation.fr
     public class TimeSpanHumanizeTests
     {
 
-        [InlineData(366, "1 année")]
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1 an")]
         [InlineData(731, "2 ans")]
         [InlineData(1096, "3 ans")]
         [InlineData(4018, "11 ans")]
-        [Theory]
-        [Trait("Translation", "Google")]
         public void Years(int days, string expected)
         {
-            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: TimeUnit.Year));
         }
 
         [Theory]
@@ -26,7 +28,7 @@ namespace Humanizer.Tests.Localisation.fr
         [InlineData(335, "11 mois")]
         public void Months(int days, string expected)
         {
-            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: TimeUnit.Year));
         }
 
         [Theory]
@@ -83,12 +85,20 @@ namespace Humanizer.Tests.Localisation.fr
             Assert.Equal(expected, actual);
         }
 
-        [Fact]
-        public void NoTime()
+        [Theory]
+        [InlineData(TimeUnit.Year, "0 an")]
+        [InlineData(TimeUnit.Month, "0 mois")]
+        [InlineData(TimeUnit.Week, "0 semaine")]
+        [InlineData(TimeUnit.Day, "0 jour")]
+        [InlineData(TimeUnit.Hour, "0 heure")]
+        [InlineData(TimeUnit.Minute, "0 minute")]
+        [InlineData(TimeUnit.Second, "0 seconde")]
+        [InlineData(TimeUnit.Millisecond, "0 milliseconde")]
+        public void NoTime(TimeUnit minUnit, string expected)
         {
             var noTime = TimeSpan.Zero;
-            var actual = noTime.Humanize();
-            Assert.Equal("0 millisecondes", actual);
+            var actual = noTime.Humanize(minUnit: minUnit);
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
@@ -96,7 +106,7 @@ namespace Humanizer.Tests.Localisation.fr
         {
             var noTime = TimeSpan.Zero;
             var actual = noTime.Humanize(toWords: true);
-            Assert.Equal("pas de temps", actual);
+            Assert.Equal("temps nul", actual);
         }
     }
 }

--- a/src/Humanizer/Localisation/Formatters/FrenchFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/FrenchFormatter.cs
@@ -16,6 +16,11 @@
                 return resourceKey + DualPostfix;
             }
 
+            if (number == 0 && resourceKey.StartsWith("TimeSpanHumanize_Multiple"))
+            {
+                return resourceKey + "_Singular";
+            }
+
             return resourceKey;
         }
     }

--- a/src/Humanizer/Properties/Resources.fr-BE.resx
+++ b/src/Humanizer/Properties/Resources.fr-BE.resx
@@ -229,7 +229,7 @@
     <value>1 semaine</value>
   </data>
   <data name="TimeSpanHumanize_Zero" xml:space="preserve">
-    <value>pas de temps</value>
+    <value>temps nul</value>
   </data>
   <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
     <value>{0} mois</value>
@@ -241,7 +241,7 @@
     <value>1 mois</value>
   </data>
   <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
-    <value>1 année</value>
+    <value>1 an</value>
   </data>
   <data name="DateHumanize_MultipleDaysAgo_Dual" xml:space="preserve">
     <value>avant-hier</value>

--- a/src/Humanizer/Properties/Resources.fr.resx
+++ b/src/Humanizer/Properties/Resources.fr.resx
@@ -229,7 +229,7 @@
     <value>1 semaine</value>
   </data>
   <data name="TimeSpanHumanize_Zero" xml:space="preserve">
-    <value>pas de temps</value>
+    <value>temps nul</value>
   </data>
   <data name="DateHumanize_Never" xml:space="preserve">
     <value>jamais</value>
@@ -244,12 +244,36 @@
     <value>1 mois</value>
   </data>
   <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
-    <value>1 année</value>
+    <value>1 an</value>
   </data>
   <data name="DateHumanize_MultipleDaysAgo_Dual" xml:space="preserve">
     <value>avant-hier</value>
   </data>
   <data name="DateHumanize_MultipleDaysFromNow_Dual" xml:space="preserve">
     <value>après-demain</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears_Singular" xml:space="preserve">
+    <value>{0} an</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths_Singular" xml:space="preserve">
+    <value>{0} mois</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleWeeks_Singular" xml:space="preserve">
+    <value>{0} semaine</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleDays_Singular" xml:space="preserve">
+    <value>{0} jour</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleHours_Singular" xml:space="preserve">
+    <value>{0} heure</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMinutes_Singular" xml:space="preserve">
+    <value>{0} minute</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleSeconds_Singular" xml:space="preserve">
+    <value>{0} seconde</value>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMilliseconds_Singular" xml:space="preserve">
+    <value>{0} milliseconde</value>
   </data>
 </root>


### PR DESCRIPTION
Fixes #973 
- Replace "année" with "an"
- Make sure 0 is followed by a singular time unit (not plural, as in English)
- Replace "pas de temps" by "temps nul", which arguably sounds more natural

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [ ] No ReSharper warnings
 - [x] There is proper unit test coverage
 - [ ] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [ ] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `dev` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [ ] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
