### PR TITLE
Fix DateOnly, TimeOnly & DateTime issues in French

### DIFF
--- a/src/Humanizer.Tests.Shared/Localisation/fr/DateToOrdinalWordsTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/fr/DateToOrdinalWordsTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Xunit;
+
+namespace Humanizer.Tests.Localisation.fr
+{
+    [UseCulture("fr")]
+    public class DateToOrdinalWordsTests
+    {
+        [Fact]
+        public void OrdinalizeString()
+        {
+            Assert.Equal("1er janvier 2015", new DateTime(2015, 1, 1).ToOrdinalWords());
+            Assert.Equal("2 mars 2020", new DateTime(2020, 3, 2).ToOrdinalWords());
+            Assert.Equal("31 octobre 2021", new DateTime(2021, 10, 31).ToOrdinalWords());
+        }
+
+#if NET6_0_OR_GREATER
+        [Fact]
+        public void OrdinalizeDateOnlyString()
+        {
+            Assert.Equal("1er janvier 2015", new DateOnly(2015, 1, 1).ToOrdinalWords());
+            Assert.Equal("2 mars 2020", new DateOnly(2020, 3, 2).ToOrdinalWords());
+            Assert.Equal("31 octobre 2021", new DateOnly(2021, 10, 31).ToOrdinalWords());
+        }
+#endif
+    }
+}

