### PR TITLE
Add 'heading' parameter  XML docs to fix warnings during CI build

### DIFF
--- a/src/Humanizer/HeadingExtensions.cs
+++ b/src/Humanizer/HeadingExtensions.cs
@@ -71,6 +71,7 @@ namespace Humanizer
         /// <summary>
         /// Returns a heading based on the short textual representation of the heading.
         /// </summary>
+        /// <param name="heading">The short textual representation of a heading</param>
         /// <returns>The heading. -1 if the heading could not be parsed.</returns>
         public static double FromAbbreviatedHeading(this string heading)
         {
@@ -80,6 +81,7 @@ namespace Humanizer
         /// <summary>
         /// Returns a heading based on the short textual representation of the heading.
         /// </summary>
+        /// <param name="heading">The short textual representation of a heading</param>
         /// <param name="culture">The culture of the heading</param>
         /// <returns>The heading. -1 if the heading could not be parsed.</returns>
         public static double FromAbbreviatedHeading(this string heading, CultureInfo culture = null)


### PR DESCRIPTION
The current CI [build](https://dev.azure.com/dotnet/Humanizer/_build/results?buildId=59800&view=results) for the main branch has build warnings caused by a change I did previously.
```
Warning CS1573: Parameter 'heading' has no matching param tag in the XML comment for 'HeadingExtensions.FromAbbreviatedHeading(string, CultureInfo)' (but other parameters do)
```

This PR adds the missing XML documentations parameter.

Here is a checklist you should tick through before submitting a pull request: 
 - [ ] Implementation is clean
 - [ ] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [ ] No Code Analysis warnings
 - [ ] There is proper unit test coverage
 - [ ] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [ ] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [X] Xml documentation is added/updated for the addition/change
 - [X] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [ ] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [ ] Readme is updated if you change an existing feature or add a new one
 - [X] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
