### PR TITLE
Adjust `IndexOf` Usage

### DIFF
--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -248,7 +248,9 @@ namespace Humanizer.Bytes
 
             format = format.Replace("#.##", "0.##");
 
-            bool has(string s) => format.IndexOf(s, StringComparison.CurrentCultureIgnoreCase) != -1;
+            var culture = provider as CultureInfo ?? CultureInfo.CurrentCulture;
+
+            bool has(string s) => culture.CompareInfo.IndexOf(format, s, CompareOptions.IgnoreCase) != -1;
             string output(double n) => n.ToString(format, provider);
 
             if (has(TerabyteSymbol))

--- a/src/Humanizer/Localisation/NumberToWords/AfrikaansNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/AfrikaansNumberToWordsConverter.cs
@@ -149,7 +149,7 @@ namespace Humanizer.Localisation.NumberToWords
         private static string RemoveOnePrefix(string toWords)
         {
             // one hundred => hundredth
-            if (toWords.IndexOf("een", StringComparison.Ordinal) == 0)
+            if (toWords.StartsWith("een", StringComparison.Ordinal))
             {
                 if (toWords.IndexOf("een en", StringComparison.Ordinal) != 0)
                 {

--- a/src/Humanizer/Localisation/NumberToWords/ArmenianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/ArmenianNumberToWordsConverter.cs
@@ -167,7 +167,7 @@ namespace Humanizer.Localisation.NumberToWords
         private static string RemoveOnePrefix(string toWords)
         {
             // one hundred => hundredth
-            if (toWords.IndexOf("մեկ", StringComparison.Ordinal) == 0)
+            if (toWords.StartsWith("մեկ", StringComparison.Ordinal))
             {
                 toWords = toWords.Remove(0, 4);
             }

--- a/src/Humanizer/Localisation/NumberToWords/EnglishNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/EnglishNumberToWordsConverter.cs
@@ -154,7 +154,7 @@ namespace Humanizer.Localisation.NumberToWords
         private static string RemoveOnePrefix(string toWords)
         {
             // one hundred => hundredth
-            if (toWords.IndexOf("one", StringComparison.Ordinal) == 0)
+            if (toWords.StartsWith("one", StringComparison.Ordinal))
             {
                 toWords = toWords.Remove(0, 4);
             }

--- a/src/Humanizer/Localisation/NumberToWords/TamilNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/TamilNumberToWordsConverter.cs
@@ -269,7 +269,7 @@ namespace Humanizer.Localisation.NumberToWords
         private static string RemoveOnePrefix(string toWords)
         {
             // one hundred => hundredth
-            if (toWords.IndexOf("one", StringComparison.Ordinal) == 0)
+            if (toWords.StartsWith("one", StringComparison.Ordinal))
                 toWords = toWords.Remove(0, 4);
 
             return toWords;


### PR DESCRIPTION
Nerd-sniped myself this morning:

1. Noticed a use of `CurrentCultureIgnoreCase` in the presence of an `IFormatProvider`. Since most `IFormatProviders` are `CultureInfo`, we can use their `CompareInfo`.
2. Noticed a few uses of `str.IndexOf(...) == 0` which can be more efficiently written as `str.StartsWith(...)`.

### Checklist

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No Code Analysis warnings
 - [ ] There is proper unit test coverage
    - Not sure if it's worth writing a unit test for the `CurrentCultureIgnoreCase` change? Existing tests pass.
 - [ ] ~~If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution~~
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [ ] ~~Xml documentation is added/updated for the addition/change~~
 - [x] Your PR is (re)based on top of the latest commits from the `dev` branch (more info below)
 - [ ] ~~Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`~~
 - [ ] ~~Readme is updated if you change an existing feature or add a new one~~
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