--- a/src/Humanizer.Tests.Shared/Localisation/fr/TimeOnlyHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/fr/TimeOnlyHumanizeTests.cs
@@ -1,0 +1,86 @@
+﻿#if NET6_0_OR_GREATER
+
+using System;
+using Humanizer.Configuration;
+using Humanizer.DateTimeHumanizeStrategy;
+using Xunit;
+
+namespace Humanizer.Tests.Localisation.fr
+{
+    [UseCulture("fr")]
+    public class TimeOnlyHumanizeTests
+    {
+        [Fact]
+        public void DefaultStrategy_SameTime()
+        {
+            Configurator.TimeOnlyHumanizeStrategy = new DefaultTimeOnlyHumanizeStrategy();
+
+            var inputTime = new TimeOnly(13, 07, 05);
+            var baseTime = new TimeOnly(13, 07, 05);
+
+            const string expectedResult = "maintenant";
+            var actualResult = inputTime.Humanize(baseTime);
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void DefaultStrategy_HoursApart()
+        {
+            Configurator.TimeOnlyHumanizeStrategy = new DefaultTimeOnlyHumanizeStrategy();
+
+            var inputTime = new TimeOnly(13, 08, 05);
+            var baseTime = new TimeOnly(1, 08, 05);
+
+            const string expectedResult = "dans 12 heures";
+            var actualResult = inputTime.Humanize(baseTime);
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void DefaultStrategy_HoursAgo()
+        {
+            Configurator.TimeOnlyHumanizeStrategy = new DefaultTimeOnlyHumanizeStrategy();
+
+            var inputTime = new TimeOnly(13, 07, 02);
+            var baseTime = new TimeOnly(17, 07, 05);
+
+            const string expectedResult = "il y a 4 heures";
+            var actualResult = inputTime.Humanize(baseTime);
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void PrecisionStrategy_NextDay()
+        {
+            Configurator.TimeOnlyHumanizeStrategy = new PrecisionTimeOnlyHumanizeStrategy(0.75);
+
+            var inputTime = new TimeOnly(18, 10, 49);
+            var baseTime = new TimeOnly(13, 07, 04);
+
+            const string expectedResult = "dans 5 heures";
+            var actualResult = inputTime.Humanize(baseTime);
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+
+        [Fact]
+        public void Never()
+        {
+            TimeOnly? never = null;
+            Assert.Equal("jamais", never.Humanize());
+        }
+
+        [Fact]
+        public void Nullable_ExpectSame()
+        {
+            TimeOnly? never = new TimeOnly(23, 12, 7);
+            Assert.Equal(never.Value.Humanize(), never.Humanize());
+        }
+    }
+}
+
+#endif

--- a/src/Humanizer.Tests.Shared/Localisation/fr/TimeOnlyHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/fr/TimeOnlyHumanizeTests.cs
@@ -1,8 +1,6 @@
 ﻿#if NET6_0_OR_GREATER
 
 using System;
-using Humanizer.Configuration;
-using Humanizer.DateTimeHumanizeStrategy;
 using Xunit;
 
 namespace Humanizer.Tests.Localisation.fr
@@ -13,8 +11,6 @@ namespace Humanizer.Tests.Localisation.fr
         [Fact]
         public void DefaultStrategy_SameTime()
         {
-            Configurator.TimeOnlyHumanizeStrategy = new DefaultTimeOnlyHumanizeStrategy();
-
             var inputTime = new TimeOnly(13, 07, 05);
             var baseTime = new TimeOnly(13, 07, 05);
 
@@ -27,8 +23,6 @@ namespace Humanizer.Tests.Localisation.fr
         [Fact]
         public void DefaultStrategy_HoursApart()
         {
-            Configurator.TimeOnlyHumanizeStrategy = new DefaultTimeOnlyHumanizeStrategy();
-
             var inputTime = new TimeOnly(13, 08, 05);
             var baseTime = new TimeOnly(1, 08, 05);
 
@@ -41,8 +35,6 @@ namespace Humanizer.Tests.Localisation.fr
         [Fact]
         public void DefaultStrategy_HoursAgo()
         {
-            Configurator.TimeOnlyHumanizeStrategy = new DefaultTimeOnlyHumanizeStrategy();
-
             var inputTime = new TimeOnly(13, 07, 02);
             var baseTime = new TimeOnly(17, 07, 05);
 
@@ -55,8 +47,6 @@ namespace Humanizer.Tests.Localisation.fr
         [Fact]
         public void PrecisionStrategy_NextDay()
         {
-            Configurator.TimeOnlyHumanizeStrategy = new PrecisionTimeOnlyHumanizeStrategy(0.75);
-
             var inputTime = new TimeOnly(18, 10, 49);
             var baseTime = new TimeOnly(13, 07, 04);
 

--- a/src/Humanizer.Tests.Shared/Localisation/fr/TimeToClockNotationTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/fr/TimeToClockNotationTests.cs
@@ -1,0 +1,64 @@
+﻿#if NET6_0_OR_GREATER
+
+using System;
+using Xunit;
+using Humanizer.Localisation.TimeToClockNotation;
+using Humanizer;
+
+namespace Humanizer.Tests.Localisation.fr
+{
+    [UseCulture("fr")]
+    public class TimeToClockNotationTests
+    {
+        [Theory]
+        [InlineData(00, 00, "minuit")]
+        [InlineData(01, 00, "une heure")]
+        [InlineData(04, 00, "quatre heures")]
+        [InlineData(05, 01, "cinq heures une")]
+        [InlineData(06, 05, "six heures cinq")]
+        [InlineData(07, 10, "sept heures dix")]
+        [InlineData(08, 15, "huit heures et quart")]
+        [InlineData(09, 20, "neuf heures vingt")]
+        [InlineData(10, 25, "dix heures vingt-cinq")]
+        [InlineData(11, 30, "onze heures et demie")]
+        [InlineData(12, 00, "midi")]
+        [InlineData(15, 35, "quinze heures trente-cinq")]
+        [InlineData(16, 40, "dix-sept heures moins vingt")]
+        [InlineData(17, 45, "dix-huit heures moins le quart")]
+        [InlineData(18, 50, "dix-huit heures cinquante")]
+        [InlineData(19, 55, "dix-neuf heures cinquante-cinq")]
+        [InlineData(20, 59, "vingt heures cinquante-neuf")]
+        public void ConvertToClockNotationTimeOnlyString(int hours, int minutes, string expectedResult)
+        {
+            var actualResult = new TimeOnly(hours, minutes).ToClockNotation();
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Theory]
+        [InlineData(00, 00, "minuit")]
+        [InlineData(04, 00, "quatre heures")]
+        [InlineData(05, 01, "cinq heures")]
+        [InlineData(06, 05, "six heures cinq")]
+        [InlineData(07, 10, "sept heures dix")]
+        [InlineData(08, 15, "huit heures et quart")]
+        [InlineData(09, 20, "neuf heures vingt")]
+        [InlineData(10, 25, "dix heures vingt-cinq")]
+        [InlineData(11, 30, "onze heures et demie")]
+        [InlineData(12, 00, "midi")]
+        [InlineData(13, 23, "treize heures vingt-cinq")]
+        [InlineData(14, 32, "quatorze heures et demie")]
+        [InlineData(15, 35, "quinze heures trente-cinq")]
+        [InlineData(16, 40, "dix-sept heures moins vingt")]
+        [InlineData(17, 45, "dix-huit heures moins le quart")]
+        [InlineData(18, 50, "dix-huit heures cinquante")]
+        [InlineData(19, 55, "dix-neuf heures cinquante-cinq")]
+        [InlineData(20, 59, "vingt et une heures")]
+        public void ConvertToRoundedClockNotationTimeOnlyString(int hours, int minutes, string expectedResult)
+        {
+            var actualResult = new TimeOnly(hours, minutes).ToClockNotation(ClockNotationRounding.NearestFiveMinutes);
+            Assert.Equal(expectedResult, actualResult);
+        }
+    }
+}
+
+#endif

--- a/src/Humanizer.Tests.Shared/Localisation/fr/TimeToClockNotationTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/fr/TimeToClockNotationTests.cs
@@ -2,8 +2,6 @@
 
 using System;
 using Xunit;
-using Humanizer.Localisation.TimeToClockNotation;
-using Humanizer;
 
 namespace Humanizer.Tests.Localisation.fr
 {
@@ -12,19 +10,21 @@ namespace Humanizer.Tests.Localisation.fr
     {
         [Theory]
         [InlineData(00, 00, "minuit")]
-        [InlineData(01, 00, "une heure")]
+        [InlineData(00, 07, "minuit sept")]
+        [InlineData(01, 11, "une heure onze")]
         [InlineData(04, 00, "quatre heures")]
         [InlineData(05, 01, "cinq heures une")]
         [InlineData(06, 05, "six heures cinq")]
         [InlineData(07, 10, "sept heures dix")]
-        [InlineData(08, 15, "huit heures et quart")]
+        [InlineData(08, 15, "huit heures quinze")]
         [InlineData(09, 20, "neuf heures vingt")]
         [InlineData(10, 25, "dix heures vingt-cinq")]
-        [InlineData(11, 30, "onze heures et demie")]
+        [InlineData(11, 30, "onze heures trente")]
         [InlineData(12, 00, "midi")]
+        [InlineData(12, 38, "midi trente-huit")]
         [InlineData(15, 35, "quinze heures trente-cinq")]
-        [InlineData(16, 40, "dix-sept heures moins vingt")]
-        [InlineData(17, 45, "dix-huit heures moins le quart")]
+        [InlineData(16, 40, "seize heures quarante")]
+        [InlineData(17, 45, "dix-sept heures quarante-cinq")]
         [InlineData(18, 50, "dix-huit heures cinquante")]
         [InlineData(19, 55, "dix-neuf heures cinquante-cinq")]
         [InlineData(20, 59, "vingt heures cinquante-neuf")]
@@ -36,20 +36,23 @@ namespace Humanizer.Tests.Localisation.fr
 
         [Theory]
         [InlineData(00, 00, "minuit")]
+        [InlineData(00, 07, "minuit cinq")]
+        [InlineData(01, 11, "une heure dix")]
         [InlineData(04, 00, "quatre heures")]
         [InlineData(05, 01, "cinq heures")]
         [InlineData(06, 05, "six heures cinq")]
         [InlineData(07, 10, "sept heures dix")]
-        [InlineData(08, 15, "huit heures et quart")]
+        [InlineData(08, 15, "huit heures quinze")]
         [InlineData(09, 20, "neuf heures vingt")]
         [InlineData(10, 25, "dix heures vingt-cinq")]
-        [InlineData(11, 30, "onze heures et demie")]
+        [InlineData(11, 30, "onze heures trente")]
         [InlineData(12, 00, "midi")]
+        [InlineData(12, 38, "midi quarante")]
         [InlineData(13, 23, "treize heures vingt-cinq")]
-        [InlineData(14, 32, "quatorze heures et demie")]
+        [InlineData(14, 32, "quatorze heures trente")]
         [InlineData(15, 35, "quinze heures trente-cinq")]
-        [InlineData(16, 40, "dix-sept heures moins vingt")]
-        [InlineData(17, 45, "dix-huit heures moins le quart")]
+        [InlineData(16, 40, "seize heures quarante")]
+        [InlineData(17, 45, "dix-sept heures quarante-cinq")]
         [InlineData(18, 50, "dix-huit heures cinquante")]
         [InlineData(19, 55, "dix-neuf heures cinquante-cinq")]
         [InlineData(20, 59, "vingt et une heures")]

--- a/src/Humanizer/Configuration/DateOnlyToOrdinalWordsConverterRegistry.cs
+++ b/src/Humanizer/Configuration/DateOnlyToOrdinalWordsConverterRegistry.cs
@@ -1,15 +1,14 @@
 ﻿#if NET6_0_OR_GREATER
-
 using Humanizer.Localisation.DateToOrdinalWords;
+
 namespace Humanizer.Configuration
 {
     internal class DateOnlyToOrdinalWordsConverterRegistry : LocaliserRegistry<IDateOnlyToOrdinalWordConverter>
     {
         public DateOnlyToOrdinalWordsConverterRegistry() : base(new DefaultDateOnlyToOrdinalWordConverter())
         {
-            Register("en-UK", new DefaultDateOnlyToOrdinalWordConverter());
-            Register("de", new DefaultDateOnlyToOrdinalWordConverter());
             Register("en-US", new UsDateOnlyToOrdinalWordsConverter());
+            Register("fr", new FrDateOnlyToOrdinalWordsConverter());
         }
     }
 }

--- a/src/Humanizer/Configuration/DateToOrdinalWordsConverterRegistry.cs
+++ b/src/Humanizer/Configuration/DateToOrdinalWordsConverterRegistry.cs
@@ -1,13 +1,13 @@
 ﻿using Humanizer.Localisation.DateToOrdinalWords;
+
 namespace Humanizer.Configuration
 {
     internal class DateToOrdinalWordsConverterRegistry : LocaliserRegistry<IDateToOrdinalWordConverter>
     {
         public DateToOrdinalWordsConverterRegistry() : base(new DefaultDateToOrdinalWordConverter())
         {
-            Register("en-UK", new DefaultDateToOrdinalWordConverter());
-            Register("de", new DefaultDateToOrdinalWordConverter());
             Register("en-US", new UsDateToOrdinalWordsConverter());
+            Register("fr", new FrDateToOrdinalWordsConverter());
         }
     }
 }

--- a/src/Humanizer/Configuration/TimeOnlyToClockNotationConvertersRegistry.cs
+++ b/src/Humanizer/Configuration/TimeOnlyToClockNotationConvertersRegistry.cs
@@ -9,6 +9,7 @@ namespace Humanizer.Configuration
         public TimeOnlyToClockNotationConvertersRegistry() : base(new DefaultTimeOnlyToClockNotationConverter())
         {
             Register("pt-BR", new BrazilianPortugueseTimeOnlyToClockNotationConverter());
+            Register("fr", new FrTimeOnlyToClockNotationConverter());
         }
     }
 }

--- a/src/Humanizer/Localisation/DateToOrdinalWords/FrDateOnlyToOrdinalWordsConverter.cs
+++ b/src/Humanizer/Localisation/DateToOrdinalWords/FrDateOnlyToOrdinalWordsConverter.cs
@@ -1,0 +1,15 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+
+namespace Humanizer.Localisation.DateToOrdinalWords
+{
+    internal class FrDateOnlyToOrdinalWordsConverter : DefaultDateOnlyToOrdinalWordConverter
+    {
+        public override string Convert(DateOnly date)
+        {
+            var day = date.Day > 1 ? date.Day.ToString() : date.Day.Ordinalize();
+            return day + date.ToString(" MMMM yyyy");
+        }
+    }
+}
+#endif

--- a/src/Humanizer/Localisation/DateToOrdinalWords/FrDateToOrdinalWordsConverter.cs
+++ b/src/Humanizer/Localisation/DateToOrdinalWords/FrDateToOrdinalWordsConverter.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Humanizer.Localisation.DateToOrdinalWords
+{
+    internal class FrDateToOrdinalWordsConverter : DefaultDateToOrdinalWordConverter
+    {
+        public override string Convert(DateTime date)
+        {
+            var day = date.Day > 1 ? date.Day.ToString() : date.Day.Ordinalize();
+            return day + date.ToString(" MMMM yyyy");
+        }
+    }
+}

--- a/src/Humanizer/Localisation/TimeToClockNotation/FrTimeOnlyToClockNotationConverter.cs
+++ b/src/Humanizer/Localisation/TimeToClockNotation/FrTimeOnlyToClockNotationConverter.cs
@@ -9,14 +9,6 @@ namespace Humanizer.Localisation.TimeToClockNotation
     {
         public virtual string Convert(TimeOnly time, ClockNotationRounding roundToNearestFive)
         {
-            switch (time)
-            {
-                case { Hour: 0, Minute: 0 }:
-                    return "minuit";
-                case { Hour: 12, Minute: 0 }:
-                    return "midi";
-            }
-
             var normalizedMinutes = (int)(roundToNearestFive == ClockNotationRounding.NearestFiveMinutes
                 ? 5 * Math.Round(time.Minute / 5.0)
                 : time.Minute);
@@ -24,17 +16,18 @@ namespace Humanizer.Localisation.TimeToClockNotation
             return normalizedMinutes switch
             {
                 00 => GetHourExpression(time.Hour),
-                15 => $"{GetHourExpression(time.Hour)} et quart",
-                30 => $"{GetHourExpression(time.Hour)} et demie",
-                40 => $"{GetHourExpression(time.Hour + 1)} moins vingt",
-                45 => $"{GetHourExpression(time.Hour + 1)} moins le quart",
-                60 => $"{GetHourExpression(time.Hour + 1)}",
+                60 => GetHourExpression(time.Hour + 1),
                 _ => $"{GetHourExpression(time.Hour)} {normalizedMinutes.ToWords(GrammaticalGender.Feminine)}"
             };
 
             static string GetHourExpression(int hour)
             {
-                return hour.ToWords(GrammaticalGender.Feminine) + (hour > 1 ? " heures" : " heure");
+                return hour switch
+                {
+                    0 => "minuit",
+                    12 => "midi",
+                    _ => hour.ToWords(GrammaticalGender.Feminine) + (hour > 1 ? " heures" : " heure")
+                };
             }
         }
     }

--- a/src/Humanizer/Localisation/TimeToClockNotation/FrTimeOnlyToClockNotationConverter.cs
+++ b/src/Humanizer/Localisation/TimeToClockNotation/FrTimeOnlyToClockNotationConverter.cs
@@ -1,0 +1,43 @@
+﻿#if NET6_0_OR_GREATER
+
+using System;
+using Humanizer;
+
+namespace Humanizer.Localisation.TimeToClockNotation
+{
+    internal class FrTimeOnlyToClockNotationConverter : ITimeOnlyToClockNotationConverter
+    {
+        public virtual string Convert(TimeOnly time, ClockNotationRounding roundToNearestFive)
+        {
+            switch (time)
+            {
+                case { Hour: 0, Minute: 0 }:
+                    return "minuit";
+                case { Hour: 12, Minute: 0 }:
+                    return "midi";
+            }
+
+            var normalizedMinutes = (int)(roundToNearestFive == ClockNotationRounding.NearestFiveMinutes
+                ? 5 * Math.Round(time.Minute / 5.0)
+                : time.Minute);
+
+            return normalizedMinutes switch
+            {
+                00 => GetHourExpression(time.Hour),
+                15 => $"{GetHourExpression(time.Hour)} et quart",
+                30 => $"{GetHourExpression(time.Hour)} et demie",
+                40 => $"{GetHourExpression(time.Hour + 1)} moins vingt",
+                45 => $"{GetHourExpression(time.Hour + 1)} moins le quart",
+                60 => $"{GetHourExpression(time.Hour + 1)}",
+                _ => $"{GetHourExpression(time.Hour)} {normalizedMinutes.ToWords(GrammaticalGender.Feminine)}"
+            };
+
+            static string GetHourExpression(int hour)
+            {
+                return hour.ToWords(GrammaticalGender.Feminine) + (hour > 1 ? " heures" : " heure");
+            }
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
- Add `DateToOrdinalWordsTests`, `TimeOnlyHumanizeTests` & `TimeToClockNotationTests` for French culture
- Adapt code so that tests pass

Relates to https://github.com/Humanizr/Humanizer/issues/1081  
Relates to https://github.com/Humanizr/Humanizer/pull/1134#issuecomment-952634390  
Fixes https://github.com/Humanizr/Humanizer/issues/1012  

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage
 - [ ] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [ ] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [ ] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
