### PR TITLE
From kebabed to pascalized fix Issue#1282

### DIFF
--- a/src/Humanizer.Tests.Shared/InflectorTests.cs
+++ b/src/Humanizer.Tests.Shared/InflectorTests.cs
@@ -126,6 +126,8 @@ namespace Humanizer.Tests
         [InlineData("customer_first_name goes here", "CustomerFirstNameGoesHere")]
         [InlineData("customer name", "CustomerName")]
         [InlineData("customer   name", "CustomerName")]
+        [InlineData("customer-first-name", "CustomerFirstName")]
+        [InlineData("_customer-first-name", "CustomerFirstName")]
         public void Pascalize(string input, string expectedOutput)
         {
             Assert.Equal(expectedOutput, input.Pascalize());

--- a/src/Humanizer.Tests.Shared/InflectorTests.cs
+++ b/src/Humanizer.Tests.Shared/InflectorTests.cs
@@ -128,6 +128,7 @@ namespace Humanizer.Tests
         [InlineData("customer   name", "CustomerName")]
         [InlineData("customer-first-name", "CustomerFirstName")]
         [InlineData("_customer-first-name", "CustomerFirstName")]
+        [InlineData(" customer__first--name", "CustomerFirstName")]
         public void Pascalize(string input, string expectedOutput)
         {
             Assert.Equal(expectedOutput, input.Pascalize());

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -70,8 +70,8 @@ namespace Humanizer
         /// <param name="input"></param>
         /// <returns></returns>
         public static string Pascalize(this string input)
-        {   
-            return Regex.Replace(input, "(?:^|_| +)(.)", match => match.Groups[1].Value.ToUpper());
+        {
+            return Regex.Replace(input, "(?:_+|-+|^| +)(.)", match => match.Groups[1].Value.ToUpper());
         }
 
         /// <summary>

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -71,7 +71,7 @@ namespace Humanizer
         /// <returns></returns>
         public static string Pascalize(this string input)
         {
-            return Regex.Replace(input, "(?:_+|-+|^| +)(.)", match => match.Groups[1].Value.ToUpper());
+            return Regex.Replace(input, @"(?:[ _-]+|^)([a-zA-Z])", match => match.Groups[1].Value.ToUpper());
         }
 
         /// <summary>


### PR DESCRIPTION
Adjusted regex to handle converting from kebabed to pascalized.
Pascalize now works properly when first character is the separator.
Pascalize also works if there are multiple character separators such as "--"/"__" or two spaces.
All additions are covered in unit tests, all tests have passed succesfully.
