### PR TITLE
improve perf IcelandicFormatter

### DIFF
--- a/src/Humanizer/Localisation/Formatters/IcelandicFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/IcelandicFormatter.cs
@@ -1,35 +1,45 @@
-﻿namespace Humanizer
+﻿namespace Humanizer;
+
+class IcelandicFormatter() :
+    DefaultFormatter(LocaleCode)
 {
-    class IcelandicFormatter() :
-        DefaultFormatter(LocaleCode)
+    const string LocaleCode = "is";
+    readonly CultureInfo localCulture = new(LocaleCode);
+
+    public override string DataUnitHumanize(DataUnit dataUnit, double count, bool toSymbol = true) =>
+        base.DataUnitHumanize(dataUnit, count, toSymbol)?.TrimEnd('s');
+
+    protected override string Format(string resourceKey, int number, bool toWords = false)
     {
-        const string LocaleCode = "is";
-        readonly CultureInfo _localCulture = new(LocaleCode);
+        var resourceString = Resources.GetResource(GetResourceKey(resourceKey, number), localCulture);
 
-        public override string DataUnitHumanize(DataUnit dataUnit, double count, bool toSymbol = true) =>
-            base.DataUnitHumanize(dataUnit, count, toSymbol)?.TrimEnd('s');
-
-        protected override string Format(string resourceKey, int number, bool toWords = false)
+        if (string.IsNullOrEmpty(resourceString))
         {
-            var resourceString = Resources.GetResource(GetResourceKey(resourceKey, number), _localCulture);
-
-            if (string.IsNullOrEmpty(resourceString))
-            {
-                throw new ArgumentException($@"The resource object with key '{resourceKey}' was not found", nameof(resourceKey));
-            }
-            var words = resourceString.Split(' ');
-
-            var unitGender = words.Last() switch
-            {
-                var x when x.StartsWith("mán") => GrammaticalGender.Masculine,
-                var x when x.StartsWith("dag") => GrammaticalGender.Masculine,
-                var x when x.StartsWith("ár") => GrammaticalGender.Neuter,
-                _ => GrammaticalGender.Feminine
-            };
-
-            return toWords ?
-                resourceString.FormatWith(number.ToWords(unitGender, _localCulture)) :
-                resourceString.FormatWith(number);
+            throw new ArgumentException($@"The resource object with key '{resourceKey}' was not found", nameof(resourceKey));
         }
+
+        if (toWords)
+        {
+            var unitGender = GetGrammaticalGender(resourceString);
+            return string.Format(resourceString, number.ToWords(unitGender, localCulture));
+        }
+
+        return string.Format(resourceString, number);
+    }
+
+    static GrammaticalGender GetGrammaticalGender(string resource)
+    {
+        if (resource.Contains(" mán") ||
+            resource.Contains(" dag"))
+        {
+            return GrammaticalGender.Masculine;
+        }
+
+        if (resource.Contains(" ár"))
+        {
+            return GrammaticalGender.Neuter;
+        }
+
+        return GrammaticalGender.Feminine;
     }
 }


### PR DESCRIPTION
 * avoid string alloc of `nextWord.Substring(0, 1));`
 * avoid alloc of `resourceString.Split(' ');`
 * avoid the redundant array alloc in FormatWith