### PR TITLE
Register Korean formatter

### DIFF
--- a/src/Humanizer.Tests.Shared/Humanizer.Tests.Shared.projitems
+++ b/src/Humanizer.Tests.Shared/Humanizer.Tests.Shared.projitems
@@ -111,6 +111,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\ja\DateHumanizeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\ja\NumberToWordsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\ja\TimeSpanHumanizeTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Localisation\ko-KR\TimeSpanHumanizeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\ku\NumberToWordsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\ku\TimeSpanHumanizeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\mt\DateHumanizeTests.cs" />

--- a/src/Humanizer.Tests.Shared/Localisation/ko-KR/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/ko-KR/TimeSpanHumanizeTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using Xunit;
+
+namespace Humanizer.Tests.Localisation.koKR
+{
+    [UseCulture("ko-KR")]
+    public class TimeSpanHumanizeTests
+    {
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(366, "1년")]
+        [InlineData(731, "2년")]
+        [InlineData(1096, "3년")]
+        [InlineData(4018, "11년")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(31, "1개월")]
+        [InlineData(61, "2개월")]
+        [InlineData(92, "3개월")]
+        [InlineData(335, "11개월")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(7, "1주")]
+        [InlineData(14, "2주")]
+        public void Weeks(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize());
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(1, "1일")]
+        [InlineData(2, "2일")]
+        public void Days(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize());
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(1, "1시간")]
+        [InlineData(2, "2시간")]
+        public void Hours(int hours, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromHours(hours).Humanize());
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(1, "1분")]
+        [InlineData(2, "2분")]
+        public void Minutes(int minutes, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromMinutes(minutes).Humanize());
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(1, "1초")]
+        [InlineData(2, "2초")]
+        public void Seconds(int seconds, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromSeconds(seconds).Humanize());
+        }
+
+        [Theory]
+        [Trait("Translation", "Google")]
+        [InlineData(1, "1밀리초")]
+        [InlineData(2, "2밀리초")]
+        public void Milliseconds(int milliseconds, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromMilliseconds(milliseconds).Humanize());
+        }
+
+        [Fact]
+        [Trait("Translation", "Google")]
+        public void NoTime()
+        {
+            Assert.Equal("0밀리초", TimeSpan.Zero.Humanize());
+        }
+
+        [Fact]
+        public void NoTimeToWords()
+        {
+            Assert.Equal("방금", TimeSpan.Zero.Humanize(toWords: true));
+        }
+    }
+}

--- a/src/Humanizer/Configuration/FormatterRegistry.cs
+++ b/src/Humanizer/Configuration/FormatterRegistry.cs
@@ -41,6 +41,7 @@ namespace Humanizer.Configuration
             RegisterDefaultFormatter("hy");
             RegisterDefaultFormatter("id");
             RegisterDefaultFormatter("ja");
+            RegisterDefaultFormatter("ko-KR");
             Register("mt", new MalteseFormatter("mt"));
             RegisterDefaultFormatter("nb");
             RegisterDefaultFormatter("nb-NO");


### PR DESCRIPTION
Here is a checklist you should tick through before submitting a pull request: 
 - [X] Implementation is clean
 - [X] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [X] No Code Analysis warnings
 - [X] There is proper unit test coverage
 - [X] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [X] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [X] Xml documentation is added/updated for the addition/change
 - [X] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [X] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [X] Readme is updated if you change an existing feature or add a new one
 - [X] Run either `build.cmd` or `build.ps1` and ensure there are no test failures

Registers a formatter for the existing Korean translations. The unit test is merely to verify that the translations are picked up, and are based on the Resources and Google translate, because I do not speak Korean.

Fixes #1073