### PR TITLE
Fix Japanese single year translation

### DIFF
--- a/src/Humanizer.Tests.Shared/Localisation/ja/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/ja/TimeSpanHumanizeTests.cs
@@ -9,7 +9,7 @@ namespace Humanizer.Tests.Localisation.ja
 
         [Theory]
         [Trait("Translation", "Google")]
-        [InlineData(366, "1 年間の")]
+        [InlineData(366, "1 年")]
         [InlineData(731, "2 年")]
         [InlineData(1096, "3 年")]
         [InlineData(4018, "11 年")]

--- a/src/Humanizer/Properties/Resources.ja.resx
+++ b/src/Humanizer/Properties/Resources.ja.resx
@@ -241,6 +241,6 @@
     <value>1 ヶ月</value>
   </data>
   <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
-    <value>1 年間の</value>
+    <value>1 年</value>
   </data>
 </root>

--- a/src/Humanizer/Properties/Resources.ja.resx
+++ b/src/Humanizer/Properties/Resources.ja.resx
@@ -5,7 +5,7 @@
     
     Version 2.0
     
-    The primary goals of this format is to allow a simple XML format 
+    The primary goals of this format is to allow a simple XML format
     that is mostly human readable. The generation and parsing of the 
     various data types are done through the TypeConverter classes 
     associated with the data types.


### PR DESCRIPTION
Fixes #1049 Japanese single year translation.

I am not a native Japanese speaker, so would be nice to get a confirmation that this is actually the correct way to translate it.

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [ ] No Code Analysis warnings
 - [ ] There is proper unit test coverage
 - [ ] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [ ] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `dev` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [ ] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
