### PR TITLE
special case for letter 's'

### DIFF
--- a/src/Humanizer.Tests.Shared/InflectorTests.cs
+++ b/src/Humanizer.Tests.Shared/InflectorTests.cs
@@ -71,6 +71,19 @@ namespace Humanizer.Tests
             Assert.Equal(singular, plural.Singularize(skipSimpleWords: true));
         }
 
+        [Theory]
+        [InlineData("a")]
+        [InlineData("A")]
+        [InlineData("s")]
+        [InlineData("S")]
+        [InlineData("z")]
+        [InlineData("Z")]
+        [InlineData("1")]
+        public void SingularizeSingleLetter(string input)
+        {
+            Assert.Equal(input, input.Singularize());
+        }
+
         //Uppercases individual words and removes some characters 
         [Theory]
         [InlineData("some title", "Some Title")]
@@ -280,6 +293,7 @@ namespace Humanizer.Tests
             yield return new object[] { "alumna", "alumnae" };
             yield return new object[] { "alumnus", "alumni" };
             yield return new object[] { "fungus", "fungi" };
+
             yield return new object[] { "water", "water" };
             yield return new object[] { "waters", "waters" };
             yield return new object[] { "semen", "semen" };
@@ -377,11 +391,18 @@ namespace Humanizer.Tests
             yield return new object[] { "hoe", "hoes" };
             yield return new object[] { "toe", "toes" };
             yield return new object[] { "woe", "woes" };
-            // Duplicated test case - Already added by Bas Jansen
-            // yield return new object[] { "potato", "potatoes" };
 
-            //Issue 1132
+            //Issue #1132
             yield return new object[] { "metadata", "metadata" };
+
+            //Issue #1154
+            yield return new object[] { "a", "as" };
+            yield return new object[] { "A", "As" };
+            yield return new object[] { "s", "ss" };
+            yield return new object[] { "S", "Ss" };
+            yield return new object[] { "z", "zs" };
+            yield return new object[] { "Z", "Zs" };
+            yield return new object[] { "1", "1s" };
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/Humanizer/Inflections/Vocabulary.cs
+++ b/src/Humanizer/Inflections/Vocabulary.cs
@@ -17,6 +17,7 @@ namespace Humanizer.Inflections
         private readonly List<Rule> _plurals = new List<Rule>();
         private readonly List<Rule> _singulars = new List<Rule>();
         private readonly List<string> _uncountables = new List<string>();
+        private readonly Regex _letterS = new Regex("^([sS])[sS]*$");
 
         /// <summary>
         /// Adds a word to the vocabulary which cannot easily be pluralized/singularized by RegEx, e.g. "person" and "people".
@@ -75,6 +76,12 @@ namespace Humanizer.Inflections
         /// <returns></returns>
         public string Pluralize(string word, bool inputIsKnownToBeSingular = true)
         {
+            var s = LetterS(word);
+            if (s != null)
+            {
+                return s + "s";
+            }
+
             var result = ApplyRules(_plurals, word, false);
 
             if (inputIsKnownToBeSingular)
@@ -101,6 +108,12 @@ namespace Humanizer.Inflections
         /// <returns></returns>
         public string Singularize(string word, bool inputIsKnownToBePlural = true, bool skipSimpleWords = false)
         {
+            var s = LetterS(word);
+            if (s != null)
+            {
+                return s;
+            }
+
             var result = ApplyRules(_singulars, word, skipSimpleWords);
 
             if (inputIsKnownToBePlural)
@@ -156,6 +169,15 @@ namespace Humanizer.Inflections
         private string MatchUpperCase(string word, string replacement)
         {
             return char.IsUpper(word[0]) && char.IsLower(replacement[0]) ? char.ToUpper(replacement[0]) + replacement.Substring(1) : replacement;
+        }
+
+        /// <summary>
+        /// If the word is the letter s, singular or plural, return the letter s singular
+        /// </summary>
+        private string LetterS(string word)
+        {
+            var s = _letterS.Match(word);
+            return s.Groups.Count > 1 ? s.Groups[1].Value : null;
         }
 
         private class Rule


### PR DESCRIPTION
Handle singularizing and pluralizing of letter 's'.

It is not sufficient to just handle singularizing of single letter words because letter 's' has a special meaning when singularizing and pluralizing.

Fixes #1154

---

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
