### PR TITLE
fix DateOnly has current date return 'today'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -355,7 +355,7 @@ The default precision is set to .75 but you can pass your desired precision too.
 104 seconds => one minute ago/from now
 105 seconds => two minutes ago/from now
 
-25 days => a month ago/from now
+25 days => a month ago/from today
 ```
 
 **No dehumanization for dates as `Humanize` is a lossy transformation and the human friendly date is not reversible**

--- a/src/Humanizer.Tests.Shared/DateHumanizeDefaultStrategyTests.cs
+++ b/src/Humanizer.Tests.Shared/DateHumanizeDefaultStrategyTests.cs
@@ -76,7 +76,7 @@ namespace Humanizer.Tests
 
         [Theory]
         [InlineData(38, "tomorrow")]
-        [InlineData(40, "2 days from now")]
+        [InlineData(40, "2 days from today")]
         public void HoursFromNowNotTomorrow(int hours, string expected)
         {
             //Only test with injected date, as results are dependent on time of day
@@ -98,9 +98,9 @@ namespace Humanizer.Tests
 
         [Theory]
         [InlineData(1, "tomorrow")]
-        [InlineData(10, "10 days from now")]
-        [InlineData(27, "27 days from now")]
-        [InlineData(32, "one month from now")]
+        [InlineData(10, "10 days from today")]
+        [InlineData(27, "27 days from today")]
+        [InlineData(32, "one month from today")]
         public void DaysFromNow(int days, string expected)
         {
             DateHumanize.Verify(expected, days, TimeUnit.Day, Tense.Future);
@@ -117,10 +117,10 @@ namespace Humanizer.Tests
         }
 
         [Theory]
-        [InlineData(1, "one month from now")]
-        [InlineData(10, "10 months from now")]
-        [InlineData(11, "11 months from now")]
-        [InlineData(12, "one year from now")]
+        [InlineData(1, "one month from today")]
+        [InlineData(10, "10 months from today")]
+        [InlineData(11, "11 months from today")]
+        [InlineData(12, "one year from today")]
         public void MonthsFromNow(int months, string expected)
         {
             DateHumanize.Verify(expected, months, TimeUnit.Month, Tense.Future);
@@ -135,8 +135,8 @@ namespace Humanizer.Tests
         }
 
         [Theory]
-        [InlineData(1, "one year from now")]
-        [InlineData(2, "2 years from now")]
+        [InlineData(1, "one year from today")]
+        [InlineData(2, "2 years from today")]
         public void YearsFromNow(int years, string expected)
         {
             DateHumanize.Verify(expected, years, TimeUnit.Year, Tense.Future);
@@ -164,7 +164,7 @@ namespace Humanizer.Tests
         }
 
         [Theory]
-        [InlineData(1, TimeUnit.Year, Tense.Future, "en-US", "one year from now")]
+        [InlineData(1, TimeUnit.Year, Tense.Future, "en-US", "one year from today")]
         [InlineData(40, TimeUnit.Second, Tense.Past, "ru-RU", "40 секунд назад")]
         [InlineData(2, TimeUnit.Day, Tense.Past, "sv-SE", "för 2 dagar sedan")]
         public void CanSpecifyCultureExplicitly(int unit, TimeUnit timeUnit, Tense tense, string culture, string expected)

--- a/src/Humanizer.Tests.Shared/DateOnlyHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/DateOnlyHumanizeTests.cs
@@ -33,7 +33,7 @@ namespace Humanizer.Tests
             var inputTime = new DateOnly(2015, 08, 05);
             var baseTime = new DateOnly(2015, 07, 05);
 
-            const string expectedResult = "one month from now";
+            const string expectedResult = "one month from today";
             var actualResult = inputTime.Humanize(baseTime);
 
             Assert.Equal(expectedResult, actualResult);

--- a/src/Humanizer.Tests.Shared/DateTimeHumanizePrecisionStrategyTests.cs
+++ b/src/Humanizer.Tests.Shared/DateTimeHumanizePrecisionStrategyTests.cs
@@ -110,9 +110,9 @@ namespace Humanizer.Tests
         [InlineData(18, "tomorrow")]
         [InlineData(24, "tomorrow")]
         [InlineData(41, "tomorrow")]
-        [InlineData(42, "2 days from now")]
-        [InlineData(48, "2 days from now")]
-        [InlineData(60, "2 days from now")]
+        [InlineData(42, "2 days from today")]
+        [InlineData(48, "2 days from today")]
+        [InlineData(60, "2 days from today")]
         public void HoursFromNow(int hours, string expected)
         {
             DateHumanize.Verify(expected, hours, TimeUnit.Hour, Tense.Future, DefaultPrecision);
@@ -134,13 +134,13 @@ namespace Humanizer.Tests
 
         [Theory]
         [InlineData(1, "tomorrow")]
-        [InlineData(10, "10 days from now")]
-        [InlineData(20, "20 days from now")]
-        [InlineData(22, "22 days from now")]
-        [InlineData(23, "one month from now")]
-        [InlineData(31, "one month from now")]
-        [InlineData(43, "one month from now")]
-        [InlineData(53, "2 months from now")]
+        [InlineData(10, "10 days from today")]
+        [InlineData(20, "20 days from today")]
+        [InlineData(22, "22 days from today")]
+        [InlineData(23, "one month from today")]
+        [InlineData(31, "one month from today")]
+        [InlineData(43, "one month from today")]
+        [InlineData(53, "2 months from today")]
         public void DaysFromNow(int days, string expected)
         {
             DateHumanize.Verify(expected, days, TimeUnit.Day, Tense.Future, DefaultPrecision);
@@ -160,13 +160,13 @@ namespace Humanizer.Tests
         }
 
         [Theory]
-        [InlineData(1, "one month from now")]
-        [InlineData(8, "8 months from now")]
-        [InlineData(9, "one year from now")]
-        [InlineData(12, "one year from now")]
-        [InlineData(19, "one year from now")]
-        [InlineData(21, "2 years from now")]
-        [InlineData(24, "2 years from now")]
+        [InlineData(1, "one month from today")]
+        [InlineData(8, "8 months from today")]
+        [InlineData(9, "one year from today")]
+        [InlineData(12, "one year from today")]
+        [InlineData(19, "one year from today")]
+        [InlineData(21, "2 years from today")]
+        [InlineData(24, "2 years from today")]
         public void MonthsFromNow(int months, string expected)
         {
             DateHumanize.Verify(expected, months, TimeUnit.Month, Tense.Future, DefaultPrecision);
@@ -181,8 +181,8 @@ namespace Humanizer.Tests
         }
 
         [Theory]
-        [InlineData(1, "one year from now")]
-        [InlineData(2, "2 years from now")]
+        [InlineData(1, "one year from today")]
+        [InlineData(2, "2 years from today")]
         public void YearsFromNow(int years, string expected)
         {
             DateHumanize.Verify(expected, years, TimeUnit.Year, Tense.Future, DefaultPrecision);

--- a/src/Humanizer.Tests.Shared/Localisation/ar/DateHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/ar/DateHumanizeTests.cs
@@ -19,7 +19,7 @@ namespace Humanizer.Tests.Localisation.ar
         [Theory]
         [InlineData(1, "في غضون يوم واحد من الآن")]
         [InlineData(2, "في غضون يومين من الآن")]
-        [InlineData(10, "في غضون 10 أيام من الآن")]
+        [InlineData(10, "في غضون 10 يوم من اليوم")]
         [InlineData(17, "في غضون 17 يوم من اليوم")]
         public void DaysFromNow(int days, string expected)
         {

--- a/src/Humanizer.Tests.Shared/Localisation/ar/DateHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/ar/DateHumanizeTests.cs
@@ -19,7 +19,7 @@ namespace Humanizer.Tests.Localisation.ar
         [Theory]
         [InlineData(1, "في غضون يوم واحد من الآن")]
         [InlineData(2, "في غضون يومين من الآن")]
-        [InlineData(10, "في غضون 10 أيام من الآن")]
+        [InlineData(10,"في غضون 10 يوم من اليوم")]
         [InlineData(17, "في غضون 17 يوم من الآن")]
         public void DaysFromNow(int days, string expected)
         {

--- a/src/Humanizer.Tests.Shared/Localisation/ar/DateHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/ar/DateHumanizeTests.cs
@@ -20,7 +20,7 @@ namespace Humanizer.Tests.Localisation.ar
         [InlineData(1, "في غضون يوم واحد من الآن")]
         [InlineData(2, "في غضون يومين من الآن")]
         [InlineData(10, "في غضون 10 أيام من الآن")]
-        [InlineData(17, "في غضون 17 يوم من الآن")]
+        [InlineData(17, "في غضون 17 يوم من اليوم")]
         public void DaysFromNow(int days, string expected)
         {
             DateHumanize.Verify(expected, days, TimeUnit.Day, Tense.Future);

--- a/src/Humanizer.Tests.Shared/Localisation/id/DateHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/id/DateHumanizeTests.cs
@@ -82,7 +82,7 @@ namespace Humanizer.Tests.Localisation.id
 
         [Theory]
         [InlineData(1, "sebulan dari sekarang")]
-        [InlineData(10, "10 bulan dari sekarang")]
+        [InlineData(10, "sebulan dari hari ini")]
         public void MonthsFromNow(int months, string expected)
         {
             DateHumanize.Verify(expected, months, TimeUnit.Month, Tense.Future);
@@ -97,8 +97,8 @@ namespace Humanizer.Tests.Localisation.id
         }
 
         [Theory]
-        [InlineData(1, "setahun dari sekarang")]
-        [InlineData(2, "2 tahun dari sekarang")]
+        [InlineData(1, "setahun dari hari ini")]
+        [InlineData(2, "2 tahun dari hari ini")]
         public void YearsFromNow(int years, string expected)
         {
             DateHumanize.Verify(expected, years, TimeUnit.Year, Tense.Future);

--- a/src/Humanizer.Tests.Shared/Localisation/id/DateHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/id/DateHumanizeTests.cs
@@ -81,7 +81,7 @@ namespace Humanizer.Tests.Localisation.id
         }
 
         [Theory]
-        [InlineData(1, "sebulan dari dari hari ini")]
+        [InlineData(1, "sebulan dari hari ini")]
         [InlineData(10, "10 bulan dari hari ini")]
        public void MonthsFromNow(int months, string expected)
         {

--- a/src/Humanizer.Tests.Shared/Localisation/id/DateHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/id/DateHumanizeTests.cs
@@ -82,7 +82,7 @@ namespace Humanizer.Tests.Localisation.id
 
         [Theory]
         [InlineData(1, "sebulan dari sekarang")]
-        [InlineData(10, "sebulan dari hari ini")]
+        [InlineData(10, "10 bulan dari hari ini")]
        public void MonthsFromNow(int months, string expected)
         {
             DateHumanize.Verify(expected, months, TimeUnit.Month, Tense.Future);

--- a/src/Humanizer.Tests.Shared/Localisation/id/DateHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/id/DateHumanizeTests.cs
@@ -81,7 +81,7 @@ namespace Humanizer.Tests.Localisation.id
         }
 
         [Theory]
-        [InlineData(1, "sebulan dari sekarang")]
+        [InlineData(1, "sebulan dari dari hari ini")]
         [InlineData(10, "10 bulan dari hari ini")]
        public void MonthsFromNow(int months, string expected)
         {

--- a/src/Humanizer.Tests.Shared/Localisation/id/DateHumanizeTests.cs
+++ b/src/Humanizer.Tests.Shared/Localisation/id/DateHumanizeTests.cs
@@ -66,7 +66,7 @@ namespace Humanizer.Tests.Localisation.id
 
         [Theory]
         [InlineData(1, "besok")]
-        [InlineData(10, "10 hari dari sekarang")]
+        [InlineData(10, "10 hari dari hari ini")]
         public void DaysFromNow(int days, string expected)
         {
             DateHumanize.Verify(expected, days, TimeUnit.Day, Tense.Future);
@@ -82,7 +82,7 @@ namespace Humanizer.Tests.Localisation.id
 
         [Theory]
         [InlineData(1, "sebulan dari sekarang")]
-        [InlineData(10, "10 bulan dari sekarang")]
+        [InlineData(10, "10 bulan dari hari ini")]
         public void MonthsFromNow(int months, string expected)
         {
             DateHumanize.Verify(expected, months, TimeUnit.Month, Tense.Future);

--- a/src/Humanizer/FluentDate/In.SomeTimeFrom.cs
+++ b/src/Humanizer/FluentDate/In.SomeTimeFrom.cs
@@ -61,7 +61,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 1 days from now
+			/// 1 days from today
 			/// </summary>
 			public static DateTime Day
 			{
@@ -77,7 +77,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 1 weeks from now
+			/// 1 weeks from today
 			/// </summary>
 			public static DateTime Week
 			{
@@ -93,7 +93,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 1 months from now
+			/// 1 months from today
 			/// </summary>
 			public static DateTime Month
 			{
@@ -109,7 +109,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 1 years from now
+			/// 1 years from today
 			/// </summary>
 			public static DateTime Year
 			{
@@ -178,7 +178,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 2 days from now
+			/// 2 days from today
 			/// </summary>
 			public static DateTime Days
 			{
@@ -194,7 +194,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 2 weeks from now
+			/// 2 weeks from today
 			/// </summary>
 			public static DateTime Weeks
 			{
@@ -210,7 +210,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 2 months from now
+			/// 2 months from today
 			/// </summary>
 			public static DateTime Months
 			{
@@ -226,7 +226,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 2 years from now
+			/// 2 years from today
 			/// </summary>
 			public static DateTime Years
 			{
@@ -295,7 +295,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 3 days from now
+			/// 3 days from today
 			/// </summary>
 			public static DateTime Days
 			{
@@ -311,7 +311,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 3 weeks from now
+			/// 3 weeks from today
 			/// </summary>
 			public static DateTime Weeks
 			{
@@ -327,7 +327,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 3 months from now
+			/// 3 months from today
 			/// </summary>
 			public static DateTime Months
 			{
@@ -343,7 +343,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 3 years from now
+			/// 3 years from today
 			/// </summary>
 			public static DateTime Years
 			{
@@ -412,7 +412,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 4 days from now
+			/// 4 days from today
 			/// </summary>
 			public static DateTime Days
 			{
@@ -428,7 +428,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 4 weeks from now
+			/// 4 weeks from today
 			/// </summary>
 			public static DateTime Weeks
 			{
@@ -444,7 +444,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 4 months from now
+			/// 4 months from today
 			/// </summary>
 			public static DateTime Months
 			{
@@ -460,7 +460,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 4 years from now
+			/// 4 years from today
 			/// </summary>
 			public static DateTime Years
 			{
@@ -529,7 +529,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 5 days from now
+			/// 5 days from today
 			/// </summary>
 			public static DateTime Days
 			{
@@ -545,7 +545,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 5 weeks from now
+			/// 5 weeks from today
 			/// </summary>
 			public static DateTime Weeks
 			{
@@ -561,7 +561,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 5 months from now
+			/// 5 months from today
 			/// </summary>
 			public static DateTime Months
 			{
@@ -577,7 +577,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 5 years from now
+			/// 5 years from today
 			/// </summary>
 			public static DateTime Years
 			{
@@ -646,7 +646,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 6 days from now
+			/// 6 days from today
 			/// </summary>
 			public static DateTime Days
 			{
@@ -662,7 +662,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 6 weeks from now
+			/// 6 weeks from today
 			/// </summary>
 			public static DateTime Weeks
 			{
@@ -678,7 +678,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 6 months from now
+			/// 6 months from today
 			/// </summary>
 			public static DateTime Months
 			{
@@ -694,7 +694,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 6 years from now
+			/// 6 years from today
 			/// </summary>
 			public static DateTime Years
 			{
@@ -763,7 +763,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 7 days from now
+			/// 7 days from today
 			/// </summary>
 			public static DateTime Days
 			{
@@ -779,7 +779,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 7 weeks from now
+			/// 7 weeks from today
 			/// </summary>
 			public static DateTime Weeks
 			{
@@ -795,7 +795,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 7 months from now
+			/// 7 months from today
 			/// </summary>
 			public static DateTime Months
 			{
@@ -811,7 +811,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 7 years from now
+			/// 7 years from today
 			/// </summary>
 			public static DateTime Years
 			{
@@ -880,7 +880,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 8 days from now
+			/// 8 days from today
 			/// </summary>
 			public static DateTime Days
 			{
@@ -896,7 +896,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 8 weeks from now
+			/// 8 weeks from today
 			/// </summary>
 			public static DateTime Weeks
 			{
@@ -912,7 +912,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 8 months from now
+			/// 8 months from today
 			/// </summary>
 			public static DateTime Months
 			{
@@ -928,7 +928,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 8 years from now
+			/// 8 years from today
 			/// </summary>
 			public static DateTime Years
 			{
@@ -997,7 +997,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 9 days from now
+			/// 9 days from today
 			/// </summary>
 			public static DateTime Days
 			{
@@ -1013,7 +1013,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 9 weeks from now
+			/// 9 weeks from today
 			/// </summary>
 			public static DateTime Weeks
 			{
@@ -1029,7 +1029,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 9 months from now
+			/// 9 months from today
 			/// </summary>
 			public static DateTime Months
 			{
@@ -1045,7 +1045,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 9 years from now
+			/// 9 years from today
 			/// </summary>
 			public static DateTime Years
 			{
@@ -1114,7 +1114,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 10 days from now
+			/// 10 days from today
 			/// </summary>
 			public static DateTime Days
 			{
@@ -1130,7 +1130,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 10 weeks from now
+			/// 10 weeks from today
 			/// </summary>
 			public static DateTime Weeks
 			{
@@ -1146,7 +1146,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 10 months from now
+			/// 10 months from today
 			/// </summary>
 			public static DateTime Months
 			{
@@ -1162,7 +1162,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 10 years from now
+			/// 10 years from today
 			/// </summary>
 			public static DateTime Years
 			{

--- a/src/Humanizer/FluentDate/In.SomeTimeFrom.tt
+++ b/src/Humanizer/FluentDate/In.SomeTimeFrom.tt
@@ -82,7 +82,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// <#= i #> days from now
+			/// <#= i #> days from today
 			/// </summary>
 			public static DateTime <#= day #>
 			{
@@ -98,7 +98,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// <#= i #> weeks from now
+			/// <#= i #> weeks from today
 			/// </summary>
 			public static DateTime <#= week #>
 			{
@@ -114,7 +114,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// <#= i #> months from now
+			/// <#= i #> months from today
 			/// </summary>
 			public static DateTime <#= month #>
 			{
@@ -130,7 +130,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// <#= i #> years from now
+			/// <#= i #> years from today
 			/// </summary>
 			public static DateTime <#= year #>
 			{

--- a/src/Humanizer/FluentDate/InDate.SomeTimeFrom.cs
+++ b/src/Humanizer/FluentDate/InDate.SomeTimeFrom.cs
@@ -15,7 +15,7 @@ namespace Humanizer
 		public static class One
 		{
 			/// <summary>
-			/// 1 days from now
+			/// 1 days from today
 			/// </summary>
 			public static DateOnly Day
 			{
@@ -39,7 +39,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 1 weeks from now
+			/// 1 weeks from today
 			/// </summary>
 			public static DateOnly Week
 			{
@@ -63,7 +63,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 1 months from now
+			/// 1 months from today
 			/// </summary>
 			public static DateOnly Month
 			{
@@ -87,7 +87,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 1 years from now
+			/// 1 years from today
 			/// </summary>
 			public static DateOnly Year
 			{
@@ -116,7 +116,7 @@ namespace Humanizer
 		public static class Two
 		{
 			/// <summary>
-			/// 2 days from now
+			/// 2 days from today
 			/// </summary>
 			public static DateOnly Days
 			{
@@ -140,7 +140,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 2 weeks from now
+			/// 2 weeks from today
 			/// </summary>
 			public static DateOnly Weeks
 			{
@@ -164,7 +164,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 2 months from now
+			/// 2 months from today
 			/// </summary>
 			public static DateOnly Months
 			{
@@ -188,7 +188,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 2 years from now
+			/// 2 years from today
 			/// </summary>
 			public static DateOnly Years
 			{
@@ -217,7 +217,7 @@ namespace Humanizer
 		public static class Three
 		{
 			/// <summary>
-			/// 3 days from now
+			/// 3 days from today
 			/// </summary>
 			public static DateOnly Days
 			{
@@ -241,7 +241,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 3 weeks from now
+			/// 3 weeks from today
 			/// </summary>
 			public static DateOnly Weeks
 			{
@@ -265,7 +265,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 3 months from now
+			/// 3 months from today
 			/// </summary>
 			public static DateOnly Months
 			{
@@ -289,7 +289,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 3 years from now
+			/// 3 years from today
 			/// </summary>
 			public static DateOnly Years
 			{
@@ -318,7 +318,7 @@ namespace Humanizer
 		public static class Four
 		{
 			/// <summary>
-			/// 4 days from now
+			/// 4 days from today
 			/// </summary>
 			public static DateOnly Days
 			{
@@ -342,7 +342,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 4 weeks from now
+			/// 4 weeks from today
 			/// </summary>
 			public static DateOnly Weeks
 			{
@@ -366,7 +366,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 4 months from now
+			/// 4 months from today
 			/// </summary>
 			public static DateOnly Months
 			{
@@ -390,7 +390,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 4 years from now
+			/// 4 years from today
 			/// </summary>
 			public static DateOnly Years
 			{
@@ -419,7 +419,7 @@ namespace Humanizer
 		public static class Five
 		{
 			/// <summary>
-			/// 5 days from now
+			/// 5 days from today
 			/// </summary>
 			public static DateOnly Days
 			{
@@ -443,7 +443,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 5 weeks from now
+			/// 5 weeks from today
 			/// </summary>
 			public static DateOnly Weeks
 			{
@@ -467,7 +467,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 5 months from now
+			/// 5 months from today
 			/// </summary>
 			public static DateOnly Months
 			{
@@ -491,7 +491,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 5 years from now
+			/// 5 years from today
 			/// </summary>
 			public static DateOnly Years
 			{
@@ -520,7 +520,7 @@ namespace Humanizer
 		public static class Six
 		{
 			/// <summary>
-			/// 6 days from now
+			/// 6 days from today
 			/// </summary>
 			public static DateOnly Days
 			{
@@ -544,7 +544,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 6 weeks from now
+			/// 6 weeks from today
 			/// </summary>
 			public static DateOnly Weeks
 			{
@@ -568,7 +568,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 6 months from now
+			/// 6 months from today
 			/// </summary>
 			public static DateOnly Months
 			{
@@ -592,7 +592,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 6 years from now
+			/// 6 years from today
 			/// </summary>
 			public static DateOnly Years
 			{
@@ -621,7 +621,7 @@ namespace Humanizer
 		public static class Seven
 		{
 			/// <summary>
-			/// 7 days from now
+			/// 7 days from today
 			/// </summary>
 			public static DateOnly Days
 			{
@@ -645,7 +645,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 7 weeks from now
+			/// 7 weeks from today
 			/// </summary>
 			public static DateOnly Weeks
 			{
@@ -669,7 +669,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 7 months from now
+			/// 7 months from today
 			/// </summary>
 			public static DateOnly Months
 			{
@@ -693,7 +693,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 7 years from now
+			/// 7 years from today
 			/// </summary>
 			public static DateOnly Years
 			{
@@ -722,7 +722,7 @@ namespace Humanizer
 		public static class Eight
 		{
 			/// <summary>
-			/// 8 days from now
+			/// 8 days from today
 			/// </summary>
 			public static DateOnly Days
 			{
@@ -746,7 +746,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 8 weeks from now
+			/// 8 weeks from today
 			/// </summary>
 			public static DateOnly Weeks
 			{
@@ -770,7 +770,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 8 months from now
+			/// 8 months from today
 			/// </summary>
 			public static DateOnly Months
 			{
@@ -794,7 +794,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 8 years from now
+			/// 8 years from today
 			/// </summary>
 			public static DateOnly Years
 			{
@@ -823,7 +823,7 @@ namespace Humanizer
 		public static class Nine
 		{
 			/// <summary>
-			/// 9 days from now
+			/// 9 days from today
 			/// </summary>
 			public static DateOnly Days
 			{
@@ -847,7 +847,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 9 weeks from now
+			/// 9 weeks from today
 			/// </summary>
 			public static DateOnly Weeks
 			{
@@ -871,7 +871,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 9 months from now
+			/// 9 months from today
 			/// </summary>
 			public static DateOnly Months
 			{
@@ -895,7 +895,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 9 years from now
+			/// 9 years from today
 			/// </summary>
 			public static DateOnly Years
 			{
@@ -924,7 +924,7 @@ namespace Humanizer
 		public static class Ten
 		{
 			/// <summary>
-			/// 10 days from now
+			/// 10 days from today
 			/// </summary>
 			public static DateOnly Days
 			{
@@ -948,7 +948,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 10 weeks from now
+			/// 10 weeks from today
 			/// </summary>
 			public static DateOnly Weeks
 			{
@@ -972,7 +972,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 10 months from now
+			/// 10 months from today
 			/// </summary>
 			public static DateOnly Months
 			{
@@ -996,7 +996,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// 10 years from now
+			/// 10 years from today
 			/// </summary>
 			public static DateOnly Years
 			{

--- a/src/Humanizer/FluentDate/InDate.SomeTimeFrom.tt
+++ b/src/Humanizer/FluentDate/InDate.SomeTimeFrom.tt
@@ -34,7 +34,7 @@ namespace Humanizer
 		public static class <#= i.ToWords().Dehumanize() #>
 		{
 			/// <summary>
-			/// <#= i #> days from now
+			/// <#= i #> days from today
 			/// </summary>
 			public static DateOnly <#= day #>
 			{
@@ -58,7 +58,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// <#= i #> weeks from now
+			/// <#= i #> weeks from today
 			/// </summary>
 			public static DateOnly <#= week #>
 			{
@@ -82,7 +82,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// <#= i #> months from now
+			/// <#= i #> months from today
 			/// </summary>
 			public static DateOnly <#= month #>
 			{
@@ -106,7 +106,7 @@ namespace Humanizer
 			}
 
 			/// <summary>
-			/// <#= i #> years from now
+			/// <#= i #> years from today
 			/// </summary>
 			public static DateOnly <#= year #>
 			{

--- a/src/Humanizer/Properties/Resources.ar.resx
+++ b/src/Humanizer/Properties/Resources.ar.resx
@@ -314,15 +314,16 @@
     <comment>{0} years ago</comment>
   </data>
   <data name="DateHumanize_MultipleDaysFromNow" xml:space="preserve">
-    <value>في غضون {0} يوم من الآن</value>
+    <value>في غضون {0} يوم من اليوم</value>
+    <comment>Within {0} days from today</comment>
   </data>
   <data name="DateHumanize_MultipleDaysFromNow_Dual" xml:space="preserve">
     <value>في غضون يومين من الآن</value>
     <comment>in 2 days</comment>
   </data>
   <data name="DateHumanize_MultipleDaysFromNow_Plural" xml:space="preserve">
-    <value>في غضون {0} أيام من الآن</value>
-    <comment>{0} days from now</comment>
+    <value>في غضون {0} يوم من اليوم</value>
+    <comment>Within {0} days from today</comment>
   </data>
   <data name="DateHumanize_MultipleHoursFromNow" xml:space="preserve">
     <value>في غضون {0} ساعة من الآن</value>

--- a/src/Humanizer/Properties/Resources.he.resx
+++ b/src/Humanizer/Properties/Resources.he.resx
@@ -315,7 +315,7 @@
   </data>
   <data name="DateHumanize_MultipleDaysFromNow" xml:space="preserve">
     <value>בעוד {0} יום</value>
-    <comment>{0} days from now</comment>
+    <comment>in {0} days</comment>
   </data>
   <data name="DateHumanize_MultipleDaysFromNow_Dual" xml:space="preserve">
     <value>בעוד יומיים</value>
@@ -323,7 +323,7 @@
   </data>
   <data name="DateHumanize_MultipleDaysFromNow_Plural" xml:space="preserve">
     <value>בעוד {0} ימים</value>
-    <comment>{0} days from now</comment>
+    <comment>in {0} days</comment>
   </data>
   <data name="DateHumanize_MultipleHoursFromNow" xml:space="preserve">
     <value>בעוד {0} שעות</value>

--- a/src/Humanizer/Properties/Resources.id.resx
+++ b/src/Humanizer/Properties/Resources.id.resx
@@ -218,8 +218,8 @@
     <comment>1 week</comment>
   </data>
   <data name="DateHumanize_MultipleDaysFromNow" xml:space="preserve">
-    <value>{0} hari dari sekarang</value>
-    <comment>{0} days from now</comment>
+    <value>{0} hari dari hari ini</value>
+    <comment>{0} days from today</comment>
   </data>
   <data name="DateHumanize_MultipleHoursFromNow" xml:space="preserve">
     <value>{0} jam dari sekarang</value>
@@ -230,16 +230,16 @@
     <comment>{0} minutes from now</comment>
   </data>
   <data name="DateHumanize_MultipleMonthsFromNow" xml:space="preserve">
-    <value>{0} bulan dari sekarang</value>
-    <comment>{0} months from now</comment>
+    <value>{0} bulan dari hari ini</value>
+    <comment>{0} months from today</comment>
   </data>
   <data name="DateHumanize_MultipleSecondsFromNow" xml:space="preserve">
     <value>{0} detik dari sekarang</value>
     <comment>{0} seconds from now</comment>
   </data>
   <data name="DateHumanize_MultipleYearsFromNow" xml:space="preserve">
-    <value>{0} tahun dari sekarang</value>
-    <comment>{0} years from now</comment>
+    <value>{0} tahun dari hari ini</value>
+    <comment>{0} years from today</comment>
   </data>
   <data name="DateHumanize_Now" xml:space="preserve">
     <value>sekarang</value>
@@ -258,16 +258,16 @@
     <comment>a minute from now</comment>
   </data>
   <data name="DateHumanize_SingleMonthFromNow" xml:space="preserve">
-    <value>sebulan dari sekarang</value>
-    <comment>one month from now</comment>
+    <value>sebulan dari hari ini</value>
+    <comment>one month from today</comment>
   </data>
   <data name="DateHumanize_SingleSecondFromNow" xml:space="preserve">
     <value>sedetik dari sekarang</value>
     <comment>one second from now</comment>
   </data>
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
-    <value>setahun dari sekarang</value>
-    <comment>one year from now</comment>
+    <value>setahun dari hari ini</value>
+    <comment>one year from today</comment>
   </data>
   <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
     <value>{0} bulan</value>

--- a/src/Humanizer/Properties/Resources.resx
+++ b/src/Humanizer/Properties/Resources.resx
@@ -193,7 +193,7 @@
     <value>1 week</value>
   </data>
   <data name="DateHumanize_MultipleDaysFromNow" xml:space="preserve">
-    <value>{0} days from now</value>
+    <value>{0} days from today</value>
   </data>
   <data name="DateHumanize_MultipleHoursFromNow" xml:space="preserve">
     <value>{0} hours from now</value>
@@ -202,13 +202,13 @@
     <value>{0} minutes from now</value>
   </data>
   <data name="DateHumanize_MultipleMonthsFromNow" xml:space="preserve">
-    <value>{0} months from now</value>
+    <value>{0} months from today</value>
   </data>
   <data name="DateHumanize_MultipleSecondsFromNow" xml:space="preserve">
     <value>{0} seconds from now</value>
   </data>
   <data name="DateHumanize_MultipleYearsFromNow" xml:space="preserve">
-    <value>{0} years from now</value>
+    <value>{0} years from today</value>
   </data>
   <data name="DateHumanize_Now" xml:space="preserve">
     <value>now</value>
@@ -223,13 +223,13 @@
     <value>a minute from now</value>
   </data>
   <data name="DateHumanize_SingleMonthFromNow" xml:space="preserve">
-    <value>one month from now</value>
+    <value>one month from today</value>
   </data>
   <data name="DateHumanize_SingleSecondFromNow" xml:space="preserve">
     <value>one second from now</value>
   </data>
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
-    <value>one year from now</value>
+    <value>one year from today</value>
   </data>
   <data name="DateHumanize_MultipleHoursFromNow_Dual" xml:space="preserve">
     <value>{0} hours from now</value>
@@ -244,7 +244,7 @@
     <value>{0} seconds from now</value>
   </data>
   <data name="DateHumanize_MultipleYearsFromNow_Dual" xml:space="preserve">
-    <value>{0} years from now</value>
+    <value>{0} years from today</value>
   </data>
   <data name="TimeSpanHumanize_MultipleDays_Dual" xml:space="preserve">
     <value>{0} days</value>
@@ -286,16 +286,16 @@
     <value>{0} days ago</value>
   </data>
   <data name="DateHumanize_MultipleDaysFromNow_Dual" xml:space="preserve">
-    <value>{0} days from now</value>
+    <value>{0} days from today</value>
   </data>
   <data name="DateHumanize_MultipleDaysFromNow_Plural" xml:space="preserve">
-    <value>{0} days from now</value>
+    <value>{0} days from today</value>
   </data>
   <data name="DateHumanize_MultipleDaysFromNow_Singular" xml:space="preserve">
-    <value>{0} day from now</value>
+    <value>{0} day from today</value>
   </data>
   <data name="DateHumanize_MultipleDaysFromNow_TrialQuadral" xml:space="preserve">
-    <value>{0} days from now</value>
+    <value>{0} days from today</value>
   </data>
   <data name="DateHumanize_MultipleHoursAgo_Above20" xml:space="preserve">
     <value>{0} hours ago</value>
@@ -358,16 +358,16 @@
     <value>{0} months ago</value>
   </data>
   <data name="DateHumanize_MultipleMonthsFromNow_Dual" xml:space="preserve">
-    <value>{0} months from now</value>
+    <value>{0} months from today</value>
   </data>
   <data name="DateHumanize_MultipleMonthsFromNow_Plural" xml:space="preserve">
-    <value>{0} months from now</value>
+    <value>{0} months from today</value>
   </data>
   <data name="DateHumanize_MultipleMonthsFromNow_Singular" xml:space="preserve">
-    <value>{0} month from now</value>
+    <value>{0} month from today</value>
   </data>
   <data name="DateHumanize_MultipleMonthsFromNow_TrialQuadral" xml:space="preserve">
-    <value>{0} months from now</value>
+    <value>{0} months from today</value>
   </data>
   <data name="DateHumanize_MultipleSecondsAgo_Above20" xml:space="preserve">
     <value>{0} seconds ago</value>
@@ -406,13 +406,13 @@
     <value>{0} years ago</value>
   </data>
   <data name="DateHumanize_MultipleYearsFromNow_Plural" xml:space="preserve">
-    <value>{0} years from now</value>
+    <value>{0} years from today</value>
   </data>
   <data name="DateHumanize_MultipleYearsFromNow_Singular" xml:space="preserve">
-    <value>{0} year from now</value>
+    <value>{0} year from today</value>
   </data>
   <data name="DateHumanize_MultipleYearsFromNow_TrialQuadral" xml:space="preserve">
-    <value>{0} years from now</value>
+    <value>{0} years from today</value>
   </data>
   <data name="TimeSpanHumanize_MultipleDays_Singular" xml:space="preserve">
     <value>{0} day</value>
@@ -490,7 +490,7 @@
     <value>{0} months ago</value>
   </data>
   <data name="DateHumanize_MultipleMonthsFromNow_DualTrialQuadral" xml:space="preserve">
-    <value>{0} months from now</value>
+    <value>{0} months from today</value>
   </data>
   <data name="DateHumanize_MultipleSecondsAgo_DualTrialQuadral" xml:space="preserve">
     <value>{0} seconds ago</value>
@@ -502,7 +502,7 @@
     <value>{0} years from ago</value>
   </data>
   <data name="DateHumanize_MultipleYearsFromNow_DualTrialQuadral" xml:space="preserve">
-    <value>{0} years from now</value>
+    <value>{0} years from today</value>
   </data>
   <data name="TimeSpanHumanize_MultipleHours_DualTrialQuadral" xml:space="preserve">
     <value>{0} hours</value>


### PR DESCRIPTION
fixes https://github.com/Humanizr/Humanizer/issues/1186 DateOnly has current date return 'today'

Here is a checklist you should tick through before submitting a pull request:

[x ] Implementation is clean
[ x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
[x ] No Code Analysis warnings
[x ] There is proper unit test coverage
 If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
[x ] There are very few or no comments (because comments shouldn't be needed if you write clean code)
[x ] Xml documentation is added/updated for the addition/change
[x ] Your PR is (re)based on top of the latest commits from the main branch (more info below)
[x ] Link to the issue(s) you're fixing from your PR description. Use fixes #<the issue number>
[x ] Readme is updated if you change an existing feature or add a new one
[x ] Run either build.cmd or build.ps1 and ensure there are no test failures