### PR TITLE
drop netstandard1 support

### DIFF
--- a/src/Humanizer/Humanizer.csproj
+++ b/src/Humanizer/Humanizer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">  
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;net6.0</TargetFrameworks>    
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>    
     <Authors>Mehdi Khalili, Claire Novotny</Authors>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Humanizr/Humanizer/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Humanizr/Humanizer</PackageProjectUrl>


### PR DESCRIPTION
effectively dropping support for 

 * .NET Core 1.0, 1.1 - support ended 2019-07-27
 * .NET Framework 4.6.1 - support ended 2022-04-26