### PR TITLE
Transform with Culture via `ICulturedStringTransformer`

### DIFF
--- a/src/Humanizer/Transformer/ICulturedStringTransformer.cs
+++ b/src/Humanizer/Transformer/ICulturedStringTransformer.cs
@@ -1,0 +1,18 @@
+﻿using System.Globalization;
+
+namespace Humanizer
+{
+    /// <summary>
+    /// Can transform a string with the given culture
+    /// </summary>
+    public interface ICulturedStringTransformer : IStringTransformer
+    {
+        /// <summary>
+        /// Transform the input
+        /// </summary>
+        /// <param name="input">String to be transformed</param>
+        /// <param name="culture">The culture</param>
+        /// <returns></returns>
+        string Transform(string input, CultureInfo culture);
+    }
+}

--- a/src/Humanizer/Transformer/IStringTransformer.cs
+++ b/src/Humanizer/Transformer/IStringTransformer.cs
@@ -1,7 +1,7 @@
 namespace Humanizer
 {
     /// <summary>
-    /// Can tranform a string
+    /// Can transform a string
     /// </summary>
     public interface IStringTransformer
     {

--- a/src/Humanizer/Transformer/To.cs
+++ b/src/Humanizer/Transformer/To.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Globalization;
+using System.Linq;
 
 namespace Humanizer
 {
@@ -19,12 +20,24 @@ namespace Humanizer
         }
 
         /// <summary>
+        /// Transforms a string using the provided transformers. Transformations are applied in the provided order.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="culture"></param>
+        /// <param name="transformers"></param>
+        /// <returns></returns>
+        public static string Transform(this string input, CultureInfo culture, params ICulturedStringTransformer[] transformers)
+        {
+            return transformers.Aggregate(input, (current, stringTransformer) => stringTransformer.Transform(current, culture));
+        }
+
+        /// <summary>
         /// Changes string to title case
         /// </summary>
         /// <example>
         /// "INvalid caSEs arE corrected" -> "Invalid Cases Are Corrected"
         /// </example>
-        public static IStringTransformer TitleCase
+        public static ICulturedStringTransformer TitleCase
         {
             get
             {
@@ -38,7 +51,7 @@ namespace Humanizer
         /// <example>
         /// "Sentence casing" -> "sentence casing"
         /// </example>
-        public static IStringTransformer LowerCase
+        public static ICulturedStringTransformer LowerCase
         {
             get
             {
@@ -52,7 +65,7 @@ namespace Humanizer
         /// <example>
         /// "lower case statement" -> "LOWER CASE STATEMENT"
         /// </example>
-        public static IStringTransformer UpperCase
+        public static ICulturedStringTransformer UpperCase
         {
             get
             {
@@ -66,7 +79,7 @@ namespace Humanizer
         /// <example>
         /// "lower case statement" -> "Lower case statement"
         /// </example>
-        public static IStringTransformer SentenceCase
+        public static ICulturedStringTransformer SentenceCase
         {
             get
             {

--- a/src/Humanizer/Transformer/ToLowerCase.cs
+++ b/src/Humanizer/Transformer/ToLowerCase.cs
@@ -2,11 +2,18 @@ using System.Globalization;
 
 namespace Humanizer
 {
-    internal class ToLowerCase : IStringTransformer
+    internal class ToLowerCase : ICulturedStringTransformer
     {
         public string Transform(string input)
         {
-            return CultureInfo.CurrentCulture.TextInfo.ToLower(input);
+            return Transform(input, null);
+        }
+
+        public string Transform(string input, CultureInfo culture)
+        {
+            culture ??= CultureInfo.CurrentCulture;
+
+            return culture.TextInfo.ToLower(input);
         }
     }
 }

--- a/src/Humanizer/Transformer/ToSentenceCase.cs
+++ b/src/Humanizer/Transformer/ToSentenceCase.cs
@@ -1,15 +1,24 @@
+﻿using System.Globalization;
+
 namespace Humanizer
 {
-    internal class ToSentenceCase : IStringTransformer
+    internal class ToSentenceCase : ICulturedStringTransformer
     {
         public string Transform(string input)
         {
+            return Transform(input, null);
+        }
+
+        public string Transform(string input, CultureInfo culture)
+        {
+            culture ??= CultureInfo.CurrentCulture;
+
             if (input.Length >= 1)
             {
-                return string.Concat(input.Substring(0, 1).ToUpper(), input.Substring(1));
+                return culture.TextInfo.ToUpper(input[0]) + input.Substring(1);
             }
 
-            return input.ToUpper();
+            return culture.TextInfo.ToUpper(input);
         }
     }
 }

--- a/src/Humanizer/Transformer/ToTitleCase.cs
+++ b/src/Humanizer/Transformer/ToTitleCase.cs
@@ -1,19 +1,27 @@
-﻿using System.Linq;
+﻿using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Humanizer
 {
-    internal class ToTitleCase : IStringTransformer
+    internal class ToTitleCase : ICulturedStringTransformer
     {
         public string Transform(string input)
         {
+            return Transform(input, null);
+        }
+
+        public string Transform(string input, CultureInfo culture)
+        {
+            culture ??= CultureInfo.CurrentCulture;
+
             var result = input;
             var matches = Regex.Matches(input, @"(\w|[^\u0000-\u007F])+'?\w*");
             foreach (Match word in matches)
             {
                 if (!AllCapitals(word.Value))
                 {
-                    result = ReplaceWithTitleCase(word, result);
+                    result = ReplaceWithTitleCase(word, result, culture);
                 }
             }
 
@@ -25,10 +33,10 @@ namespace Humanizer
             return input.ToCharArray().All(char.IsUpper);
         }
 
-        private static string ReplaceWithTitleCase(Match word, string source)
+        private static string ReplaceWithTitleCase(Match word, string source, CultureInfo culture)
         {
             var wordToConvert = word.Value;
-            var replacement = char.ToUpper(wordToConvert[0]) + wordToConvert.Remove(0, 1).ToLower();
+            var replacement = culture.TextInfo.ToUpper(wordToConvert[0]) + culture.TextInfo.ToLower(wordToConvert.Remove(0, 1));
             return source.Substring(0, word.Index) + replacement + source.Substring(word.Index + word.Length);
         }
     }

--- a/src/Humanizer/Transformer/ToUpperCase.cs
+++ b/src/Humanizer/Transformer/ToUpperCase.cs
@@ -1,10 +1,19 @@
+﻿using System.Globalization;
+
 namespace Humanizer
 {
-    internal class ToUpperCase : IStringTransformer
+    internal class ToUpperCase : ICulturedStringTransformer
     {
         public string Transform(string input)
         {
-            return input.ToUpper();
+            return Transform(input, null);
+        }
+
+        public string Transform(string input, CultureInfo culture)
+        {
+            culture ??= CultureInfo.CurrentCulture;
+
+            return culture.TextInfo.ToUpper(input);
         }
     }
 }


### PR DESCRIPTION
As proposed in https://github.com/Humanizr/Humanizer/issues/1061#issuecomment-830826232:

1. Adds support for `input.Transform(culture, transformers)`
2. Adds `ICulturedStringTransformer : IStringTransformer`
   https://github.com/Humanizr/Humanizer/blob/3e23bb41f4a60fcb7933227971672f25bb0df013/src/Humanizer/Transformer/ICulturedStringTransformer.cs#L16
    - New interface avoids a breaking change, but I think it's worth considering just updating `IStringTransformer.Transform()` to accept `culture`. Trivial for custom implementations to be updated with the new parameter, since they can just ignore `culture` if they don't care.
3. Updates `To.LowerCase` and such to return `ICulturedStringTransformer` (shouldn't be a breaking change, since it's assignable to `IStringTransformer`, with internal classes updated to implement the new overload.

### Checklist

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No Code Analysis warnings
 - [ ] There is proper unit test coverage
    - Haven't figured out how to test, as I don't know a language with upper/lower rules different from English.
 - [ ] ~~If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution~~
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `dev` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [ ] ~~Readme is updated if you change an existing feature or add a new one~~
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
