### PR TITLE
Support InvariantGlobalization by using provided CultureInfo instead of instantiating

### DIFF
--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -215,6 +215,7 @@ namespace Humanizer
     }
     public class DefaultFormatter : Humanizer.IFormatter
     {
+        public DefaultFormatter(System.Globalization.CultureInfo culture) { }
         public DefaultFormatter(string localeCode) { }
         protected System.Globalization.CultureInfo Culture { get; }
         public virtual string DataUnitHumanize(Humanizer.DataUnit dataUnit, double count, bool toSymbol = true) { }
@@ -770,9 +771,9 @@ namespace Humanizer
     public class LocaliserRegistry<TLocaliser>
         where TLocaliser :  class
     {
-        public LocaliserRegistry(System.Func<System.Globalization.CultureInfo?, TLocaliser> defaultLocaliser) { }
+        public LocaliserRegistry(System.Func<System.Globalization.CultureInfo, TLocaliser> defaultLocaliser) { }
         public LocaliserRegistry(TLocaliser defaultLocaliser) { }
-        public void Register(string localeCode, System.Func<System.Globalization.CultureInfo?, TLocaliser> localiser) { }
+        public void Register(string localeCode, System.Func<System.Globalization.CultureInfo, TLocaliser> localiser) { }
         public void Register(string localeCode, TLocaliser localiser) { }
         public TLocaliser ResolveForCulture(System.Globalization.CultureInfo? culture) { }
         public TLocaliser ResolveForUiCulture() { }

--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -199,6 +199,7 @@ namespace Humanizer
     }
     public class DefaultFormatter : Humanizer.IFormatter
     {
+        public DefaultFormatter(System.Globalization.CultureInfo culture) { }
         public DefaultFormatter(string localeCode) { }
         protected System.Globalization.CultureInfo Culture { get; }
         public virtual string DataUnitHumanize(Humanizer.DataUnit dataUnit, double count, bool toSymbol = true) { }
@@ -553,9 +554,9 @@ namespace Humanizer
     public class LocaliserRegistry<TLocaliser>
         where TLocaliser :  class
     {
-        public LocaliserRegistry(System.Func<System.Globalization.CultureInfo?, TLocaliser> defaultLocaliser) { }
+        public LocaliserRegistry(System.Func<System.Globalization.CultureInfo, TLocaliser> defaultLocaliser) { }
         public LocaliserRegistry(TLocaliser defaultLocaliser) { }
-        public void Register(string localeCode, System.Func<System.Globalization.CultureInfo?, TLocaliser> localiser) { }
+        public void Register(string localeCode, System.Func<System.Globalization.CultureInfo, TLocaliser> localiser) { }
         public void Register(string localeCode, TLocaliser localiser) { }
         public TLocaliser ResolveForCulture(System.Globalization.CultureInfo? culture) { }
         public TLocaliser ResolveForUiCulture() { }

--- a/src/Humanizer/Configuration/FormatterRegistry.cs
+++ b/src/Humanizer/Configuration/FormatterRegistry.cs
@@ -3,24 +3,24 @@
 class FormatterRegistry : LocaliserRegistry<IFormatter>
 {
     public FormatterRegistry()
-        : base(new DefaultFormatter("en-US"))
+        : base(c => new DefaultFormatter(c))
     {
-        Register("ar", new ArabicFormatter());
-        Register("de", new GermanFormatter());
-        Register("he", new HebrewFormatter());
-        Register("ro", new RomanianFormatter());
-        Register("ru", new RussianFormatter());
-        Register("sl", new SlovenianFormatter());
-        Register("hr", new CroatianFormatter());
-        Register("sr", new SerbianFormatter("sr"));
-        Register("sr-Latn", new SerbianFormatter("sr-Latn"));
-        Register("uk", new UkrainianFormatter());
-        Register("fr", new FrenchFormatter("fr"));
-        Register("fr-BE", new FrenchFormatter("fr-BE"));
+        Register("ar", c => new ArabicFormatter(c));
+        Register("de", c => new GermanFormatter(c));
+        Register("he", c => new HebrewFormatter(c));
+        Register("ro", c => new RomanianFormatter(c));
+        Register("ru", c => new RussianFormatter(c));
+        Register("sl", c => new SlovenianFormatter(c));
+        Register("hr", c => new CroatianFormatter(c));
+        Register("sr", c => new SerbianFormatter(c));
+        Register("sr-Latn", c => new SerbianFormatter(c));
+        Register("uk", c => new UkrainianFormatter(c));
+        Register("fr", c => new FrenchFormatter(c));
+        Register("fr-BE", c => new FrenchFormatter(c));
         RegisterCzechSlovakPolishFormatter("cs");
         RegisterCzechSlovakPolishFormatter("pl");
         RegisterCzechSlovakPolishFormatter("sk");
-        Register("bg", new BulgarianFormatter());
+        Register("bg", c => new BulgarianFormatter(c));
         RegisterDefaultFormatter("ku");
         RegisterDefaultFormatter("pt");
         RegisterDefaultFormatter("sv");
@@ -38,11 +38,11 @@ class FormatterRegistry : LocaliserRegistry<IFormatter>
         RegisterDefaultFormatter("hu");
         RegisterDefaultFormatter("hy");
         RegisterDefaultFormatter("id");
-        Register("is", new IcelandicFormatter());
+        Register("is", c => new IcelandicFormatter(c));
         RegisterDefaultFormatter("ja");
         RegisterDefaultFormatter("ko-KR");
         RegisterDefaultFormatter("lv");
-        Register("mt", new MalteseFormatter("mt"));
+        Register("mt", c => new MalteseFormatter(c));
         RegisterDefaultFormatter("ms-MY");
         RegisterDefaultFormatter("nb");
         RegisterDefaultFormatter("nb-NO");
@@ -57,22 +57,13 @@ class FormatterRegistry : LocaliserRegistry<IFormatter>
         RegisterDefaultFormatter("zh-Hant");
         RegisterDefaultFormatter("th-TH");
         RegisterDefaultFormatter("en-IN");
-        Register("lt", new LithuanianFormatter());
-        Register("lb", new LuxembourgishFormatter());
+        Register("lt", c => new LithuanianFormatter(c));
+        Register("lb", c => new LuxembourgishFormatter(c));
     }
 
-    void RegisterDefaultFormatter(string localeCode)
-    {
-        try
-        {
-            Register(localeCode, new DefaultFormatter(localeCode));
-        }
-        catch (CultureNotFoundException)
-        {
-            // Some OS's may not support the particular culture. Not much we can do for those.
-        }
-    }
+    void RegisterDefaultFormatter(string localeCode) =>
+        Register(localeCode, c => new DefaultFormatter(c));
 
     void RegisterCzechSlovakPolishFormatter(string localeCode) =>
-        Register(localeCode, new CzechSlovakPolishFormatter(localeCode));
+        Register(localeCode, c => new CzechSlovakPolishFormatter(c));
 }

--- a/src/Humanizer/Configuration/LocaliserRegistry.cs
+++ b/src/Humanizer/Configuration/LocaliserRegistry.cs
@@ -6,8 +6,8 @@
 public class LocaliserRegistry<TLocaliser>
     where TLocaliser : class
 {
-    readonly Dictionary<string, Func<CultureInfo?, TLocaliser>> _localisers = new();
-    readonly Func<CultureInfo?, TLocaliser> _defaultLocaliser;
+    readonly Dictionary<string, Func<CultureInfo, TLocaliser>> _localisers = new();
+    readonly Func<CultureInfo, TLocaliser> _defaultLocaliser;
 
     /// <summary>
     /// Creates a localiser registry with the default localiser set to the provided value
@@ -18,7 +18,7 @@ public class LocaliserRegistry<TLocaliser>
     /// <summary>
     /// Creates a localiser registry with the default localiser factory set to the provided value
     /// </summary>
-    public LocaliserRegistry(Func<CultureInfo?, TLocaliser> defaultLocaliser) =>
+    public LocaliserRegistry(Func<CultureInfo, TLocaliser> defaultLocaliser) =>
         _defaultLocaliser = defaultLocaliser;
 
     /// <summary>
@@ -31,8 +31,11 @@ public class LocaliserRegistry<TLocaliser>
     /// Gets the localiser for the specified culture
     /// </summary>
     /// <param name="culture">The culture to retrieve localiser for. If not specified, current thread's UI culture is used.</param>
-    public TLocaliser ResolveForCulture(CultureInfo? culture) =>
-        FindLocaliser(culture ?? CultureInfo.CurrentUICulture)(culture);
+    public TLocaliser ResolveForCulture(CultureInfo? culture)
+    {
+        var cultureInfo = culture ?? CultureInfo.CurrentUICulture;
+        return FindLocaliser(cultureInfo)(cultureInfo);
+    }
 
     /// <summary>
     /// Registers the localiser for the culture provided
@@ -43,14 +46,14 @@ public class LocaliserRegistry<TLocaliser>
     /// <summary>
     /// Registers the localiser factory for the culture provided
     /// </summary>
-    public void Register(string localeCode, Func<CultureInfo?, TLocaliser> localiser) =>
+    public void Register(string localeCode, Func<CultureInfo, TLocaliser> localiser) =>
         _localisers[localeCode] = localiser;
 
-    Func<CultureInfo?, TLocaliser> FindLocaliser(CultureInfo culture)
+    Func<CultureInfo, TLocaliser> FindLocaliser(CultureInfo culture)
     {
-        for (var c = culture; !string.IsNullOrEmpty(c?.Name); c = c.Parent)
+        for (var c = culture; !string.IsNullOrEmpty(c.Name); c = c.Parent)
         {
-            if (_localisers.TryGetValue(c!.Name, out var localiser))
+            if (_localisers.TryGetValue(c.Name, out var localiser))
             {
                 return localiser;
             }

--- a/src/Humanizer/Configuration/NumberToWordsConverterRegistry.cs
+++ b/src/Humanizer/Configuration/NumberToWordsConverterRegistry.cs
@@ -3,15 +3,15 @@
 class NumberToWordsConverterRegistry : LocaliserRegistry<INumberToWordsConverter>
 {
     public NumberToWordsConverterRegistry()
-        : base(_ => new EnglishNumberToWordsConverter())
+        : base(new EnglishNumberToWordsConverter())
     {
         Register("af", new AfrikaansNumberToWordsConverter());
         Register("en", new EnglishNumberToWordsConverter());
         Register("ar", new ArabicNumberToWordsConverter());
-        Register("cs", _ => new CzechNumberToWordsConverter(_));
+        Register("cs", c => new CzechNumberToWordsConverter(c));
         Register("fa", new FarsiNumberToWordsConverter());
         Register("es", new SpanishNumberToWordsConverter());
-        Register("pl", _ => new PolishNumberToWordsConverter(_));
+        Register("pl", c => new PolishNumberToWordsConverter(c));
         Register("pt", new PortugueseNumberToWordsConverter());
         Register("pt-BR", new BrazilianPortugueseNumberToWordsConverter());
         Register("ro", new RomanianNumberToWordsConverter());
@@ -21,8 +21,8 @@ class NumberToWordsConverterRegistry : LocaliserRegistry<INumberToWordsConverter
         Register("fr-CH", new FrenchSwissNumberToWordsConverter());
         Register("fr", new FrenchNumberToWordsConverter());
         Register("nl", new DutchNumberToWordsConverter());
-        Register("he", _ => new HebrewNumberToWordsConverter(_));
-        Register("sl", _ => new SlovenianNumberToWordsConverter(_));
+        Register("he", c => new HebrewNumberToWordsConverter(c));
+        Register("sl", c => new SlovenianNumberToWordsConverter(c));
         Register("de", new GermanNumberToWordsConverter());
         Register("de-CH", new GermanSwissLiechtensteinNumberToWordsConverter());
         Register("de-LI", new GermanSwissLiechtensteinNumberToWordsConverter());
@@ -35,10 +35,10 @@ class NumberToWordsConverterRegistry : LocaliserRegistry<INumberToWordsConverter
         Register("uz-Latn-UZ", new UzbekLatnNumberToWordConverter());
         Register("uz-Cyrl-UZ", new UzbekCyrlNumberToWordConverter());
         Register("sv", new SwedishNumberToWordsConverter());
-        Register("sr", _ => new SerbianCyrlNumberToWordsConverter(_));
-        Register("sr-Latn", _ => new SerbianNumberToWordsConverter(_));
+        Register("sr", c => new SerbianCyrlNumberToWordsConverter(c));
+        Register("sr-Latn", c => new SerbianNumberToWordsConverter(c));
         Register("ta", new TamilNumberToWordsConverter());
-        Register("hr", _ => new CroatianNumberToWordsConverter(_));
+        Register("hr", c => new CroatianNumberToWordsConverter(c));
         Register("nb", new NorwegianBokmalNumberToWordsConverter());
         Register("vi", new VietnameseNumberToWordsConverter());
         Register("zh-CN", new ChineseNumberToWordsConverter());

--- a/src/Humanizer/Configuration/OrdinalizerRegistry.cs
+++ b/src/Humanizer/Configuration/OrdinalizerRegistry.cs
@@ -7,7 +7,7 @@ class OrdinalizerRegistry : LocaliserRegistry<IOrdinalizer>
     {
         Register("de", new GermanOrdinalizer());
         Register("en", new EnglishOrdinalizer());
-        Register("es", new SpanishOrdinalizer());
+        Register("es", c => new SpanishOrdinalizer(c));
         Register("fr", new FrenchOrdinalizer());
         Register("is", new IcelandicOrdinalizer());
         Register("it", new ItalianOrdinalizer());

--- a/src/Humanizer/Localisation/Formatters/ArabicFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/ArabicFormatter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Humanizer;
 
-class ArabicFormatter() :
-    DefaultFormatter("ar")
+class ArabicFormatter(CultureInfo culture) :
+    DefaultFormatter(culture)
 {
     const string DualPostfix = "_Dual";
     const string PluralPostfix = "_Plural";

--- a/src/Humanizer/Localisation/Formatters/BulgarianFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/BulgarianFormatter.cs
@@ -1,6 +1,6 @@
 namespace Humanizer;
 
-class BulgarianFormatter() : DefaultFormatter("bg")
+class BulgarianFormatter(CultureInfo culture) : DefaultFormatter(culture)
 {
     protected override string NumberToWords(TimeUnit unit, int number, CultureInfo culture) =>
         number.ToWords(GetUnitGender(unit), culture);

--- a/src/Humanizer/Localisation/Formatters/BulgarianFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/BulgarianFormatter.cs
@@ -1,6 +1,7 @@
 namespace Humanizer;
 
-class BulgarianFormatter(CultureInfo culture) : DefaultFormatter(culture)
+class BulgarianFormatter(CultureInfo culture)
+    : DefaultFormatter(culture)
 {
     protected override string NumberToWords(TimeUnit unit, int number, CultureInfo culture) =>
         number.ToWords(GetUnitGender(unit), culture);

--- a/src/Humanizer/Localisation/Formatters/CroatianFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/CroatianFormatter.cs
@@ -1,7 +1,7 @@
 namespace Humanizer;
 
-class CroatianFormatter() :
-    DefaultFormatter("hr")
+class CroatianFormatter(CultureInfo culture) :
+    DefaultFormatter(culture)
 {
     const string PaucalPostfix = "_Paucal";
 

--- a/src/Humanizer/Localisation/Formatters/CzechSlovakPolishFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/CzechSlovakPolishFormatter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Humanizer;
 
-class CzechSlovakPolishFormatter(string localeCode) :
-    DefaultFormatter(localeCode)
+class CzechSlovakPolishFormatter(CultureInfo culture) :
+    DefaultFormatter(culture)
 {
     const string PaucalPostfix = "_Paucal";
 

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -5,7 +5,7 @@
 /// </summary>
 public class DefaultFormatter(CultureInfo culture) : IFormatter
 {
-    protected CultureInfo Culture => culture;
+    protected CultureInfo Culture { get; } = culture;
 
     public DefaultFormatter(string localeCode)
         : this(new CultureInfo(localeCode))

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -5,7 +5,7 @@
 /// </summary>
 public class DefaultFormatter(CultureInfo culture) : IFormatter
 {
-    protected CultureInfo Culture { get; } = culture;
+    protected CultureInfo Culture => culture;
 
     public DefaultFormatter(string localeCode)
         : this(new CultureInfo(localeCode))

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -3,13 +3,14 @@
 /// <summary>
 /// Default implementation of IFormatter interface.
 /// </summary>
-public class DefaultFormatter : IFormatter
+public class DefaultFormatter(CultureInfo culture) : IFormatter
 {
-    protected CultureInfo Culture { get; }
+    protected CultureInfo Culture { get; } = culture;
 
-    /// <param name="localeCode">Name of the culture to use.</param>
-    public DefaultFormatter(string localeCode) =>
-        Culture = new(localeCode);
+    public DefaultFormatter(string localeCode)
+        : this(new CultureInfo(localeCode))
+    {
+    }
 
     public virtual string DateHumanize_Now() =>
         GetResourceForDate(TimeUnit.Millisecond, Tense.Past, 0);

--- a/src/Humanizer/Localisation/Formatters/FrenchFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/FrenchFormatter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Humanizer;
 
-class FrenchFormatter(string localeCode) :
-    DefaultFormatter(localeCode)
+class FrenchFormatter(CultureInfo culture) :
+    DefaultFormatter(culture)
 {
     const string DualPostfix = "_Dual";
 

--- a/src/Humanizer/Localisation/Formatters/GermanFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/GermanFormatter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Humanizer;
 
-class GermanFormatter() :
-    DefaultFormatter("de")
+class GermanFormatter(CultureInfo culture) :
+    DefaultFormatter(culture)
 {
     /// <inheritdoc />
     public override string DataUnitHumanize(DataUnit dataUnit, double count, bool toSymbol = true) =>

--- a/src/Humanizer/Localisation/Formatters/HebrewFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/HebrewFormatter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Humanizer;
 
-class HebrewFormatter() :
-    DefaultFormatter("he")
+class HebrewFormatter(CultureInfo culture) :
+    DefaultFormatter(culture)
 {
     const string DualPostfix = "_Dual";
     const string PluralPostfix = "_Plural";

--- a/src/Humanizer/Localisation/Formatters/IcelandicFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/IcelandicFormatter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Humanizer;
 
-class IcelandicFormatter() :
-    DefaultFormatter("is")
+class IcelandicFormatter(CultureInfo culture) :
+    DefaultFormatter(culture)
 {
     public override string DataUnitHumanize(DataUnit dataUnit, double count, bool toSymbol = true) =>
         base.DataUnitHumanize(dataUnit, count, toSymbol).TrimEnd('s');

--- a/src/Humanizer/Localisation/Formatters/LithuanianFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/LithuanianFormatter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Humanizer;
 
-class LithuanianFormatter() :
-    DefaultFormatter("lt")
+class LithuanianFormatter(CultureInfo culture) :
+    DefaultFormatter(culture)
 {
     protected override string GetResourceKey(string resourceKey, int number)
     {

--- a/src/Humanizer/Localisation/Formatters/LuxembourgishFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/LuxembourgishFormatter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Humanizer;
 
-class LuxembourgishFormatter() :
-    DefaultFormatter("lb")
+class LuxembourgishFormatter(CultureInfo culture) :
+    DefaultFormatter(culture)
 {
     const string DualPostfix = "_Dual";
 

--- a/src/Humanizer/Localisation/Formatters/MalteseFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/MalteseFormatter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Humanizer;
 
-class MalteseFormatter(string localeCode) :
-    DefaultFormatter(localeCode)
+class MalteseFormatter(CultureInfo culture) :
+    DefaultFormatter(culture)
 {
     const string DualPostfix = "_Dual";
 

--- a/src/Humanizer/Localisation/Formatters/RomanianFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/RomanianFormatter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Humanizer;
 
-class RomanianFormatter() :
-    DefaultFormatter("ro")
+class RomanianFormatter(CultureInfo culture) :
+    DefaultFormatter(culture)
 {
     const int PrepositionIndicatingDecimals = 2;
     const int MaxNumeralWithNoPreposition = 19;

--- a/src/Humanizer/Localisation/Formatters/RussianFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/RussianFormatter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Humanizer;
 
-class RussianFormatter() :
-    DefaultFormatter("ru")
+class RussianFormatter(CultureInfo culture) :
+    DefaultFormatter(culture)
 {
     protected override string GetResourceKey(string resourceKey, int number)
     {

--- a/src/Humanizer/Localisation/Formatters/SerbianFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/SerbianFormatter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Humanizer;
 
-class SerbianFormatter(string localeCode) :
-    DefaultFormatter(localeCode)
+class SerbianFormatter(CultureInfo culture) :
+    DefaultFormatter(culture)
 {
     const string PaucalPostfix = "_Paucal";
 

--- a/src/Humanizer/Localisation/Formatters/SlovenianFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/SlovenianFormatter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Humanizer;
 
-class SlovenianFormatter() :
-    DefaultFormatter("sl")
+class SlovenianFormatter(CultureInfo culture) :
+    DefaultFormatter(culture)
 {
     const string DualPostfix = "_Dual";
     const string TrialQuadralPostfix = "_Paucal";

--- a/src/Humanizer/Localisation/Formatters/UkrainianFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/UkrainianFormatter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Humanizer;
 
-class UkrainianFormatter() : DefaultFormatter("uk")
+class UkrainianFormatter(CultureInfo culture)
+    : DefaultFormatter(culture)
 {
     protected override string GetResourceKey(string resourceKey, int number)
     {

--- a/src/Humanizer/Localisation/NumberToWords/CroatianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/CroatianNumberToWordsConverter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Humanizer;
 
-class CroatianNumberToWordsConverter(CultureInfo? culture)
+class CroatianNumberToWordsConverter(CultureInfo culture)
     : GenderlessNumberToWordsConverter
 {
     static readonly string[] UnitsMap =

--- a/src/Humanizer/Localisation/NumberToWords/CzechNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/CzechNumberToWordsConverter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Humanizer;
 
-class CzechNumberToWordsConverter(CultureInfo? culture) :
+class CzechNumberToWordsConverter(CultureInfo culture) :
     GenderedNumberToWordsConverter
 {
     static readonly string[] BillionsMap = ["miliarda", "miliardy", "miliard"];

--- a/src/Humanizer/Localisation/NumberToWords/HebrewNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/HebrewNumberToWordsConverter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Humanizer;
 
-class HebrewNumberToWordsConverter(CultureInfo? culture) :
+class HebrewNumberToWordsConverter(CultureInfo culture) :
     GenderedNumberToWordsConverter(GrammaticalGender.Feminine)
 {
     static readonly string[] UnitsFeminine = ["אפס", "אחת", "שתיים", "שלוש", "ארבע", "חמש", "שש", "שבע", "שמונה", "תשע", "עשר"];

--- a/src/Humanizer/Localisation/NumberToWords/PolishNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/PolishNumberToWordsConverter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Humanizer;
 
-class PolishNumberToWordsConverter(CultureInfo? culture) :
+class PolishNumberToWordsConverter(CultureInfo culture) :
     GenderedNumberToWordsConverter
 {
     static readonly string[] HundredsMap =

--- a/src/Humanizer/Localisation/NumberToWords/SerbianCyrlNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/SerbianCyrlNumberToWordsConverter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Humanizer;
 
-class SerbianCyrlNumberToWordsConverter(CultureInfo? culture) :
+class SerbianCyrlNumberToWordsConverter(CultureInfo culture) :
     GenderlessNumberToWordsConverter
 {
     static readonly string[] UnitsMap = ["нула", "један", "два", "три", "четири", "пет", "шест", "седам", "осам", "девет", "десет", "једанест", "дванаест", "тринаест", "четрнаест", "петнаест", "шеснаест", "седамнаест", "осамнаест", "деветнаест"];

--- a/src/Humanizer/Localisation/NumberToWords/SerbianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/SerbianNumberToWordsConverter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Humanizer;
 
-class SerbianNumberToWordsConverter(CultureInfo? culture) :
+class SerbianNumberToWordsConverter(CultureInfo culture) :
     GenderlessNumberToWordsConverter
 {
     static readonly string[] UnitsMap = ["nula", "jedan", "dva", "tri", "četiri", "pet", "šest", "sedam", "osam", "devet", "deset", "jedanaest", "dvanaest", "trinaest", "četrnaest", "petnaest", "šestnaest", "sedemnaest", "osemnaest", "devetnaest"];

--- a/src/Humanizer/Localisation/NumberToWords/SlovenianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/SlovenianNumberToWordsConverter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Humanizer;
 
-class SlovenianNumberToWordsConverter(CultureInfo? culture) :
+class SlovenianNumberToWordsConverter(CultureInfo culture) :
     GenderlessNumberToWordsConverter
 {
     static readonly string[] UnitsMap = ["nič", "ena", "dva", "tri", "štiri", "pet", "šest", "sedem", "osem", "devet", "deset", "enajst", "dvanajst", "trinajst", "štirinajst", "petnajst", "šestnajst", "sedemnajst", "osemnajst", "devetnajst"];

--- a/src/Humanizer/Localisation/Ordinalizers/SpanishOrdinalizer.cs
+++ b/src/Humanizer/Localisation/Ordinalizers/SpanishOrdinalizer.cs
@@ -1,6 +1,6 @@
 ﻿namespace Humanizer;
 
-class SpanishOrdinalizer : DefaultOrdinalizer
+class SpanishOrdinalizer(CultureInfo culture) : DefaultOrdinalizer
 {
     public override string Convert(int number, string numberString) =>
         Convert(number, numberString, GrammaticalGender.Masculine, WordForm.Normal);
@@ -33,10 +33,8 @@ class SpanishOrdinalizer : DefaultOrdinalizer
         }
     }
 
-    static CultureInfo _spanishCulture = new("es-ES");
-
-    static string GetNumberString(int number) =>
-        number.ToString(_spanishCulture);
+    string GetNumberString(int number) =>
+        number.ToString(culture);
 
     static string GetWordForm(int number, WordForm wordForm) =>
         (number % 10 == 1 || number % 10 == 3) && wordForm == WordForm.Abbreviation ? ".er" : ".º";


### PR DESCRIPTION
Using provided `CultureInfo`s instead of creating own to avoid `CultureNotFoundException`.

Fixes #1126 
Closes #1213