### PR TITLE
Register Filipino formatter

### DIFF
--- a/src/Humanizer.Tests.Shared/Humanizer.Tests.Shared.projitems
+++ b/src/Humanizer.Tests.Shared/Humanizer.Tests.Shared.projitems
@@ -80,6 +80,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\fa\TimeSpanHumanizeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\fi-FI\DateHumanizeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\fi-FI\NumberToWordsTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Localisation\fil-PH\TimeSpanHumanizeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\fr-BE\DateHumanizeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\fr-BE\NumberToWordsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Localisation\fr-BE\TimeSpanHumanizeTests.cs" />

--- a/src/Humanizer.Tests.Shared/Localisation/fil-PH/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/fil-PH/TimeSpanHumanizeTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Xunit;
+
+namespace Humanizer.Tests.Localisation.filPH
+{
+    [UseCulture("fil-PH")]
+    public class TimeSpanHumanizeTests
+    {
+        [Theory]
+        [Trait("Translation", "Google Translate")]
+        [InlineData(366, "1 taon")]
+        [InlineData(731, "2 taon")]
+        [InlineData(1096, "3 taon")]
+        [InlineData(4018, "11 taon")]
+        public void Years(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google Translate")]
+        [InlineData(31, "1 buwan")]
+        [InlineData(61, "2 buwan")]
+        [InlineData(92, "3 buwan")]
+        [InlineData(335, "11 buwan")]
+        public void Months(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: Humanizer.Localisation.TimeUnit.Year));
+        }
+
+        [Theory]
+        [Trait("Translation", "Google Translate")]
+        [InlineData(7, "1 linggo")]
+        [InlineData(14, "2 linggo")]
+        [InlineData(21, "3 linggo")]
+        [InlineData(77, "11 linggo")]
+        public void Weeks(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize());
+        }
+
+        [Theory]
+        [Trait("Translation", "Google Translate")]
+        [InlineData(1, "1 araw")]
+        [InlineData(2, "2 araw")]
+        public void Days(int days, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromDays(days).Humanize());
+        }
+
+        [Theory]
+        [Trait("Translation", "Google Translate")]
+        [InlineData(1, "1 oras")]
+        [InlineData(2, "2 oras")]
+        public void Hours(int hours, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromHours(hours).Humanize());
+        }
+
+        [Theory]
+        [Trait("Translation", "Google Translate")]
+        [InlineData(1, "1 minuto")]
+        [InlineData(2, "2 minuto")]
+        public void Minutes(int minutes, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromMinutes(minutes).Humanize());
+        }
+
+        [Theory]
+        [Trait("Translation", "Google Translate")]
+        [InlineData(1, "1 segundo")]
+        [InlineData(2, "2 segundo")]
+        public void Seconds(int seconds, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromSeconds(seconds).Humanize());
+        }
+
+        [Theory]
+        [Trait("Translation", "Google Translate")]
+        [InlineData(1, "1 millisecond")]
+        [InlineData(2, "2 milliseconds")]
+        public void Milliseconds(int milliseconds, string expected)
+        {
+            Assert.Equal(expected, TimeSpan.FromMilliseconds(milliseconds).Humanize());
+        }
+
+        [Fact]
+        public void NoTime()
+        {
+            Assert.Equal("0 milliseconds", TimeSpan.Zero.Humanize());
+        }
+
+        [Fact]
+        public void NoTimeToWords()
+        {
+            Assert.Equal("walang oras", TimeSpan.Zero.Humanize(toWords: true));
+        }
+    }
+}

--- a/src/Humanizer/Configuration/FormatterRegistry.cs
+++ b/src/Humanizer/Configuration/FormatterRegistry.cs
@@ -37,6 +37,7 @@ namespace Humanizer.Configuration
             RegisterDefaultFormatter("es");
             RegisterDefaultFormatter("fa");
             RegisterDefaultFormatter("fi-FI");
+            RegisterDefaultFormatter("fil-PH");
             RegisterDefaultFormatter("hu");
             RegisterDefaultFormatter("hy");
             RegisterDefaultFormatter("id");


### PR DESCRIPTION
Here is a checklist you should tick through before submitting a pull request: 
 - [X] Implementation is clean
 - [X] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [X] No Code Analysis warnings
 - [X] There is proper unit test coverage
 - [X] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [X] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [X] Xml documentation is added/updated for the addition/change
 - [X] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [X] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [X] Readme is updated if you change an existing feature or add a new one
 - [X] Run either `build.cmd` or `build.ps1` and ensure there are no test failures

Registers a formatter for the existing Filipino translations. The unit test is merely to verify that the translations are picked up, and are based on the Resources and Google translate, because I do not speak Filipino.