### PR TITLE
Add tests for french culture ByteSize unit expression

### DIFF
--- a/src/Humanizer.Tests.Shared/Bytes/ByteSizeExtensionsTests.cs
+++ b/src/Humanizer.Tests.Shared/Bytes/ByteSizeExtensionsTests.cs
@@ -66,6 +66,7 @@ namespace Humanizer.Tests.Bytes
 
         [Theory]
         [InlineData(2, null, "en", "2 TB")]
+        [InlineData(2, null, "fr", "2 To")]
         [InlineData(2, "GB", "en", "2048 GB")]
         [InlineData(2.1, null, "en", "2.1 TB")]
         [InlineData(2.123, "#.#", "en", "2.1 TB")]
@@ -138,6 +139,7 @@ namespace Humanizer.Tests.Bytes
         [InlineData(0, null, "en", "0 b")]
         [InlineData(0, "GB", "en", "0 GB")]
         [InlineData(2, null, "en", "2 GB")]
+        [InlineData(2, null, "fr", "2 Go")]
         [InlineData(2, "MB", "en", "2048 MB")]
         [InlineData(2.123, "#.##", "en", "2.12 GB")]
         public void HumanizesGigabytes(double input, string format, string cultureName, string expectedValue)
@@ -207,6 +209,7 @@ namespace Humanizer.Tests.Bytes
         [InlineData(0, null, "en", "0 b")]
         [InlineData(0, "MB", "en", "0 MB")]
         [InlineData(2, null, "en", "2 MB")]
+        [InlineData(2, null, "fr", "2 Mo")]
         [InlineData(2, "KB", "en", "2048 KB")]
         [InlineData(2.123, "#", "en", "2 MB")]
         public void HumanizesMegabytes(double input, string format, string cultureName, string expectedValue)
@@ -276,6 +279,7 @@ namespace Humanizer.Tests.Bytes
         [InlineData(0, null, "en", "0 b")]
         [InlineData(0, "KB", "en", "0 KB")]
         [InlineData(2, null, "en", "2 KB")]
+        [InlineData(2, null, "fr", "2 Ko")]
         [InlineData(2, "B", "en", "2048 B")]
         [InlineData(2.123, "#.####", "en", "2.123 KB")]
         public void HumanizesKilobytes(double input, string format, string cultureName, string expectedValue)
@@ -347,6 +351,7 @@ namespace Humanizer.Tests.Bytes
         [InlineData(0, "#.## B", "en", "0 B")]
         [InlineData(0, "B", "en", "0 B")]
         [InlineData(2, null, "en", "2 B")]
+        [InlineData(2, null, "fr", "2 o")]
         [InlineData(2000, "KB", "en", "1.95 KB")]
         [InlineData(2123, "#.##", "en", "2.07 KB")]
         [InlineData(10000000, "KB", "en", "9765.63 KB")]
@@ -412,6 +417,7 @@ namespace Humanizer.Tests.Bytes
         [InlineData(0, null, "en", "0 b")]
         [InlineData(0, "b", "en", "0 b")]
         [InlineData(2, null, "en", "2 b")]
+        [InlineData(2, null, "fr", "2 b")]
         [InlineData(12, "B", "en", "1.5 B")]
         [InlineData(10000, "#.# KB", "en", "1.2 KB")]
         public void HumanizesBits(long input, string format, string cultureName, string expectedValue)

--- a/src/Humanizer.Tests.Shared/Bytes/ByteSizeExtensionsTests.cs
+++ b/src/Humanizer.Tests.Shared/Bytes/ByteSizeExtensionsTests.cs
@@ -65,20 +65,13 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Theory]
-        [InlineData(2, null, "2 TB")]
-        [InlineData(2, "GB", "2048 GB")]
-        [InlineData(2.123, "#.#", "2.1 TB")]
-        public void HumanizesTerabytes(double input, string format, string expectedValue)
-        {
-            Assert.Equal(expectedValue, input.Terabytes().Humanize(format));
-        }
-
-        [Theory]
-        [InlineData(2.1, null, "en-US", "2.1 TB")]
-        [InlineData(2.123, "#.#", "en-US", "2.1 TB")]
+        [InlineData(2, null, "en", "2 TB")]
+        [InlineData(2, "GB", "en", "2048 GB")]
+        [InlineData(2.1, null, "en", "2.1 TB")]
+        [InlineData(2.123, "#.#", "en", "2.1 TB")]
         [InlineData(2.1, null, "ru-RU", "2,1 TB")]
         [InlineData(2.123, "#.#", "ru-RU", "2,1 TB")]
-        public void HumanizeWithFormatProvider(double input, string format, string cultureName, string expectedValue)
+        public void HumanizesTerabytes(double input, string format, string cultureName, string expectedValue)
         {
             var culture = new CultureInfo(cultureName);
 
@@ -142,14 +135,16 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Theory]
-        [InlineData(0, null, "0 b")]
-        [InlineData(0, "GB", "0 GB")]
-        [InlineData(2, null, "2 GB")]
-        [InlineData(2, "MB", "2048 MB")]
-        [InlineData(2.123, "#.##", "2.12 GB")]
-        public void HumanizesGigabytes(double input, string format, string expectedValue)
+        [InlineData(0, null, "en", "0 b")]
+        [InlineData(0, "GB", "en", "0 GB")]
+        [InlineData(2, null, "en", "2 GB")]
+        [InlineData(2, "MB", "en", "2048 MB")]
+        [InlineData(2.123, "#.##", "en", "2.12 GB")]
+        public void HumanizesGigabytes(double input, string format, string cultureName, string expectedValue)
         {
-            Assert.Equal(expectedValue, input.Gigabytes().Humanize(format));
+            var cultureInfo = new CultureInfo(cultureName);
+
+            Assert.Equal(expectedValue, input.Gigabytes().Humanize(format, cultureInfo));
         }
 
         [Fact]
