### PR TITLE
Parse `ByteSize` with `IFormatProvider`

### DIFF
--- a/src/Humanizer.Tests.Shared/Bytes/ParsingTests.cs
+++ b/src/Humanizer.Tests.Shared/Bytes/ParsingTests.cs
@@ -56,10 +56,13 @@ namespace Humanizer.Tests.Bytes
         [Theory]
         [InlineData("2000.01KB", "")] // Invariant
         [InlineData("2,000.01KB", "")]
+        [InlineData("+2000.01KB", "")]
         [InlineData("2000.01KB", "en")]
         [InlineData("2,000.01KB", "en")]
+        [InlineData("+2000.01KB", "en")]
         [InlineData("2000,01KB", "de")]
         [InlineData("2.000,01KB", "de")]
+        [InlineData("+2000,01KB", "de")]
         public void TryParseWithCultureInfo(string value, string cultureName)
         {
             var culture = new CultureInfo(cultureName);
@@ -77,12 +80,13 @@ namespace Humanizer.Tests.Bytes
             {
                 NumberDecimalSeparator = "_",
                 NumberGroupSeparator = ";",
+                NegativeSign = "−", // proper minus, not hyphen-minus
             };
 
-            var value = "2;000_01KB";
+            var value = "−2;000_01KB";
 
             Assert.True(ByteSize.TryParse(value, numberFormat, out var resultByteSize));
-            Assert.Equal(ByteSize.FromKilobytes(2000.01), resultByteSize);
+            Assert.Equal(ByteSize.FromKilobytes(-2000.01), resultByteSize);
 
             Assert.Equal(resultByteSize, ByteSize.Parse(value, numberFormat));
         }

--- a/src/Humanizer.Tests.Shared/Bytes/ParsingTests.cs
+++ b/src/Humanizer.Tests.Shared/Bytes/ParsingTests.cs
@@ -38,6 +38,12 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Fact]
+        public void TryParseThrowsOnNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => { ByteSize.TryParse(null, out var result); });
+        }
+
+        [Fact]
         public void TryParse()
         {
             var resultBool = ByteSize.TryParse("1020KB", out var resultByteSize);
@@ -89,31 +95,24 @@ namespace Humanizer.Tests.Bytes
         [Theory]
         [InlineData("Unexpected Value")]
         [InlineData("1000")]
+        [InlineData(" 1000 ")]
         [InlineData("KB")]
+        [InlineData("1000.5b")] // Partial bits
+        [InlineData("1000KBB")] // Bad suffix
         public void TryParseReturnsFalseOnBadValue(string input)
         {
             var resultBool = ByteSize.TryParse(input, out var resultByteSize);
 
             Assert.False(resultBool);
             Assert.Equal(new ByteSize(), resultByteSize);
+
+            Assert.Throws<FormatException>(() => { ByteSize.Parse(input); });
         }
 
         [Fact]
         public void TryParseWorksWithLotsOfSpaces()
         {
             Assert.Equal(ByteSize.FromKilobytes(100), ByteSize.Parse(" 100 KB "));
-        }
-
-        [Fact]
-        public void ParseThrowsOnPartialBits()
-        {
-            Assert.Throws<FormatException>(() => { ByteSize.Parse("10.5b"); });
-        }
-
-        [Fact]
-        public void ParseThrowsOnInvalid()
-        {
-            Assert.Throws<FormatException>(() => { ByteSize.Parse("Unexpected Value"); });
         }
 
         [Fact]

--- a/src/Humanizer.Tests.Shared/Bytes/ParsingTests.cs
+++ b/src/Humanizer.Tests.Shared/Bytes/ParsingTests.cs
@@ -21,6 +21,7 @@
 //THE SOFTWARE.
 
 using System;
+using System.Globalization;
 using Humanizer.Bytes;
 using Xunit;
 
@@ -43,6 +44,36 @@ namespace Humanizer.Tests.Bytes
 
             Assert.True(resultBool);
             Assert.Equal(ByteSize.FromKilobytes(1020), resultByteSize);
+        }
+
+        [Theory]
+        [InlineData("2000.01KB", "")] // Invariant
+        [InlineData("2000.01KB", "en")]
+        [InlineData("2000,01KB", "de")]
+        public void TryParseWithCultureInfo(string value, string cultureName)
+        {
+            var culture = new CultureInfo(cultureName);
+
+            Assert.True(ByteSize.TryParse(value, culture, out var resultByteSize));
+            Assert.Equal(ByteSize.FromKilobytes(2000.01), resultByteSize);
+
+            Assert.Equal(resultByteSize, ByteSize.Parse(value, culture));
+        }
+
+        [Fact]
+        public void TryParseWithNumberFormatInfo()
+        {
+            var numberFormat = new NumberFormatInfo
+            {
+                NumberDecimalSeparator = "_",
+            };
+
+            var value = "2000_01KB";
+
+            Assert.True(ByteSize.TryParse(value, numberFormat, out var resultByteSize));
+            Assert.Equal(ByteSize.FromKilobytes(2000.01), resultByteSize);
+
+            Assert.Equal(resultByteSize, ByteSize.Parse(value, numberFormat));
         }
 
         [Fact]

