### PR TITLE
Number and overload

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -783,6 +783,14 @@ Also, culture to use can be specified explicitly. If it is not, current thread's
 1.ToWords(GrammaticalGender.Masculine, new CultureInfo("ru")) => "один"
 ```
 
+Another overload of the method allow you to pass a bool to remove the "And" that can be added before the last number:
+
+```C#
+3501.ToWords(false) => "three thousand five hundred one"
+102.ToWords(false) => "one hundred two" 
+``` 
+This method can be useful for writing checks for example.
+
 ### <a id="number-toordinalwords">Number to ordinal words</a>
 This is kind of mixing `ToWords` with `Ordinalize`. You can call `ToOrdinalWords` on a number to get an ordinal representation of the number in words! For example:
 

--- a/src/Humanizer.Tests.Shared/NumberToWordsTests.cs
+++ b/src/Humanizer.Tests.Shared/NumberToWordsTests.cs
@@ -40,6 +40,13 @@ namespace Humanizer.Tests
             Assert.Equal(expected, number.ToWords());
         }
 
+        [InlineData(3501L, "three thousand five hundred one", false)]
+        [Theory]
+        public void ToWordsWithoutAnd(int number, string expected, bool addAnd)
+        {
+            Assert.Equal(expected, number.ToWords(addAnd));
+        }
+
         [InlineData(1L, "one")]
         [InlineData(11L, "eleven")]
         [InlineData(111L, "one hundred and eleven")]

--- a/src/Humanizer/Localisation/NumberToWords/ArabicNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/ArabicNumberToWordsConverter.cs
@@ -16,7 +16,7 @@ namespace Humanizer.Localisation.NumberToWords
 
         private static readonly string[] FeminineOnesGroup = { "", "واحدة", "اثنتان", "ثلاث", "أربع", "خمس", "ست", "سبع", "ثمان", "تسع", "عشر", "إحدى عشرة", "اثنتا عشرة", "ثلاث عشرة", "أربع عشرة", "خمس عشرة", "ست عشرة", "سبع عشرة", "ثمان عشرة", "تسع عشرة" };
 
-        public override string Convert(long number, GrammaticalGender gender)
+        public override string Convert(long number, GrammaticalGender gender, bool addAnd = true)
         {
             if (number == 0)
             {

--- a/src/Humanizer/Localisation/NumberToWords/BrazilianPortugueseNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/BrazilianPortugueseNumberToWordsConverter.cs
@@ -13,7 +13,7 @@ namespace Humanizer.Localisation.NumberToWords
         private static readonly string[] PortugueseOrdinalTensMap = { "zero", "décimo", "vigésimo", "trigésimo", "quadragésimo", "quinquagésimo", "sexagésimo", "septuagésimo", "octogésimo", "nonagésimo" };
         private static readonly string[] PortugueseOrdinalHundredsMap = { "zero", "centésimo", "ducentésimo", "trecentésimo", "quadringentésimo", "quingentésimo", "sexcentésimo", "septingentésimo", "octingentésimo", "noningentésimo" };
 
-        public override string Convert(long input, GrammaticalGender gender)
+        public override string Convert(long input, GrammaticalGender gender, bool addAnd = true)
         {
             if (input > 999999999999 || input < -999999999999)
             {

--- a/src/Humanizer/Localisation/NumberToWords/BulgarianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/BulgarianNumberToWordsConverter.cs
@@ -39,12 +39,12 @@ namespace Humanizer.Localisation.NumberToWords
             "осемнадесет", "деветнадесет"
         };
 
-        public override string Convert(long input, GrammaticalGender gender)
+        public override string Convert(long input, GrammaticalGender gender, bool addAnd = true)
         {
             return Convert(input, gender, false);
         }
 
-        private string Convert(long input, GrammaticalGender gender, bool isOrdinal)
+        private string Convert(long input, GrammaticalGender gender, bool isOrdinal, bool addAnd = true)
         {
             if (input > int.MaxValue || input < int.MinValue)
             {

--- a/src/Humanizer/Localisation/NumberToWords/CzechNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/CzechNumberToWordsConverter.cs
@@ -26,7 +26,7 @@ namespace Humanizer.Localisation.NumberToWords
             _culture = culture;
         }
 
-        public override string Convert(long number, GrammaticalGender gender)
+        public override string Convert(long number, GrammaticalGender gender, bool addAnd = true)
         {
             if (number == 0)
             {

--- a/src/Humanizer/Localisation/NumberToWords/EnglishNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/EnglishNumberToWordsConverter.cs
@@ -25,12 +25,17 @@ namespace Humanizer.Localisation.NumberToWords
             return Convert(number, false);
         }
 
+        public override string Convert(long number, bool addAnd = true)
+        {
+            return Convert(number, false, addAnd);
+        }
+
         public override string ConvertToOrdinal(int number)
         {
             return Convert(number, true);
         }
 
-        private string Convert(long number, bool isOrdinal)
+        private string Convert(long number, bool isOrdinal, bool addAnd = true)
         {
             if (number == 0)
             {
@@ -88,7 +93,7 @@ namespace Humanizer.Localisation.NumberToWords
 
             if (number > 0)
             {
-                if (parts.Count != 0)
+                if (parts.Count != 0 && addAnd)
                 {
                     parts.Add("and");
                 }

--- a/src/Humanizer/Localisation/NumberToWords/FrenchNumberToWordsConverterBase.cs
+++ b/src/Humanizer/Localisation/NumberToWords/FrenchNumberToWordsConverterBase.cs
@@ -8,7 +8,7 @@ namespace Humanizer.Localisation.NumberToWords
         private static readonly string[] UnitsMap = { "zéro", "un", "deux", "trois", "quatre", "cinq", "six", "sept", "huit", "neuf", "dix", "onze", "douze", "treize", "quatorze", "quinze", "seize", "dix-sept", "dix-huit", "dix-neuf" };
         private static readonly string[] TensMap = { "zéro", "dix", "vingt", "trente", "quarante", "cinquante", "soixante", "septante", "octante", "nonante" };
 
-        public override string Convert(long input, GrammaticalGender gender)
+        public override string Convert(long input, GrammaticalGender gender, bool addAnd = true)
         {
             if (input > Int32.MaxValue || input < Int32.MinValue)
             {

--- a/src/Humanizer/Localisation/NumberToWords/GenderedNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/GenderedNumberToWordsConverter.cs
@@ -19,13 +19,19 @@
             return Convert(number, _defaultGender);
         }
 
+        public string Convert(long number, bool addAnd)
+        {
+            return Convert(number, _defaultGender);
+        }
+
         /// <summary>
         /// Converts the number to string using the provided grammatical gender
         /// </summary>
         /// <param name="number"></param>
         /// <param name="gender"></param>
         /// <returns></returns>
-        public abstract string Convert(long number, GrammaticalGender gender);
+        public abstract string Convert(long number, GrammaticalGender gender, bool addAnd = true);
+
 
         /// <summary>
         /// Converts the number to ordinal string using the locale's default grammatical gender

--- a/src/Humanizer/Localisation/NumberToWords/GenderlessNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/GenderlessNumberToWordsConverter.cs
@@ -9,16 +9,22 @@
         /// <returns></returns>
         public abstract string Convert(long number);
 
+        public virtual string Convert(long number, bool addAnd)
+        {
+            return Convert(number);
+        }
+
         /// <summary>
         /// Converts the number to string ignoring the provided grammatical gender
         /// </summary>
         /// <param name="number"></param>
         /// <param name="gender"></param>
         /// <returns></returns>
-        public virtual string Convert(long number, GrammaticalGender gender)
+        public virtual string Convert(long number, GrammaticalGender gender, bool addAnd = true)
         {
             return Convert(number);
         }
+
 
         /// <summary>
         /// Converts the number to ordinal string

--- a/src/Humanizer/Localisation/NumberToWords/GermanNumberToWordsConverterBase.cs
+++ b/src/Humanizer/Localisation/NumberToWords/GermanNumberToWordsConverterBase.cs
@@ -17,7 +17,7 @@ namespace Humanizer.Localisation.NumberToWords
         private readonly string[] BillionOrdinalSingular = { "einmilliard", "einemilliarde" };
         private readonly string[] BillionOrdinalPlural = { "{0}milliard", "{0}milliarden" };
 
-        public override string Convert(long number, GrammaticalGender gender)
+        public override string Convert(long number, GrammaticalGender gender, bool addAnd = true)
         {
             if (number == 0)
             {

--- a/src/Humanizer/Localisation/NumberToWords/HebrewNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/HebrewNumberToWordsConverter.cs
@@ -38,7 +38,7 @@ namespace Humanizer.Localisation.NumberToWords
             _culture = culture;
         }
 
-        public override string Convert(long input, GrammaticalGender gender)
+        public override string Convert(long input, GrammaticalGender gender, bool addAnd = true)
         {
             if (input > Int32.MaxValue || input < Int32.MinValue)
             {

--- a/src/Humanizer/Localisation/NumberToWords/INumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/INumberToWordsConverter.cs
@@ -13,12 +13,19 @@
         string Convert(long number);
 
         /// <summary>
+        /// Converts the number to string using the locale's default grammatical gender with or without adding 'And'
+        /// </summary>
+        /// <param name="number"></param>
+        /// <returns></returns>
+        string Convert(long number, bool addAnd);
+
+        /// <summary>
         /// Converts the number to string using the provided grammatical gender
         /// </summary>
         /// <param name="number"></param>
         /// <param name="gender"></param>
         /// <returns></returns>
-        string Convert(long number, GrammaticalGender gender);
+        string Convert(long number, GrammaticalGender gender, bool addAnd = true);
 
         /// <summary>
         /// Converts the number to ordinal string using the locale's default grammatical gender

--- a/src/Humanizer/Localisation/NumberToWords/ItalianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/ItalianNumberToWordsConverter.cs
@@ -5,7 +5,7 @@ namespace Humanizer.Localisation.NumberToWords
 {
     internal class ItalianNumberToWordsConverter : GenderedNumberToWordsConverter
     {
-        public override string Convert(long input, GrammaticalGender gender)
+        public override string Convert(long input, GrammaticalGender gender, bool addAnd = true)
         {
             if (input > Int32.MaxValue || input < Int32.MinValue)
             {

--- a/src/Humanizer/Localisation/NumberToWords/MalteseNumberToWordsConvertor.cs
+++ b/src/Humanizer/Localisation/NumberToWords/MalteseNumberToWordsConvertor.cs
@@ -34,7 +34,7 @@ namespace Humanizer.Localisation.NumberToWords
             "tmintax-il", "dsatax-il"
         };
 
-        public override string Convert(long input, GrammaticalGender gender)
+        public override string Convert(long input, GrammaticalGender gender, bool addAnd = true)
         {
             bool negativeNumber = false;
 

--- a/src/Humanizer/Localisation/NumberToWords/NorwegianBokmalNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/NorwegianBokmalNumberToWordsConverter.cs
@@ -21,7 +21,7 @@ namespace Humanizer.Localisation.NumberToWords
             {12, "tolvte"}
         };
 
-        public override string Convert(long number, GrammaticalGender gender)
+        public override string Convert(long number, GrammaticalGender gender, bool addAnd = true)
         {
             if (number > Int32.MaxValue || number < Int32.MinValue)
             {

--- a/src/Humanizer/Localisation/NumberToWords/PortugueseNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/PortugueseNumberToWordsConverter.cs
@@ -13,7 +13,7 @@ namespace Humanizer.Localisation.NumberToWords
         private static readonly string[] PortugueseOrdinalTensMap = { "zero", "décimo", "vigésimo", "trigésimo", "quadragésimo", "quinquagésimo", "sexagésimo", "septuagésimo", "octogésimo", "nonagésimo" };
         private static readonly string[] PortugueseOrdinalHundredsMap = { "zero", "centésimo", "ducentésimo", "trecentésimo", "quadringentésimo", "quingentésimo", "sexcentésimo", "septingentésimo", "octingentésimo", "noningentésimo" };
 
-        public override string Convert(long input, GrammaticalGender gender)
+        public override string Convert(long input, GrammaticalGender gender, bool addAnd = true)
         {
             if (input > 999999999999 || input < -999999999999)
             {

--- a/src/Humanizer/Localisation/NumberToWords/RomanianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/RomanianNumberToWordsConverter.cs
@@ -5,7 +5,7 @@ namespace Humanizer.Localisation.NumberToWords
 {
     internal class RomanianNumberToWordsConverter : GenderedNumberToWordsConverter
     {
-        public override string Convert(long number, GrammaticalGender gender)
+        public override string Convert(long number, GrammaticalGender gender, bool addAnd = true)
         {
             if (number > Int32.MaxValue || number < Int32.MinValue)
             {

--- a/src/Humanizer/Localisation/NumberToWords/RussianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/RussianNumberToWordsConverter.cs
@@ -14,7 +14,7 @@ namespace Humanizer.Localisation.NumberToWords
         private static readonly string[] TensOrdinal = { string.Empty, "десят", "двадцат", "тридцат", "сороков", "пятидесят", "шестидесят", "семидесят", "восьмидесят", "девяност" };
         private static readonly string[] UnitsOrdinal = { string.Empty, "перв", "втор", "трет", "четверт", "пят", "шест", "седьм", "восьм", "девят", "десят", "одиннадцат", "двенадцат", "тринадцат", "четырнадцат", "пятнадцат", "шестнадцат", "семнадцат", "восемнадцат", "девятнадцат" };
 
-        public override string Convert(long input, GrammaticalGender gender)
+        public override string Convert(long input, GrammaticalGender gender, bool addAnd = true)
         {
             if (input == 0)
             { 

--- a/src/Humanizer/Localisation/NumberToWords/SpanishNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/SpanishNumberToWordsConverter.cs
@@ -29,7 +29,7 @@ namespace Humanizer.Localisation.NumberToWords
             {9, "noveno"},
         };
 
-        public override string Convert(long input, GrammaticalGender gender)
+        public override string Convert(long input, GrammaticalGender gender, bool addAnd = true)
         {
             if (input > Int32.MaxValue || input < Int32.MinValue)
             {

--- a/src/Humanizer/Localisation/NumberToWords/SwedishNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/SwedishNumberToWordsConverter.cs
@@ -26,8 +26,8 @@ namespace Humanizer.Localisation.NumberToWords
             new Fact {Value = 1000,       Name = "tusen", Prefix = " ",  Postfix = " ", DisplayOneUnit = true},
             new Fact {Value = 100,        Name = "hundra", Prefix = "",  Postfix = "",  DisplayOneUnit = false}
         };
-
-        public override string Convert(long input, GrammaticalGender gender)
+         
+        public override string Convert(long input, GrammaticalGender gender, bool addAnd = true)
         {
             if (input > Int32.MaxValue || input < Int32.MinValue)
             {

--- a/src/Humanizer/Localisation/NumberToWords/UkrainianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/UkrainianNumberToWordsConverter.cs
@@ -14,7 +14,7 @@ namespace Humanizer.Localisation.NumberToWords
         private static readonly string[] TensOrdinal = { string.Empty, "десят", "двадцят", "тридцят", "сороков", "п'ятдесят", "шістдесят", "сімдесят", "вісімдесят", "дев'яност" };
         private static readonly string[] UnitsOrdinal = { "нульов", "перш", "друг", "трет", "четверт", "п'ят", "шост", "сьом", "восьм", "дев'ят", "десят", "одинадцят", "дванадцят", "тринадцят", "чотирнадцят", "п'ятнадцят", "шістнадцят", "сімнадцят", "вісімнадцят", "дев'ятнадцят" };
 
-        public override string Convert(long input, GrammaticalGender gender)
+        public override string Convert(long input, GrammaticalGender gender, bool addAnd = true)
         {
             if (input == 0)
             {

--- a/src/Humanizer/NumberToWordsExtension.cs
+++ b/src/Humanizer/NumberToWordsExtension.cs
@@ -19,6 +19,19 @@ namespace Humanizer
             return ((long)number).ToWords(culture);
         }
 
+
+        /// <summary>
+        /// 3501.ToWords(false) -> "three thousand five hundred one"
+        /// </summary>
+        /// <param name="number">Number to be turned to words</param>
+        /// <param name="addAnd">To add 'and' before the last number.</param>
+        /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+        /// <returns></returns>
+        public static string ToWords(this int number,bool addAnd, CultureInfo culture = null)
+        {
+            return ((long)number).ToWords(culture, addAnd);
+        }
+
         /// <summary>
         /// For locales that support gender-specific forms
         /// </summary>
@@ -50,9 +63,9 @@ namespace Humanizer
         /// <param name="number">Number to be turned to words</param>
         /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
         /// <returns></returns>
-        public static string ToWords(this long number, CultureInfo culture = null)
+        public static string ToWords(this long number, CultureInfo culture = null, bool addAnd = true)
         {
-            return Configurator.GetNumberToWordsConverter(culture).Convert(number);
+            return Configurator.GetNumberToWordsConverter(culture).Convert(number, addAnd);
         }
 
         /// <summary>


### PR DESCRIPTION
Adding an overload to extension NumberToWords to remove the "and" before last number. Fixes #919 
The overload has been added to the EnglishNumberToWordsConverter only for now, but can be added in different locales

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage
 - [ ] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `dev` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
