### PR TITLE
also target net7 and 8

### DIFF
--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -1,6 +1,6 @@
 ﻿[assembly: System.Resources.NeutralResourcesLanguage("en")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Humanizer.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100F9104F5F9BDB168AE140366EB1CD84C469B020EA3423D5D29996D5214CE2BD9B7C0BA3EAD1CA545C4399668AB8911E61CC1CC83C7DF6D50FD6B781365B467E65173F40A11C957D27C5AA0CB0F8DA9C91C988203CC8AEF1468C74A472839D0FD870DA8D13A4DC6B3AAFDAF0384D8E18E393C613D88BF02A64467A119902204FCC")]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace Humanizer
 {
     public class ByteRate

--- a/src/Humanizer/Humanizer.csproj
+++ b/src/Humanizer/Humanizer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">  
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>    
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>    
     <Authors>Mehdi Khalili, Claire Novotny</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Humanizr/Humanizer</PackageProjectUrl>


### PR DESCRIPTION
so we can leverage of compiler features that are bound to runtime version