### PR TITLE
Add French support when using toWords: true in TimeSpan humanization

### DIFF
--- a/src/Humanizer.Tests.Shared/Localisation/fr/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/fr/TimeSpanHumanizeTests.cs
@@ -8,9 +8,7 @@ namespace Humanizer.Tests.Localisation.fr
     [UseCulture("fr")]
     public class TimeSpanHumanizeTests
     {
-
         [Theory]
-        [Trait("Translation", "Google")]
         [InlineData(366, "1 an")]
         [InlineData(731, "2 ans")]
         [InlineData(1096, "3 ans")]
@@ -21,7 +19,16 @@ namespace Humanizer.Tests.Localisation.fr
         }
 
         [Theory]
-        [Trait("Translation", "Google")]
+        [InlineData(366, "un an")]
+        [InlineData(731, "deux ans")]
+        [InlineData(1096, "trois ans")]
+        [InlineData(4018, "onze ans")]
+        public void YearsToWord(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: TimeUnit.Year, toWords: true));
+        }
+
+        [Theory]
         [InlineData(31, "1 mois")]
         [InlineData(61, "2 mois")]
         [InlineData(92, "3 mois")]
@@ -32,11 +39,30 @@ namespace Humanizer.Tests.Localisation.fr
         }
 
         [Theory]
+        [InlineData(31, "un mois")]
+        [InlineData(61, "deux mois")]
+        [InlineData(92, "trois mois")]
+        [InlineData(335, "onze mois")]
+        public void MonthsToWords(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: TimeUnit.Year, toWords: true));
+        }
+
+        [Theory]
         [InlineData(14, "2 semaines")]
         [InlineData(7, "1 semaine")]
         public void Weeks(int days, string expected)
         {
             var actual = TimeSpan.FromDays(days).Humanize();
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(14, "deux semaines")]
+        [InlineData(7, "une semaine")]
+        public void WeeksToWords(int days, string expected)
+        {
+            var actual = TimeSpan.FromDays(days).Humanize(toWords: true);
             Assert.Equal(expected, actual);
         }
 
@@ -50,11 +76,29 @@ namespace Humanizer.Tests.Localisation.fr
         }
 
         [Theory]
+        [InlineData(6, "six jours")]
+        [InlineData(1, "un jour")]
+        public void DaysToWords(int days, string expected)
+        {
+            var actual = TimeSpan.FromDays(days).Humanize(toWords: true);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
         [InlineData(2, "2 heures")]
         [InlineData(1, "1 heure")]
         public void Hours(int hours, string expected)
         {
             var actual = TimeSpan.FromHours(hours).Humanize();
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(2, "deux heures")]
+        [InlineData(1, "une heure")]
+        public void HoursToWords(int hours, string expected)
+        {
+            var actual = TimeSpan.FromHours(hours).Humanize(toWords: true);
             Assert.Equal(expected, actual);
         }
 
@@ -68,6 +112,15 @@ namespace Humanizer.Tests.Localisation.fr
         }
 
         [Theory]
+        [InlineData(2, "deux minutes")]
+        [InlineData(1, "une minute")]
+        public void MinutesToWords(int minutes, string expected)
+        {
+            var actual = TimeSpan.FromMinutes(minutes).Humanize(toWords: true);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
         [InlineData(2, "2 secondes")]
         [InlineData(1, "1 seconde")]
         public void Seconds(int seconds, string expected)
@@ -77,11 +130,29 @@ namespace Humanizer.Tests.Localisation.fr
         }
 
         [Theory]
+        [InlineData(2, "deux secondes")]
+        [InlineData(1, "une seconde")]
+        public void SecondsToWords(int seconds, string expected)
+        {
+            var actual = TimeSpan.FromSeconds(seconds).Humanize(toWords: true);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
         [InlineData(2, "2 millisecondes")]
         [InlineData(1, "1 milliseconde")]
         public void Milliseconds(int ms, string expected)
         {
             var actual = TimeSpan.FromMilliseconds(ms).Humanize();
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(2, "deux millisecondes")]
+        [InlineData(1, "une milliseconde")]
+        public void MillisecondsToWords(int ms, string expected)
+        {
+            var actual = TimeSpan.FromMilliseconds(ms).Humanize(toWords: true);
             Assert.Equal(expected, actual);
         }
 

--- a/src/Humanizer/Properties/Resources.fr.resx
+++ b/src/Humanizer/Properties/Resources.fr.resx
@@ -276,4 +276,28 @@
   <data name="TimeSpanHumanize_MultipleMilliseconds_Singular" xml:space="preserve">
     <value>{0} milliseconde</value>
   </data>
+  <data name="TimeSpanHumanize_SingleDay_Words" xml:space="preserve">
+    <value>un jour</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleHour_Words" xml:space="preserve">
+    <value>une heure</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMillisecond_Words" xml:space="preserve">
+    <value>une milliseconde</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMinute_Words" xml:space="preserve">
+    <value>une minute</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth_Words" xml:space="preserve">
+    <value>un mois</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleSecond_Words" xml:space="preserve">
+    <value>une seconde</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleWeek_Words" xml:space="preserve">
+    <value>une semaine</value>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear_Words" xml:space="preserve">
+    <value>un an</value>
+  </data>
 </root>


### PR DESCRIPTION
Also removed [Trait("Translation", "Google")] from TimeSpanHumanizeTests after  review. (I assumed that the trait means that the translation were automatically generated by Google vs manually written by a human)