### PR TITLE
use dotnet build instead of vsbuild

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,10 +53,12 @@ stages:
         arguments: -c $(BuildConfiguration)
       displayName: Restore
 
-    - task: VSBuild@1
+    - task: DotNetCoreCLI@2
       inputs:
-        solution: .\src\Humanizer.sln
-        configuration: $(BuildConfiguration)
+        command: build
+        projects: .\src\Humanizer.sln
+        arguments: -c $(BuildConfiguration) --no-restore
+      displayName: Build
 
     - task: NuGetToolInstaller@1
 


### PR DESCRIPTION
This PR puts the build back to use `dotnet build` instead of `vsbuild`.
It demonstrates the error that is caused by https://github.com/dotnet/msbuild/issues/7331
This PR can be merged once the above mentioned issue is fixed and included in `windows-latest` build agent.

Fixes #1180, although not in the way suggested.

---

Here is a checklist you should tick through before submitting a pull request: 
 - [ ] Implementation is clean
 - [ ] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [ ] No Code Analysis warnings
 - [ ] There is proper unit test coverage
 - [ ] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [ ] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [ ] Xml documentation is added/updated for the addition/change
 - [ ] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [ ] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [ ] Readme is updated if you change an existing feature or add a new one
 - [ ] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
