### PR TITLE
Fix singularization of the word "ties"

### DIFF
--- a/src/Humanizer.Tests.Shared/InflectorTests.cs
+++ b/src/Humanizer.Tests.Shared/InflectorTests.cs
@@ -345,6 +345,7 @@ namespace Humanizer.Tests
             yield return new object[] { "that", "those" };
             yield return new object[] { "thief", "thieves" };
             yield return new object[] { "this", "these" };
+            yield return new object[] { "tie", "ties" };
             yield return new object[] { "tooth", "teeth" };
             yield return new object[] { "torpedo", "torpedoes" };
             yield return new object[] { "trellis", "trellises" };

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -99,6 +99,7 @@ namespace Humanizer.Inflections
             _default.AddIrregular("this", "these", matchEnding: false);
             _default.AddIrregular("bus", "buses", matchEnding: false);
             _default.AddIrregular("die", "dice", matchEnding: false);
+            _default.AddIrregular("tie", "ties", matchEnding: false);
 
             _default.AddUncountable("staff");
             _default.AddUncountable("training");


### PR DESCRIPTION
Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [ ] Your PR is (re)based on top of the latest commits from the `dev` branch (more info below)
 - [ ] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures

### Issue:
The word `ties` would singularize to `ty` instead of `tie`