### PR TITLE
Fixed default number format

### DIFF
--- a/src/Humanizer.Tests.Shared/Bytes/ToStringTests.cs
+++ b/src/Humanizer.Tests.Shared/Bytes/ToStringTests.cs
@@ -37,6 +37,7 @@ namespace Humanizer.Tests.Bytes
         [Fact]
         public void ReturnsDefaultNumberFormat()
         {
+            Assert.Equal("10.5 KB", ByteSize.FromKilobytes(10.501).ToString());
             Assert.Equal("10.5 KB", ByteSize.FromKilobytes(10.5).ToString("KB"));
         }
 

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -228,7 +228,7 @@ namespace Humanizer.Bytes
             if (provider == null)
                 provider = CultureInfo.CurrentCulture;
 
-            return string.Format("{0} {1}", LargestWholeNumberValue.ToString(provider), GetLargestWholeNumberSymbol(provider));
+            return string.Format("{0:0.##} {1}", LargestWholeNumberValue.ToString(provider), GetLargestWholeNumberSymbol(provider));
         }
 
         public string ToString(string format)


### PR DESCRIPTION
This PR fixes an issue happening only when `ToString()` is invoked on a `ByteSize`. Since parameterless `ToString` is optimized and doesn't invoke `ToString(string format)` it uses `{0} {1}` to create an output string, but this format has no information on how a value should be displayed and prints a number with high precision.