### PR TITLE
Fix article sorting for words containing an article-like part inside

### DIFF
--- a/src/Humanizer.Tests.Shared/ArticlePrefixSortTests.cs
+++ b/src/Humanizer.Tests.Shared/ArticlePrefixSortTests.cs
@@ -7,6 +7,7 @@
         [InlineData(new[] { "An Ant", "The Theater", "the apple", "a Fox", "Bear" }, new[] { "An Ant", "the apple", "Bear", "a Fox", "The Theater" })]
         [InlineData(new[] { "Ant", "A Theater", "an apple", "Fox", "Bear" }, new[] { "Ant", "an apple", "Bear", "Fox", "A Theater" })]
         [InlineData(new[] { " Ant ", " A  Theater ", "  an apple  ", " Fox", "Bear " }, new[] { "A  Theater", "an apple", "Ant", "Bear", "Fox" })]
+        [InlineData(new[] { "The General Theory of Relativity" }, new[] { "The General Theory of Relativity" })]
         public void SortStringArrayIgnoringArticlePrefixes(string[] input, string[] expectedOutput) =>
             Assert.Equal(expectedOutput, EnglishArticle.PrependArticleSuffix(EnglishArticle.AppendArticlePrefix(input)));
 

--- a/src/Humanizer/ArticlePrefixSort.cs
+++ b/src/Humanizer/ArticlePrefixSort.cs
@@ -1,4 +1,6 @@
-﻿namespace Humanizer
+﻿using System.Diagnostics;
+
+namespace Humanizer
 {
     /// <summary>
     /// Contains methods for removing, appending and prepending article prefixes for sorting strings ignoring the article.
@@ -47,61 +49,34 @@
         public static string[] PrependArticleSuffix(string[] appended)
         {
             var inserted = new string[appended.Length];
+            var the = " the".AsSpan();
+            var an = " an".AsSpan();
+            var a = " a".AsSpan();
 
             for (var i = 0; i < appended.Length; i++)
             {
-                string suffix;
-                string original;
-                var append = appended[i];
-                if (append.EndsWith(EnglishArticles.The.ToString()))
+                var append = appended[i].AsSpan();
+                if (append.EndsWith(the, StringComparison.OrdinalIgnoreCase))
                 {
-                    suffix = append.Substring(append.IndexOf(" The", StringComparison.CurrentCulture));
-                    original = ToOriginalFormat(appended, suffix, i);
-                    inserted[i] = original;
+                    inserted[i] = ToOriginalFormat(append, 3);
                 }
-                else if (append.EndsWith(EnglishArticles.A.ToString()))
+                else if (append.EndsWith(an, StringComparison.OrdinalIgnoreCase))
                 {
-                    suffix = append.Substring(append.IndexOf(" A", StringComparison.CurrentCulture));
-                    original = ToOriginalFormat(appended, suffix, i);
-                    inserted[i] = original;
+                    inserted[i] = ToOriginalFormat(append, 2);
                 }
-                else if (append.EndsWith(EnglishArticles.An.ToString()))
+                else if (append.EndsWith(a, StringComparison.OrdinalIgnoreCase))
                 {
-                    suffix = append.Substring(append.IndexOf(" An", StringComparison.CurrentCulture));
-                    original = ToOriginalFormat(appended, suffix, i);
-                    inserted[i] = original;
-                }
-                else if (append.EndsWith(EnglishArticles.A.ToString().ToLowerInvariant()))
-                {
-                    suffix = append.Substring(append.IndexOf(" a", StringComparison.CurrentCulture));
-                    original = ToOriginalFormat(appended, suffix, i);
-                    inserted[i] = original;
-                }
-                else if (append.EndsWith(EnglishArticles.An.ToString().ToLowerInvariant()))
-                {
-                    suffix = append.Substring(append.IndexOf(" an", StringComparison.CurrentCulture));
-                    original = ToOriginalFormat(appended, suffix, i);
-                    inserted[i] = original;
-                }
-                else if (append.EndsWith(EnglishArticles.The.ToString().ToLowerInvariant()))
-                {
-                    suffix = append.Substring(append.IndexOf(" the", StringComparison.CurrentCulture));
-                    original = ToOriginalFormat(appended, suffix, i);
-                    inserted[i] = original;
+                    inserted[i] = ToOriginalFormat(append, 1);
                 }
                 else
                 {
-                    inserted[i] = append;
+                    inserted[i] = appended[i];
                 }
             }
             return inserted;
         }
 
-        static string ToOriginalFormat(string[] appended, string suffix, int i)
-        {
-            var insertion = appended[i].Remove(appended[i].IndexOf(suffix, StringComparison.CurrentCulture));
-            var original = $"{suffix} {insertion}";
-            return original.Trim();
-        }
+        static string ToOriginalFormat(ReadOnlySpan<char> value, int suffixLength) =>
+            $"{value[^suffixLength..]} {value[..^(suffixLength + 1)]}";
     }
 }

--- a/src/Humanizer/ArticlePrefixSort.cs
+++ b/src/Humanizer/ArticlePrefixSort.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-
-namespace Humanizer
+﻿namespace Humanizer
 {
     /// <summary>
     /// Contains methods for removing, appending and prepending article prefixes for sorting strings ignoring the article.


### PR DESCRIPTION
Fix:

Expected: ["The General Theory of Relativity"]
Actual:   ["Theory of Relativity The General"]

_Originally posted in https://github.com/Humanizr/Humanizer/pull/1419#discussion_r1496850805_