--- a/src/Humanizer.Tests.Shared/Bytes/ParsingTests.cs
+++ b/src/Humanizer.Tests.Shared/Bytes/ParsingTests.cs
@@ -38,9 +38,10 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Fact]
-        public void TryParseThrowsOnNull()
+        public void TryParseReturnsFalseOnNull()
         {
-            Assert.Throws<ArgumentNullException>(() => { ByteSize.TryParse(null, out var result); });
+            Assert.False(ByteSize.TryParse(null, out var result));
+            Assert.Equal(default, result);
         }
 
         [Fact]
@@ -93,6 +94,9 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("\t")]
         [InlineData("Unexpected Value")]
         [InlineData("1000")]
         [InlineData(" 1000 ")]

--- a/src/Humanizer.Tests.Shared/Bytes/ParsingTests.cs
+++ b/src/Humanizer.Tests.Shared/Bytes/ParsingTests.cs
@@ -48,8 +48,11 @@ namespace Humanizer.Tests.Bytes
 
         [Theory]
         [InlineData("2000.01KB", "")] // Invariant
+        [InlineData("2,000.01KB", "")]
         [InlineData("2000.01KB", "en")]
+        [InlineData("2,000.01KB", "en")]
         [InlineData("2000,01KB", "de")]
+        [InlineData("2.000,01KB", "de")]
         public void TryParseWithCultureInfo(string value, string cultureName)
         {
             var culture = new CultureInfo(cultureName);
@@ -66,9 +69,10 @@ namespace Humanizer.Tests.Bytes
             var numberFormat = new NumberFormatInfo
             {
                 NumberDecimalSeparator = "_",
+                NumberGroupSeparator = ";",
             };
 
-            var value = "2000_01KB";
+            var value = "2;000_01KB";
 
             Assert.True(ByteSize.TryParse(value, numberFormat, out var resultByteSize));
             Assert.Equal(ByteSize.FromKilobytes(2000.01), resultByteSize);

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -478,7 +478,8 @@ namespace Humanizer.Bytes
             // Arg checking
             if (string.IsNullOrWhiteSpace(s))
             {
-                throw new ArgumentNullException(nameof(s), "String is null or whitespace");
+                result = default;
+                return false;
             }
 
             // Acquiring culture-specific parsing info
@@ -586,6 +587,11 @@ namespace Humanizer.Bytes
 
         public static ByteSize Parse(string s, IFormatProvider formatProvider)
         {
+            if (s == null)
+            {
+                throw new ArgumentNullException(nameof(s));
+            }
+
             if (TryParse(s, formatProvider, out var result))
             {
                 return result;

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -22,8 +22,11 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 using Humanizer.Configuration;
 using Humanizer.Localisation;
+
+using static System.Globalization.NumberStyles;
 
 namespace Humanizer.Bytes
 {
@@ -467,11 +470,25 @@ namespace Humanizer.Bytes
 
         public static bool TryParse(string s, out ByteSize result)
         {
+            return TryParse(s, null, out result);
+        }
+
+        public static bool TryParse(string s, IFormatProvider formatProvider, out ByteSize result)
+        {
             // Arg checking
             if (string.IsNullOrWhiteSpace(s))
             {
                 throw new ArgumentNullException(nameof(s), "String is null or whitespace");
             }
+
+            // Acquiring culture-specific parsing info
+            var numberFormat = GetNumberFormatInfo(formatProvider);
+
+            const NumberStyles numberStyles = AllowDecimalPoint;
+            var numberSpecialChars = new[]
+            {
+                 Convert.ToChar(numberFormat.NumberDecimalSeparator),
+            };
 
             // Setup the result
             result = new ByteSize();
@@ -482,14 +499,10 @@ namespace Humanizer.Bytes
             int num;
             var found = false;
 
-            // Acquiring culture specific decimal separator
-
-            var decSep = Convert.ToChar(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
-
             // Pick first non-digit number
             for (num = 0; num < s.Length; num++)
             {
-                if (!(char.IsDigit(s[num]) || s[num] == decSep))
+                if (!(char.IsDigit(s[num]) || numberSpecialChars.Contains(s[num])))
                 {
                     found = true;
                     break;
@@ -508,7 +521,7 @@ namespace Humanizer.Bytes
             var sizePart = s.Substring(lastNumber, s.Length - lastNumber).Trim();
 
             // Get the numeric part
-            if (!double.TryParse(numberPart, out var number))
+            if (!double.TryParse(numberPart, numberStyles, formatProvider, out var number))
             {
                 return false;
             }
@@ -552,9 +565,24 @@ namespace Humanizer.Bytes
             return true;
         }
 
+        private static NumberFormatInfo GetNumberFormatInfo(IFormatProvider formatProvider)
+        {
+            if (formatProvider is NumberFormatInfo numberFormat)
+                return numberFormat;
+
+            var culture = formatProvider as CultureInfo ?? CultureInfo.CurrentCulture;
+
+            return culture.NumberFormat;
+        }
+
         public static ByteSize Parse(string s)
         {
-            if (TryParse(s, out var result))
+            return Parse(s, null);
+        }
+
+        public static ByteSize Parse(string s, IFormatProvider formatProvider)
+        {
+            if (TryParse(s, formatProvider, out var result))
             {
                 return result;
             }

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -485,11 +485,13 @@ namespace Humanizer.Bytes
             // Acquiring culture-specific parsing info
             var numberFormat = GetNumberFormatInfo(formatProvider);
 
-            const NumberStyles numberStyles = AllowDecimalPoint | AllowThousands;
+            const NumberStyles numberStyles = AllowDecimalPoint | AllowThousands | AllowLeadingSign;
             var numberSpecialChars = new[]
             {
                  Convert.ToChar(numberFormat.NumberDecimalSeparator),
                  Convert.ToChar(numberFormat.NumberGroupSeparator),
+                 Convert.ToChar(numberFormat.PositiveSign),
+                 Convert.ToChar(numberFormat.NegativeSign),
             };
 
             // Setup the result

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -484,10 +484,11 @@ namespace Humanizer.Bytes
             // Acquiring culture-specific parsing info
             var numberFormat = GetNumberFormatInfo(formatProvider);
 
-            const NumberStyles numberStyles = AllowDecimalPoint;
+            const NumberStyles numberStyles = AllowDecimalPoint | AllowThousands;
             var numberSpecialChars = new[]
             {
                  Convert.ToChar(numberFormat.NumberDecimalSeparator),
+                 Convert.ToChar(numberFormat.NumberGroupSeparator),
             };
 
             // Setup the result

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -561,6 +561,9 @@ namespace Humanizer.Bytes
                 case TerabyteSymbol:
                     result = FromTerabytes(number);
                     break;
+
+                default:
+                    return false;
             }
 
             return true;


### PR DESCRIPTION
Closes #1061 

1. Added new overloads for `Parse` and `TryParse`, called with `formatProvider: null` from the existing methods.
2. Using `formatProvider` with `double.TryParse` requires specifying `NumberStyles`, which is more correct anyway (`AllowDecimalPoint`) since there's no handling for negative, currency/exponents don't make sense, etc.
3. Added handling for `DecimalGroupSeparator`, too (e.g. `2,000KB`).
4. Adjusted tests to prove/fix incorrect handling for a missing/unrecognized suffix (e.g.`1000 ` or `1000KBB`).
5. Added missing test for `TryParse(null, ...)`
    - The new test codifies existing behavior; however, it occurs to me that the framework's `TryParse()` methods would just `return false` instead of throwing. Fixing that would be a breaking change, and would motivate additional changes to `Parse()`: given `null`, `throw new ArgumentNullException()`; given empty/whitespace, `throw new FormatException()`. Glad to make adjusments, if you wish.

### Checklist

Here is a checklist you should tick through before submitting a pull request: 
 - [ ] Implementation is clean
    - Subjective!
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage
 - [ ] ~~If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution~~
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [ ] Xml documentation is added/updated for the addition/change
    - Unsure what's necessary for additive change to public API. Existing `Parse`/`TryParse` do not have XML docs.
 - [x] Your PR is (re)based on top of the latest commits from the `dev` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [ ] ~~Readme is updated if you change an existing feature or add a new one~~
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