@@ -209,14 +204,16 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Theory]
-        [InlineData(0, null, "0 b")]
-        [InlineData(0, "MB", "0 MB")]
-        [InlineData(2, null, "2 MB")]
-        [InlineData(2, "KB", "2048 KB")]
-        [InlineData(2.123, "#", "2 MB")]
-        public void HumanizesMegabytes(double input, string format, string expectedValue)
+        [InlineData(0, null, "en", "0 b")]
+        [InlineData(0, "MB", "en", "0 MB")]
+        [InlineData(2, null, "en", "2 MB")]
+        [InlineData(2, "KB", "en", "2048 KB")]
+        [InlineData(2.123, "#", "en", "2 MB")]
+        public void HumanizesMegabytes(double input, string format, string cultureName, string expectedValue)
         {
-            Assert.Equal(expectedValue, input.Megabytes().Humanize(format));
+            var cultureInfo = new CultureInfo(cultureName);
+
+            Assert.Equal(expectedValue, input.Megabytes().Humanize(format, cultureInfo));
         }
 
         [Fact]
@@ -276,14 +273,16 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Theory]
-        [InlineData(0, null, "0 b")]
-        [InlineData(0, "KB", "0 KB")]
-        [InlineData(2, null, "2 KB")]
-        [InlineData(2, "B", "2048 B")]
-        [InlineData(2.123, "#.####", "2.123 KB")]
-        public void HumanizesKilobytes(double input, string format, string expectedValue)
+        [InlineData(0, null, "en", "0 b")]
+        [InlineData(0, "KB", "en", "0 KB")]
+        [InlineData(2, null, "en", "2 KB")]
+        [InlineData(2, "B", "en", "2048 B")]
+        [InlineData(2.123, "#.####", "en", "2.123 KB")]
+        public void HumanizesKilobytes(double input, string format, string cultureName, string expectedValue)
         {
-            Assert.Equal(expectedValue, input.Kilobytes().Humanize(format));
+            var cultureInfo = new CultureInfo(cultureName);
+
+            Assert.Equal(expectedValue, input.Kilobytes().Humanize(format, cultureInfo));
         }
 
         [Fact]
@@ -343,19 +342,21 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Theory]
-        [InlineData(0, null, "0 b")]
-        [InlineData(0, "#.##", "0 b")]
-        [InlineData(0, "#.## B", "0 B")]
-        [InlineData(0, "B", "0 B")]
-        [InlineData(2, null, "2 B")]
-        [InlineData(2000, "KB", "1.95 KB")]
-        [InlineData(2123, "#.##", "2.07 KB")]
-        [InlineData(10000000, "KB", "9765.63 KB")]
-        [InlineData(10000000, "#,##0 KB", "9,766 KB")]
-        [InlineData(10000000, "#,##0.# KB", "9,765.6 KB")]
-        public void HumanizesBytes(double input, string format, string expectedValue)
+        [InlineData(0, null, "en", "0 b")]
+        [InlineData(0, "#.##", "en", "0 b")]
+        [InlineData(0, "#.## B", "en", "0 B")]
+        [InlineData(0, "B", "en", "0 B")]
+        [InlineData(2, null, "en", "2 B")]
+        [InlineData(2000, "KB", "en", "1.95 KB")]
+        [InlineData(2123, "#.##", "en", "2.07 KB")]
+        [InlineData(10000000, "KB", "en", "9765.63 KB")]
+        [InlineData(10000000, "#,##0 KB", "en", "9,766 KB")]
+        [InlineData(10000000, "#,##0.# KB", "en", "9,765.6 KB")]
+        public void HumanizesBytes(double input, string format, string cultureName, string expectedValue)
         {
-            Assert.Equal(expectedValue, input.Bytes().Humanize(format));
+            var cultureInfo = new CultureInfo(cultureName);
+
+            Assert.Equal(expectedValue, input.Bytes().Humanize(format, cultureInfo));
         }
 
         [Fact]
@@ -408,14 +409,16 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Theory]
-        [InlineData(0, null, "0 b")]
-        [InlineData(0, "b", "0 b")]
-        [InlineData(2, null, "2 b")]
-        [InlineData(12, "B", "1.5 B")]
-        [InlineData(10000, "#.# KB", "1.2 KB")]
-        public void HumanizesBits(long input, string format, string expectedValue)
+        [InlineData(0, null, "en", "0 b")]
+        [InlineData(0, "b", "en", "0 b")]
+        [InlineData(2, null, "en", "2 b")]
+        [InlineData(12, "B", "en", "1.5 B")]
+        [InlineData(10000, "#.# KB", "en", "1.2 KB")]
+        public void HumanizesBits(long input, string format, string cultureName, string expectedValue)
         {
-            Assert.Equal(expectedValue, input.Bits().Humanize(format));
+            var cultureInfo = new CultureInfo(cultureName);
+
+            Assert.Equal(expectedValue, input.Bits().Humanize(format, cultureInfo));
         }
     }
 }


### PR DESCRIPTION
Fixes #1069 and add tests for culture-specific ByteSize unit expression that was added here 17e98849b52fa4e3bc50d57b53f778e8a8a264f2.
