### PR TITLE
Time format less resources

### DIFF
--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
@@ -1883,6 +1883,9 @@ namespace Humanizer.Localisation
         {
             public const string Never = "DateHumanize_Never";
             public const string Now = "DateHumanize_Now";
+            public const string SingleDay = "DateHumanize_SingleDay";
+            public const string SingleDayAgo = "DateHumanize_SingleDayAgo";
+            public const string SingleDayFromNow = "DateHumanize_SingleDayFromNow";
             public static string GetResourceKey(Humanizer.Localisation.TimeUnit timeUnit, Humanizer.Localisation.Tense timeUnitTense, int count = 1) { }
         }
         public class static TimeSpanHumanize

--- a/src/Humanizer/HeadingExtensions.cs
+++ b/src/Humanizer/HeadingExtensions.cs
@@ -27,8 +27,8 @@ namespace Humanizer
     /// </summary>
     public static class HeadingExtensions
     {
-        internal static readonly string[] headings = { "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW" };
-        internal static readonly char[] headingArrows = { '↑', '↗', '→', '↘', '↓', '↙', '←', '↖' };
+        internal static readonly string[] Headings = { "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW" };
+        internal static readonly char[] HeadingArrows = { '↑', '↗', '→', '↘', '↓', '↙', '←', '↖' };
 
         // https://stackoverflow.com/a/7490772/1720761
         /// <summary>
@@ -44,7 +44,7 @@ namespace Humanizer
         {
             var val = (int)((heading / 22.5) + .5);
 
-            var result = headings[val % 16];
+            var result = Headings[val % 16];
 
             if (style == HeadingStyle.Abbreviated)
             {
@@ -65,7 +65,7 @@ namespace Humanizer
         {
             var val = (int)((heading / 45) + .5);
 
-            return headingArrows[val % 8];
+            return HeadingArrows[val % 8];
         }
 
         /// <summary>
@@ -94,9 +94,9 @@ namespace Humanizer
             culture ??= CultureInfo.CurrentCulture;
 
             var upperCaseHeading = culture.TextInfo.ToUpper(heading);
-            for (var index = 0; index < headings.Length; ++index)
+            for (var index = 0; index < Headings.Length; ++index)
             {
-                var localizedShortHeading = Resources.GetResource($"{headings[index]}_Short", culture);
+                var localizedShortHeading = Resources.GetResource($"{Headings[index]}_Short", culture);
                 if (culture.CompareInfo.Compare(upperCaseHeading, localizedShortHeading) == 0)
                 {
                     return (index * 22.5);
@@ -111,7 +111,7 @@ namespace Humanizer
         /// </summary>
         public static double FromHeadingArrow(this char heading)
         {
-            var index = Array.IndexOf(headingArrows, heading);
+            var index = Array.IndexOf(HeadingArrows, heading);
             
             if (index == -1)
             {

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -93,7 +93,18 @@ namespace Humanizer.Localisation.Formatters
         private string GetResourceForDate(TimeUnit unit, Tense timeUnitTense, int count)
         {
             var resourceKey = ResourceKeys.DateHumanize.GetResourceKey(unit, timeUnitTense: timeUnitTense, count: count);
-            return count == 1 ? Format(resourceKey) : Format(resourceKey, count);
+            if (resourceKey == ResourceKeys.DateHumanize.SingleDay)
+            {
+                return Format(timeUnitTense == Tense.Future ? ResourceKeys.DateHumanize.SingleDayFromNow : ResourceKeys.DateHumanize.SingleDayAgo);
+            }
+            var unitValue = count == 1 ? Format(resourceKey) : Format(resourceKey, count);
+            if (resourceKey == ResourceKeys.DateHumanize.Now)
+            {
+                return unitValue;
+            }
+            var tenseKey = timeUnitTense == Tense.Future ? "DateHumanize_FromNow" : "DateHumanize_Ago";
+            var tenseValue = Format(tenseKey);
+            return tenseValue.FormatWith(unitValue);
         }
 
         private string GetResourceForTimeSpan(TimeUnit unit, int count, bool toWords = false)

--- a/src/Humanizer/Localisation/ResourceKeys.DateHumanize.cs
+++ b/src/Humanizer/Localisation/ResourceKeys.DateHumanize.cs
@@ -13,21 +13,33 @@
             public const string Now = "DateHumanize_Now";
 
             /// <summary>
+            /// Resource key for SingleDay.
+            /// </summary>
+            public const string SingleDay = "DateHumanize_SingleDay";
+
+            /// <summary>
+            /// Resource key for SingleDayAgo.
+            /// </summary>
+            public const string SingleDayAgo = "DateHumanize_SingleDayAgo";
+
+            /// <summary>
+            /// Resource key for SingleDayFromNow.
+            /// </summary>
+            public const string SingleDayFromNow = "DateHumanize_SingleDayFromNow";
+
+            /// <summary>
             /// Resource key for Never.
             /// </summary>
             public const string Never = "DateHumanize_Never";
 
             /// <summary>
-            /// Examples: DateHumanize_SingleMinuteAgo, DateHumanize_MultipleHoursAgo
+            /// Examples: DateHumanize_SingleMinute, DateHumanize_MultipleHours
             /// Note: "s" for plural served separately by third part.
             /// </summary>
-            private const string DateTimeFormat = "DateHumanize_{0}{1}{2}";
-
-            private const string Ago = "Ago";
-            private const string FromNow = "FromNow";
+            private const string DateTimeFormat = "DateHumanize_{0}{1}";
 
             /// <summary>
-            /// Generates Resource Keys accordning to convention.
+            /// Generates Resource Keys according to convention.
             /// </summary>
             /// <param name="timeUnit">Time unit</param>
             /// <param name="timeUnitTense">Is time unit in future or past</param>
@@ -35,6 +47,8 @@
             /// <returns>Resource key, like DateHumanize_SingleMinuteAgo</returns>
             public static string GetResourceKey(TimeUnit timeUnit, Tense timeUnitTense, int count = 1)
             {
+                // TODO remove timeUnitTense parameter
+
                 ValidateRange(count);
 
                 if (count == 0)
@@ -43,9 +57,8 @@
                 }
 
                 var singularity = count == 1 ? Single : Multiple;
-                var tense = timeUnitTense == Tense.Future ? FromNow : Ago;
                 var unit = timeUnit.ToString().ToQuantity(count, ShowQuantityAs.None);
-                return DateTimeFormat.FormatWith(singularity, unit, tense);
+                return DateTimeFormat.FormatWith(singularity, unit);
             }
         }
     }

--- a/src/Humanizer/Properties/Resources.es.resx
+++ b/src/Humanizer/Properties/Resources.es.resx
@@ -117,41 +117,44 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="DateHumanize_SingleSecondAgo" xml:space="preserve">
-    <value>hace un segundo</value>
+  <data name="DateHumanize_Ago" xml:space="preserve">
+    <value>hace {0}</value>
   </data>
-  <data name="DateHumanize_MultipleSecondsAgo" xml:space="preserve">
-    <value>hace {0} segundos</value>
+  <data name="DateHumanize_SingleSecond" xml:space="preserve">
+    <value>un segundo</value>
   </data>
-  <data name="DateHumanize_SingleMinuteAgo" xml:space="preserve">
-    <value>hace un minuto</value>
+  <data name="DateHumanize_MultipleSeconds" xml:space="preserve">
+    <value>{0} segundos</value>
   </data>
-  <data name="DateHumanize_MultipleMinutesAgo" xml:space="preserve">
-    <value>hace {0} minutos</value>
+  <data name="DateHumanize_SingleMinute" xml:space="preserve">
+    <value>un minuto</value>
   </data>
-  <data name="DateHumanize_SingleHourAgo" xml:space="preserve">
-    <value>hace una hora</value>
+  <data name="DateHumanize_MultipleMinutes" xml:space="preserve">
+    <value>{0} minutos</value>
   </data>
-  <data name="DateHumanize_MultipleHoursAgo" xml:space="preserve">
-    <value>hace {0} horas</value>
+  <data name="DateHumanize_SingleHour" xml:space="preserve">
+    <value>una hora</value>
+  </data>
+  <data name="DateHumanize_MultipleHours" xml:space="preserve">
+    <value>{0} horas</value>
   </data>
   <data name="DateHumanize_SingleDayAgo" xml:space="preserve">
     <value>ayer</value>
   </data>
-  <data name="DateHumanize_MultipleDaysAgo" xml:space="preserve">
-    <value>hace {0} días</value>
+  <data name="DateHumanize_MultipleDays" xml:space="preserve">
+    <value>{0} días</value>
   </data>
-  <data name="DateHumanize_SingleMonthAgo" xml:space="preserve">
-    <value>hace un mes</value>
+  <data name="DateHumanize_SingleMonth" xml:space="preserve">
+    <value>un mes</value>
   </data>
-  <data name="DateHumanize_MultipleMonthsAgo" xml:space="preserve">
-    <value>hace {0} meses</value>
+  <data name="DateHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} meses</value>
   </data>
-  <data name="DateHumanize_SingleYearAgo" xml:space="preserve">
-    <value>hace un año</value>
+  <data name="DateHumanize_SingleYear" xml:space="preserve">
+    <value>un año</value>
   </data>
-  <data name="DateHumanize_MultipleYearsAgo" xml:space="preserve">
-    <value>hace {0} años</value>
+  <data name="DateHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} años</value>
   </data>
   <data name="TimeSpanHumanize_MultipleDays" xml:space="preserve">
     <value>{0} días</value>
@@ -192,41 +195,11 @@
   <data name="TimeSpanHumanize_Zero" xml:space="preserve">
     <value>nada</value>
   </data>
-  <data name="DateHumanize_MultipleDaysFromNow" xml:space="preserve">
-    <value>en {0} días</value>
-  </data>
-  <data name="DateHumanize_MultipleHoursFromNow" xml:space="preserve">
-    <value>en {0} horas</value>
-  </data>
-  <data name="DateHumanize_MultipleMinutesFromNow" xml:space="preserve">
-    <value>en {0} minutos</value>
-  </data>
-  <data name="DateHumanize_MultipleMonthsFromNow" xml:space="preserve">
-    <value>en {0} meses</value>
-  </data>
-  <data name="DateHumanize_MultipleSecondsFromNow" xml:space="preserve">
-    <value>en {0} segundos</value>
-  </data>
-  <data name="DateHumanize_MultipleYearsFromNow" xml:space="preserve">
-    <value>en {0} años</value>
+  <data name="DateHumanize_FromNow" xml:space="preserve">
+    <value>en {0}</value>
   </data>
   <data name="DateHumanize_SingleDayFromNow" xml:space="preserve">
     <value>mañana</value>
-  </data>
-  <data name="DateHumanize_SingleHourFromNow" xml:space="preserve">
-    <value>en una hora</value>
-  </data>
-  <data name="DateHumanize_SingleMinuteFromNow" xml:space="preserve">
-    <value>en un minuto</value>
-  </data>
-  <data name="DateHumanize_SingleMonthFromNow" xml:space="preserve">
-    <value>en un mes</value>
-  </data>
-  <data name="DateHumanize_SingleSecondFromNow" xml:space="preserve">
-    <value>en un segundo</value>
-  </data>
-  <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
-    <value>en un año</value>
   </data>
   <data name="DateHumanize_Now" xml:space="preserve">
     <value>ahora</value>

--- a/src/Humanizer/Properties/Resources.resx
+++ b/src/Humanizer/Properties/Resources.resx
@@ -117,41 +117,38 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="DateHumanize_SingleSecondAgo" xml:space="preserve">
-    <value>one second ago</value>
+  <data name="DateHumanize_Ago" xml:space="preserve">
+    <value>{0} ago</value>
   </data>
-  <data name="DateHumanize_MultipleSecondsAgo" xml:space="preserve">
-    <value>{0} seconds ago</value>
+  <data name="DateHumanize_SingleSecond" xml:space="preserve">
+    <value>one second</value>
   </data>
-  <data name="DateHumanize_SingleMinuteAgo" xml:space="preserve">
-    <value>a minute ago</value>
+  <data name="DateHumanize_MultipleSeconds" xml:space="preserve">
+    <value>{0} seconds</value>
   </data>
-  <data name="DateHumanize_MultipleMinutesAgo" xml:space="preserve">
-    <value>{0} minutes ago</value>
+  <data name="DateHumanize_SingleHour" xml:space="preserve">
+    <value>an hour</value>
   </data>
-  <data name="DateHumanize_SingleHourAgo" xml:space="preserve">
-    <value>an hour ago</value>
-  </data>
-  <data name="DateHumanize_MultipleHoursAgo" xml:space="preserve">
-    <value>{0} hours ago</value>
+  <data name="DateHumanize_MultipleHours" xml:space="preserve">
+    <value>{0} hours</value>
   </data>
   <data name="DateHumanize_SingleDayAgo" xml:space="preserve">
     <value>yesterday</value>
   </data>
-  <data name="DateHumanize_MultipleDaysAgo" xml:space="preserve">
-    <value>{0} days ago</value>
+  <data name="DateHumanize_MultipleDays" xml:space="preserve">
+    <value>{0} days</value>
   </data>
-  <data name="DateHumanize_SingleMonthAgo" xml:space="preserve">
-    <value>one month ago</value>
+  <data name="DateHumanize_SingleMonth" xml:space="preserve">
+    <value>one month</value>
   </data>
-  <data name="DateHumanize_MultipleMonthsAgo" xml:space="preserve">
-    <value>{0} months ago</value>
+  <data name="DateHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} months</value>
   </data>
-  <data name="DateHumanize_SingleYearAgo" xml:space="preserve">
-    <value>one year ago</value>
+  <data name="DateHumanize_SingleYear" xml:space="preserve">
+    <value>one year</value>
   </data>
-  <data name="DateHumanize_MultipleYearsAgo" xml:space="preserve">
-    <value>{0} years ago</value>
+  <data name="DateHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} years</value>
   </data>
   <data name="TimeSpanHumanize_MultipleDays" xml:space="preserve">
     <value>{0} days</value>
@@ -192,23 +189,11 @@
   <data name="TimeSpanHumanize_SingleWeek" xml:space="preserve">
     <value>1 week</value>
   </data>
-  <data name="DateHumanize_MultipleDaysFromNow" xml:space="preserve">
-    <value>{0} days from now</value>
+  <data name="DateHumanize_FromNow" xml:space="preserve">
+    <value>{0} from now</value>
   </data>
-  <data name="DateHumanize_MultipleHoursFromNow" xml:space="preserve">
-    <value>{0} hours from now</value>
-  </data>
-  <data name="DateHumanize_MultipleMinutesFromNow" xml:space="preserve">
-    <value>{0} minutes from now</value>
-  </data>
-  <data name="DateHumanize_MultipleMonthsFromNow" xml:space="preserve">
-    <value>{0} months from now</value>
-  </data>
-  <data name="DateHumanize_MultipleSecondsFromNow" xml:space="preserve">
-    <value>{0} seconds from now</value>
-  </data>
-  <data name="DateHumanize_MultipleYearsFromNow" xml:space="preserve">
-    <value>{0} years from now</value>
+  <data name="DateHumanize_MultipleMinutes" xml:space="preserve">
+    <value>{0} minutes</value>
   </data>
   <data name="DateHumanize_Now" xml:space="preserve">
     <value>now</value>
@@ -216,20 +201,8 @@
   <data name="DateHumanize_SingleDayFromNow" xml:space="preserve">
     <value>tomorrow</value>
   </data>
-  <data name="DateHumanize_SingleHourFromNow" xml:space="preserve">
-    <value>an hour from now</value>
-  </data>
-  <data name="DateHumanize_SingleMinuteFromNow" xml:space="preserve">
-    <value>a minute from now</value>
-  </data>
-  <data name="DateHumanize_SingleMonthFromNow" xml:space="preserve">
-    <value>one month from now</value>
-  </data>
-  <data name="DateHumanize_SingleSecondFromNow" xml:space="preserve">
-    <value>one second from now</value>
-  </data>
-  <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
-    <value>one year from now</value>
+  <data name="DateHumanize_SingleMinute" xml:space="preserve">
+    <value>a minute</value>
   </data>
   <data name="DateHumanize_MultipleHoursFromNow_Dual" xml:space="preserve">
     <value>{0} hours from now</value>

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -13,9 +13,9 @@ namespace Humanizer
     /// </summary>
     public static class TimeSpanHumanizeExtensions
     {
-        private const int _daysInAWeek = 7;
-        private const double _daysInAYear = 365.2425; // see https://en.wikipedia.org/wiki/Gregorian_calendar
-        private const double _daysInAMonth = _daysInAYear / 12;
+        private const int DaysInAWeek = 7;
+        private const double DaysInAYear = 365.2425; // see https://en.wikipedia.org/wiki/Gregorian_calendar
+        private const double DaysInAMonth = DaysInAYear / 12;
 
         /// <summary>
         /// Turns a TimeSpan into a human readable form. E.g. 1 day.
@@ -125,25 +125,25 @@ namespace Humanizer
         {
             if (isTimeUnitToGetTheMaximumTimeUnit)
             {
-                return (int)(timespan.Days / _daysInAMonth);
+                return (int)(timespan.Days / DaysInAMonth);
             }
             else
             {
-                var remainingDays = timespan.Days % _daysInAYear;
-                return (int)(remainingDays / _daysInAMonth);
+                var remainingDays = timespan.Days % DaysInAYear;
+                return (int)(remainingDays / DaysInAMonth);
             }
         }
 
         private static int GetSpecialCaseYearAsInteger(TimeSpan timespan)
         {
-            return (int)(timespan.Days / _daysInAYear);
+            return (int)(timespan.Days / DaysInAYear);
         }
 
         private static int GetSpecialCaseWeeksAsInteger(TimeSpan timespan, bool isTimeUnitToGetTheMaximumTimeUnit)
         {
-            if (isTimeUnitToGetTheMaximumTimeUnit || timespan.Days < _daysInAMonth)
+            if (isTimeUnitToGetTheMaximumTimeUnit || timespan.Days < DaysInAMonth)
             {
-                return timespan.Days / _daysInAWeek;
+                return timespan.Days / DaysInAWeek;
             }
             return 0;
         }
@@ -154,12 +154,12 @@ namespace Humanizer
             {
                 return timespan.Days;
             }
-            if (timespan.Days < _daysInAMonth || maximumTimeUnit == TimeUnit.Week)
+            if (timespan.Days < DaysInAMonth || maximumTimeUnit == TimeUnit.Week)
             {
-                var remainingDays = timespan.Days % _daysInAWeek;
+                var remainingDays = timespan.Days % DaysInAWeek;
                 return remainingDays;
             }
-            return (int)(timespan.Days % _daysInAMonth);
+            return (int)(timespan.Days % DaysInAMonth);
         }
 
         private static int GetNormalCaseTimeAsInteger(int timeNumberOfUnits, double totalTimeNumberOfUnits, bool isTimeUnitToGetTheMaximumTimeUnit)


### PR DESCRIPTION
This PR is a work in progress. Comments are welcome to help guide the progress.

Use double formatting as suggested in https://github.com/Humanizr/Humanizer/issues/571#issuecomment-300205885 in order to reduce the number of translated string resources needed for #1183

Put this on hold because there's a lot more to do, and maybe it's not even helping for #1183, so I'll get back to that.

---

Here is a checklist you should tick through before submitting a pull request: 
 - [ ] Implementation is clean
 - [ ] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [ ] No Code Analysis warnings
 - [ ] There is proper unit test coverage
 - [ ] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [ ] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [ ] Xml documentation is added/updated for the addition/change
 - [ ] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [ ] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [ ] Readme is updated if you change an existing feature or add a new one
 - [ ] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
