### PR TITLE
Various cleanup largely driven by analyzers

### DIFF
--- a/src/Humanizer/ArticlePrefixSort.cs
+++ b/src/Humanizer/ArticlePrefixSort.cs
@@ -1,11 +1,11 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 /// <summary>
 /// Contains methods for removing, appending and prepending article prefixes for sorting strings ignoring the article.
 /// </summary>
 public static class EnglishArticle
 {
-    static Regex _regex = new("^((The)|(the)|(a)|(A)|(An)|(an))\\s\\w+", RegexOptions.Compiled);
+    static readonly Regex _regex = new("^((The)|(the)|(a)|(A)|(An)|(an))\\s\\w+", RegexOptions.Compiled);
 
     /// <summary>
     /// Removes the prefixed article and appends it to the same string.

--- a/src/Humanizer/EnumCache.cs
+++ b/src/Humanizer/EnumCache.cs
@@ -1,13 +1,13 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 namespace Humanizer;
 
 static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>
     where T : struct, Enum
 {
-    static (T Zero, FrozenDictionary<T, string> Humanized, Dictionary<string, T> Dehumanized, FrozenSet<T> Values, bool IsBitFieldEnum) info;
+    static readonly (T Zero, FrozenDictionary<T, string> Humanized, Dictionary<string, T> Dehumanized, FrozenSet<T> Values, bool IsBitFieldEnum) info = CreateInfo();
 
-    static EnumCache()
+    private static (T Zero, FrozenDictionary<T, string> Humanized, Dictionary<string, T> Dehumanized, FrozenSet<T> Values, bool IsBitFieldEnum) CreateInfo()
     {
         var values = EnumPolyfill.GetValues<T>().ToFrozenSet();
         var type = typeof(T);
@@ -22,7 +22,7 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
         }
 
         var isBitFieldEnum = type.GetCustomAttribute(typeof(FlagsAttribute)) != null;
-        info = (
+        return (
             zero,
             humanized.ToFrozenDictionary(),
             dehumanized,

--- a/src/Humanizer/EnumDehumanizeExtensions.cs
+++ b/src/Humanizer/EnumDehumanizeExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 /// <summary>
 /// Contains extension methods for dehumanizing Enum string values.
@@ -27,7 +27,7 @@ public static class EnumDehumanizeExtensions
         where TTargetEnum : struct, Enum =>
         DehumanizeToPrivate<TTargetEnum>(input, onNoMatch);
 
-    static MethodInfo dehumanizeToMethod = typeof(EnumDehumanizeExtensions)
+    static readonly MethodInfo dehumanizeToMethod = typeof(EnumDehumanizeExtensions)
         .GetMethod("DehumanizeTo", [typeof(string), typeof(OnNoMatch)])!;
 
     /// <summary>

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -1,14 +1,11 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 /// <summary>
 /// Container for registered Vocabularies.  At present, only a single vocabulary is supported: Default.
 /// </summary>
 public static class Vocabularies
 {
-    static readonly Lazy<Vocabulary> Instance;
-
-    static Vocabularies() =>
-        Instance = new(BuildDefault, LazyThreadSafetyMode.PublicationOnly);
+    static readonly Lazy<Vocabulary> Instance = new(BuildDefault, LazyThreadSafetyMode.PublicationOnly);
 
     /// <summary>
     /// The default vocabulary used for singular/plural irregularities.

--- a/src/Humanizer/Localisation/Formatters/MalteseFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/MalteseFormatter.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class MalteseFormatter(CultureInfo culture) :
     DefaultFormatter(culture)
@@ -10,56 +10,22 @@ class MalteseFormatter(CultureInfo culture) :
             return resourceKey;
         }
 
-        if (DualResourceKeys.TryGetValue(resourceKey, out var result))
+        return resourceKey switch
         {
-            return result;
-        }
-
-        return resourceKey;
+            "DateHumanize_MultipleDaysAgo" => "DateHumanize_MultipleDaysAgo_Dual",
+            "DateHumanize_MultipleDaysFromNow" => "DateHumanize_MultipleDaysFromNow_Dual",
+            "DateHumanize_MultipleHoursAgo" => "DateHumanize_MultipleHoursAgo_Dual",
+            "DateHumanize_MultipleHoursFromNow" => "DateHumanize_MultipleHoursFromNow_Dual",
+            "DateHumanize_MultipleMonthsAgo" => "DateHumanize_MultipleMonthsAgo_Dual",
+            "DateHumanize_MultipleMonthsFromNow" => "DateHumanize_MultipleMonthsFromNow_Dual",
+            "DateHumanize_MultipleYearsAgo" => "DateHumanize_MultipleYearsAgo_Dual",
+            "DateHumanize_MultipleYearsFromNow" => "DateHumanize_MultipleYearsFromNow_Dual",
+            "TimeSpanHumanize_MultipleDays" => "TimeSpanHumanize_MultipleDays_Dual",
+            "TimeSpanHumanize_MultipleYears" => "TimeSpanHumanize_MultipleYears_Dual",
+            "TimeSpanHumanize_MultipleMonths" => "TimeSpanHumanize_MultipleMonths_Dual",
+            "TimeSpanHumanize_MultipleHours" => "TimeSpanHumanize_MultipleHours_Dual",
+            "TimeSpanHumanize_MultipleWeeks" => "TimeSpanHumanize_MultipleWeeks_Dual",
+            _ => resourceKey,
+        };
     }
-
-    static readonly FrozenDictionary<string, string> DualResourceKeys =
-        new Dictionary<string, string>
-            {
-                {
-                    "DateHumanize_MultipleDaysAgo", "DateHumanize_MultipleDaysAgo_Dual"
-                },
-                {
-                    "DateHumanize_MultipleDaysFromNow", "DateHumanize_MultipleDaysFromNow_Dual"
-                },
-                {
-                    "DateHumanize_MultipleHoursAgo", "DateHumanize_MultipleHoursAgo_Dual"
-                },
-                {
-                    "DateHumanize_MultipleHoursFromNow", "DateHumanize_MultipleHoursFromNow_Dual"
-                },
-                {
-                    "DateHumanize_MultipleMonthsAgo", "DateHumanize_MultipleMonthsAgo_Dual"
-                },
-                {
-                    "DateHumanize_MultipleMonthsFromNow", "DateHumanize_MultipleMonthsFromNow_Dual"
-                },
-                {
-                    "DateHumanize_MultipleYearsAgo", "DateHumanize_MultipleYearsAgo_Dual"
-                },
-                {
-                    "DateHumanize_MultipleYearsFromNow", "DateHumanize_MultipleYearsFromNow_Dual"
-                },
-                {
-                    "TimeSpanHumanize_MultipleDays", "TimeSpanHumanize_MultipleDays_Dual"
-                },
-                {
-                    "TimeSpanHumanize_MultipleYears", "TimeSpanHumanize_MultipleYears_Dual"
-                },
-                {
-                    "TimeSpanHumanize_MultipleMonths", "TimeSpanHumanize_MultipleMonths_Dual"
-                },
-                {
-                    "TimeSpanHumanize_MultipleHours", "TimeSpanHumanize_MultipleHours_Dual"
-                },
-                {
-                    "TimeSpanHumanize_MultipleWeeks", "TimeSpanHumanize_MultipleWeeks_Dual"
-                },
-            }
-            .ToFrozenDictionary();
 }

--- a/src/Humanizer/Localisation/NumberToWords/AfrikaansNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/AfrikaansNumberToWordsConverter.cs
@@ -163,12 +163,10 @@ class AfrikaansNumberToWordsConverter :
     static string RemoveOnePrefix(string toWords)
     {
         // one hundred => hundredth
-        if (toWords.StartsWith("een", StringComparison.Ordinal))
+        if (toWords.StartsWith("een", StringComparison.Ordinal) &&
+            !toWords.StartsWith("een en", StringComparison.Ordinal))
         {
-            if (toWords.IndexOf("een en", StringComparison.Ordinal) != 0)
-            {
-                toWords = toWords.Remove(0, 4);
-            }
+            toWords = toWords.Remove(0, 4);
         }
 
         return toWords;

--- a/src/Humanizer/Localisation/NumberToWords/ArmenianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/ArmenianNumberToWordsConverter.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class ArmenianNumberToWordsConverter :
     GenderlessNumberToWordsConverter
@@ -166,17 +166,6 @@ class ArmenianNumberToWordsConverter :
         }
 
         return UnitsMap[number];
-    }
-
-    static string RemoveOnePrefix(string toWords)
-    {
-        // one hundred => hundredth
-        if (toWords.StartsWith("մեկ", StringComparison.Ordinal))
-        {
-            toWords = toWords.Remove(0, 4);
-        }
-
-        return toWords;
     }
 
     static bool ExceptionNumbersToWords(long number, [NotNullWhen(true)] out string? words) =>

--- a/src/Humanizer/Localisation/NumberToWords/BulgarianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/BulgarianNumberToWordsConverter.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class BulgarianNumberToWordsConverter() :
     GenderedNumberToWordsConverter(GrammaticalGender.Neuter)
@@ -66,7 +66,7 @@ class BulgarianNumberToWordsConverter() :
         return string.Join(" ", parts);
     }
 
-    static void CollectParts(IList<string> parts, ref long number, bool isOrdinal, long divisor, GrammaticalGender gender, string singular, string plural, string ordinal)
+    static void CollectParts(List<string> parts, ref long number, bool isOrdinal, long divisor, GrammaticalGender gender, string singular, string plural, string ordinal)
     {
         if (number < divisor)
         {
@@ -93,7 +93,7 @@ class BulgarianNumberToWordsConverter() :
         }
     }
 
-    static void CollectPartsUnderOneThousand(IList<string> parts, ref long number, bool isOrdinal, GrammaticalGender gender)
+    static void CollectPartsUnderOneThousand(List<string> parts, ref long number, bool isOrdinal, GrammaticalGender gender)
     {
         if (number == 0)
         {

--- a/src/Humanizer/Localisation/NumberToWords/FrenchBelgianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/FrenchBelgianNumberToWordsConverter.cs
@@ -1,8 +1,8 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class FrenchBelgianNumberToWordsConverter : FrenchNumberToWordsConverterBase
 {
-    protected override void CollectPartsUnderAHundred(ICollection<string> parts, ref long number, GrammaticalGender gender, bool pluralize)
+    protected override void CollectPartsUnderAHundred(List<string> parts, ref long number, GrammaticalGender gender, bool pluralize)
     {
         if (number == 80)
         {

--- a/src/Humanizer/Localisation/NumberToWords/FrenchNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/FrenchNumberToWordsConverter.cs
@@ -1,8 +1,8 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class FrenchNumberToWordsConverter : FrenchNumberToWordsConverterBase
 {
-    protected override void CollectPartsUnderAHundred(ICollection<string> parts, ref long number, GrammaticalGender gender, bool pluralize)
+    protected override void CollectPartsUnderAHundred(List<string> parts, ref long number, GrammaticalGender gender, bool pluralize)
     {
         if (number == 71)
         {

--- a/src/Humanizer/Localisation/NumberToWords/FrenchNumberToWordsConverterBase.cs
+++ b/src/Humanizer/Localisation/NumberToWords/FrenchNumberToWordsConverterBase.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 abstract class FrenchNumberToWordsConverterBase : GenderedNumberToWordsConverter
 {
@@ -79,7 +79,7 @@ abstract class FrenchNumberToWordsConverterBase : GenderedNumberToWordsConverter
         return UnitsMap[number];
     }
 
-    static void CollectHundreds(ICollection<string> parts, ref long number, long d, string form, bool pluralize)
+    static void CollectHundreds(List<string> parts, ref long number, long d, string form, bool pluralize)
     {
         if (number < d)
         {
@@ -107,7 +107,7 @@ abstract class FrenchNumberToWordsConverterBase : GenderedNumberToWordsConverter
         number %= d;
     }
 
-    void CollectParts(ICollection<string> parts, ref long number, long d, string form)
+    void CollectParts(List<string> parts, ref long number, long d, string form)
     {
         if (number < d)
         {
@@ -130,7 +130,7 @@ abstract class FrenchNumberToWordsConverterBase : GenderedNumberToWordsConverter
         number %= d;
     }
 
-    void CollectPartsUnderAThousand(ICollection<string> parts, long number, GrammaticalGender gender, bool pluralize)
+    void CollectPartsUnderAThousand(List<string> parts, long number, GrammaticalGender gender, bool pluralize)
     {
         CollectHundreds(parts, ref number, 100, "cent", pluralize);
 
@@ -140,7 +140,7 @@ abstract class FrenchNumberToWordsConverterBase : GenderedNumberToWordsConverter
         }
     }
 
-    void CollectThousands(ICollection<string> parts, ref long number, int d, string form)
+    void CollectThousands(List<string> parts, ref long number, int d, string form)
     {
         if (number < d)
         {
@@ -158,7 +158,7 @@ abstract class FrenchNumberToWordsConverterBase : GenderedNumberToWordsConverter
         number %= d;
     }
 
-    protected virtual void CollectPartsUnderAHundred(ICollection<string> parts, ref long number, GrammaticalGender gender, bool pluralize)
+    protected virtual void CollectPartsUnderAHundred(List<string> parts, ref long number, GrammaticalGender gender, bool pluralize)
     {
         if (number < 20)
         {

--- a/src/Humanizer/Localisation/NumberToWords/GermanNumberToWordsConverterBase.cs
+++ b/src/Humanizer/Localisation/NumberToWords/GermanNumberToWordsConverterBase.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 abstract class GermanNumberToWordsConverterBase : GenderedNumberToWordsConverter
 {
@@ -98,7 +98,7 @@ abstract class GermanNumberToWordsConverterBase : GenderedNumberToWordsConverter
         return string.Concat(parts);
     }
 
-    void CollectParts(ICollection<string> parts, ref long number, long divisor, bool addSpaceBeforeNextPart, string pluralFormat, string singular)
+    void CollectParts(List<string> parts, ref long number, long divisor, bool addSpaceBeforeNextPart, string pluralFormat, string singular)
     {
         if (number / divisor > 0)
         {
@@ -111,7 +111,7 @@ abstract class GermanNumberToWordsConverterBase : GenderedNumberToWordsConverter
         }
     }
 
-    void CollectOrdinalParts(ICollection<string> parts, ref int number, int divisor, bool evaluateNoRest, string[] pluralFormats, string[] singulars)
+    void CollectOrdinalParts(List<string> parts, ref int number, int divisor, bool evaluateNoRest, string[] pluralFormats, string[] singulars)
     {
         if (number / divisor > 0)
         {

--- a/src/Humanizer/Localisation/NumberToWords/IcelandicNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/IcelandicNumberToWordsConverter.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class IcelandicNumberToWordsConverter : GenderedNumberToWordsConverter
 {
@@ -110,7 +110,7 @@ class IcelandicNumberToWordsConverter : GenderedNumberToWordsConverter
     static string GetOrdinalEnding(GrammaticalGender gender) =>
         gender == GrammaticalGender.Masculine ? "i" : "a";
 
-    static void GetUnits(ICollection<string?> builder, long number, GrammaticalGender gender)
+    static void GetUnits(List<string?> builder, long number, GrammaticalGender gender)
     {
         if (number is > 0 and < 5)
         {
@@ -129,7 +129,7 @@ class IcelandicNumberToWordsConverter : GenderedNumberToWordsConverter
         }
     }
 
-    static void CollectOrdinalParts(ICollection<string?> builder, int threeDigitPart, Fact conversionRule, GrammaticalGender partGender, GrammaticalGender ordinalGender)
+    static void CollectOrdinalParts(List<string?> builder, int threeDigitPart, Fact conversionRule, GrammaticalGender partGender, GrammaticalGender ordinalGender)
     {
         var hundreds = threeDigitPart / 100;
         var hundredRemainder = threeDigitPart % 100;
@@ -225,7 +225,7 @@ class IcelandicNumberToWordsConverter : GenderedNumberToWordsConverter
         return null;
     }
 
-    static void CollectParts(IList<string?> parts, ref long number, ref bool needsAnd, Fact rule)
+    static void CollectParts(List<string?> parts, ref long number, ref bool needsAnd, Fact rule)
     {
         var remainder = number / rule.Power;
         if (remainder > 0)
@@ -244,7 +244,7 @@ class IcelandicNumberToWordsConverter : GenderedNumberToWordsConverter
         }
     }
 
-    static void CollectPart(ICollection<string?> parts, long number, Fact rule)
+    static void CollectPart(List<string?> parts, long number, Fact rule)
     {
         if (number == 1)
         {
@@ -257,7 +257,7 @@ class IcelandicNumberToWordsConverter : GenderedNumberToWordsConverter
         }
     }
 
-    static void CollectPartUnderOneThousand(ICollection<string?> builder, long number, GrammaticalGender gender)
+    static void CollectPartUnderOneThousand(List<string?> builder, long number, GrammaticalGender gender)
     {
         var hundreds = number / 100;
         var hundredRemainder = number % 100;
@@ -300,7 +300,7 @@ class IcelandicNumberToWordsConverter : GenderedNumberToWordsConverter
         }
     }
 
-    static void CollectOrdinal(IList<string?> parts, ref int number, ref bool needsAnd, Fact rule, GrammaticalGender gender)
+    static void CollectOrdinal(List<string?> parts, ref int number, ref bool needsAnd, Fact rule, GrammaticalGender gender)
     {
         var remainder = number / rule.Power;
         if (remainder > 0)

--- a/src/Humanizer/Localisation/NumberToWords/IndianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/IndianNumberToWordsConverter.cs
@@ -1,35 +1,7 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class IndianNumberToWordsConverter : GenderlessNumberToWordsConverter
 {
-    static readonly Dictionary<long, string> OrdinalExceptions = new()
-    {
-        {
-            1, "first"
-        },
-        {
-            2, "second"
-        },
-        {
-            3, "third"
-        },
-        {
-            4, "fourth"
-        },
-        {
-            5, "fifth"
-        },
-        {
-            8, "eighth"
-        },
-        {
-            9, "ninth"
-        },
-        {
-            12, "twelfth"
-        },
-    };
-
     static readonly string[] Tillnineteen =
     [
         "one", "two", "three", "four", "five", "six", "seven", "eight",
@@ -81,7 +53,4 @@ class IndianNumberToWordsConverter : GenderlessNumberToWordsConverter
         return NumberToText(number / 10000000)
             .Trim() + " crore " + NumberToText(number % 10000000);
     }
-
-    static bool ExceptionNumbersToWords(long number, [NotNullWhen(true)] out string? words) =>
-        OrdinalExceptions.TryGetValue(number, out words);
 }

--- a/src/Humanizer/Localisation/NumberToWords/Italian/ItalianCardinalNumberCruncher.cs
+++ b/src/Humanizer/Localisation/NumberToWords/Italian/ItalianCardinalNumberCruncher.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class ItalianCardinalNumberCruncher(int number, GrammaticalGender gender)
 {
@@ -230,7 +230,7 @@ class ItalianCardinalNumberCruncher(int number, GrammaticalGender gender)
     /// <summary>
     /// Lookup table converting units number to text. Index 1 for 1, index 2 for 2, up to index 9.
     /// </summary>
-    static string[] _unitsNumberToText =
+    static readonly string[] _unitsNumberToText =
     [
         string.Empty,
         "uno",
@@ -247,7 +247,7 @@ class ItalianCardinalNumberCruncher(int number, GrammaticalGender gender)
     /// <summary>
     /// Lookup table converting tens number to text. Index 2 for 20, index 3 for 30, up to index 9 for 90.
     /// </summary>
-    static string[] _tensOver20NumberToText =
+    static readonly string[] _tensOver20NumberToText =
     [
         string.Empty,
         string.Empty,
@@ -264,7 +264,7 @@ class ItalianCardinalNumberCruncher(int number, GrammaticalGender gender)
     /// <summary>
     /// Lookup table converting teens number to text. Index 0 for 10, index 1 for 11, up to index 9 for 19.
     /// </summary>
-    static string[] _teensUnder20NumberToText =
+    static readonly string[] _teensUnder20NumberToText =
     [
         "dieci",
         "undici",
@@ -281,7 +281,7 @@ class ItalianCardinalNumberCruncher(int number, GrammaticalGender gender)
     /// <summary>
     /// Lookup table converting hundreds number to text. Index 0 for no hundreds, index 1 for 100, up to index 9.
     /// </summary>
-    static string[] _hundredNumberToText =
+    static readonly string[] _hundredNumberToText =
     [
         string.Empty,
         "cento",

--- a/src/Humanizer/Localisation/NumberToWords/Italian/ItalianOrdinalNumberCruncher.cs
+++ b/src/Humanizer/Localisation/NumberToWords/Italian/ItalianOrdinalNumberCruncher.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class ItalianOrdinalNumberCruncher(int number, GrammaticalGender gender)
 {
@@ -90,7 +90,7 @@ class ItalianOrdinalNumberCruncher(int number, GrammaticalGender gender)
     /// <summary>
     /// Lookup table converting units number to text. Index 1 for 1, index 2 for 2, up to index 9.
     /// </summary>
-    static string[] _unitsUnder10NumberToText =
+    static readonly string[] _unitsUnder10NumberToText =
     [
         string.Empty,
         "prim",
@@ -104,5 +104,5 @@ class ItalianOrdinalNumberCruncher(int number, GrammaticalGender gender)
         "non"
     ];
 
-    static int _lengthOf10AsCardinal = "dieci".Length;
+    static readonly int _lengthOf10AsCardinal = "dieci".Length;
 }

--- a/src/Humanizer/Localisation/NumberToWords/LithuanianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/LithuanianNumberToWordsConverter.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class LithuanianNumberToWordsConverter : GenderedNumberToWordsConverter
 {
@@ -60,7 +60,7 @@ class LithuanianNumberToWordsConverter : GenderedNumberToWordsConverter
         }
     }
 
-    static void CollectParts(ICollection<string> parts, ref long number, long divisor,
+    static void CollectParts(List<string> parts, ref long number, long divisor,
         GrammaticalGender gender, params string[] forms)
     {
         var result = number / divisor;
@@ -79,7 +79,7 @@ class LithuanianNumberToWordsConverter : GenderedNumberToWordsConverter
         parts.Add(ChooseForm(result, forms));
     }
 
-    static void CollectOrdinalParts(ICollection<string> parts, ref long number, long divisor,
+    static void CollectOrdinalParts(List<string> parts, ref long number, long divisor,
         GrammaticalGender gender, string ordinalForm, params string[] forms)
     {
         var result = number / divisor;
@@ -98,7 +98,7 @@ class LithuanianNumberToWordsConverter : GenderedNumberToWordsConverter
         parts.Add(ChooseCardinalOrOrdinalForm(result, ordinalForm, forms, useOrdinalForm: number == 0));
     }
 
-    static void CollectPartsUnderOneThousand(ICollection<string> parts, long number, GrammaticalGender gender)
+    static void CollectPartsUnderOneThousand(List<string> parts, long number, GrammaticalGender gender)
     {
         if (number >= 100)
         {
@@ -120,7 +120,7 @@ class LithuanianNumberToWordsConverter : GenderedNumberToWordsConverter
         }
     }
 
-    static void CollectOrdinalPartsUnderOneThousand(ICollection<string> parts, long number,
+    static void CollectOrdinalPartsUnderOneThousand(List<string> parts, long number,
         GrammaticalGender gender, bool lastNumber = false)
     {
         if (number >= 100)

--- a/src/Humanizer/Localisation/NumberToWords/LuxembourgishNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/LuxembourgishNumberToWordsConverter.cs
@@ -115,7 +115,7 @@ class LuxembourgishNumberToWordsConverter : GenderedNumberToWordsConverter
         return string.Concat(parts);
     }
 
-    private void CollectParts(ICollection<string> parts, ref long number, long divisor, bool addSpaceBeforeNextPart, string pluralFormat, string singular)
+    private void CollectParts(List<string> parts, ref long number, long divisor, bool addSpaceBeforeNextPart, string pluralFormat, string singular)
     {
         if (number / divisor <= 0)
         {
@@ -130,7 +130,7 @@ class LuxembourgishNumberToWordsConverter : GenderedNumberToWordsConverter
         }
     }
 
-    private void CollectOrdinalParts(ICollection<string> parts, ref int number, int divisor, bool evaluateNoRest, string[] pluralFormats, string[] singulars)
+    private void CollectOrdinalParts(List<string> parts, ref int number, int divisor, bool evaluateNoRest, string[] pluralFormats, string[] singulars)
     {
         if (number / divisor <= 0)
         {

--- a/src/Humanizer/Localisation/NumberToWords/PolishNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/PolishNumberToWordsConverter.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class PolishNumberToWordsConverter(CultureInfo culture) :
     GenderedNumberToWordsConverter
@@ -49,7 +49,7 @@ class PolishNumberToWordsConverter(CultureInfo culture) :
     public override string ConvertToOrdinal(int number, GrammaticalGender gender) =>
         number.ToString(culture);
 
-    static void CollectParts(ICollection<string> parts, long input, GrammaticalGender gender)
+    static void CollectParts(List<string> parts, long input, GrammaticalGender gender)
     {
         var inputSign = 1;
         if (input < 0)
@@ -92,7 +92,7 @@ class PolishNumberToWordsConverter(CultureInfo culture) :
         }
     }
 
-    static void CollectPartsUnderThousand(ICollection<string> parts, int number, GrammaticalGender gender)
+    static void CollectPartsUnderThousand(List<string> parts, int number, GrammaticalGender gender)
     {
         var hundredsDigit = number / 100;
         var tensDigit = number % 100 / 10;

--- a/src/Humanizer/Localisation/NumberToWords/RussianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/RussianNumberToWordsConverter.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class RussianNumberToWordsConverter : GenderedNumberToWordsConverter
 {
@@ -97,7 +97,7 @@ class RussianNumberToWordsConverter : GenderedNumberToWordsConverter
         return string.Join(" ", parts);
     }
 
-    static void CollectPartsUnderOneThousand(ICollection<string> parts, long number, GrammaticalGender gender)
+    static void CollectPartsUnderOneThousand(List<string> parts, long number, GrammaticalGender gender)
     {
         if (number >= 100)
         {
@@ -167,7 +167,7 @@ class RussianNumberToWordsConverter : GenderedNumberToWordsConverter
         return string.Concat(parts);
     }
 
-    static void CollectParts(ICollection<string> parts, ref long number, long divisor, GrammaticalGender gender, params string[] forms)
+    static void CollectParts(List<string> parts, ref long number, long divisor, GrammaticalGender gender, params string[] forms)
     {
         var result = Math.Abs(number / divisor);
         if (result == 0)
@@ -180,7 +180,7 @@ class RussianNumberToWordsConverter : GenderedNumberToWordsConverter
         number = Math.Abs(number % divisor);
     }
 
-    static void CollectOrdinalParts(ICollection<string> parts, ref long number, int divisor, GrammaticalGender gender, string prefixedForm, params string[] forms)
+    static void CollectOrdinalParts(List<string> parts, ref long number, int divisor, GrammaticalGender gender, string prefixedForm, params string[] forms)
     {
         if (number < divisor)
         {

--- a/src/Humanizer/Localisation/NumberToWords/SpanishNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/SpanishNumberToWordsConverter.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class SpanishNumberToWordsConverter : GenderedNumberToWordsConverter
 {
@@ -129,11 +129,10 @@ class SpanishNumberToWordsConverter : GenderedNumberToWordsConverter
         return Convert(number) + " veces";
     }
 
-    static string BuildWord(IReadOnlyList<string> wordParts)
+    static string BuildWord(List<string> wordParts)
     {
-        var parts = wordParts.ToList();
-        parts.RemoveAll(string.IsNullOrEmpty);
-        return string.Join(" ", parts);
+        wordParts.RemoveAll(string.IsNullOrEmpty);
+        return string.Join(" ", wordParts);
     }
 
     static string ConvertHundreds(in long inputNumber, out long remainder, GrammaticalGender gender)
@@ -228,7 +227,7 @@ class SpanishNumberToWordsConverter : GenderedNumberToWordsConverter
         return wordPart + $" y {UnitsMap[inputNumber % 10]}";
     }
 
-    static IReadOnlyList<string> GetGenderedHundredsMap(GrammaticalGender gender)
+    static List<string> GetGenderedHundredsMap(GrammaticalGender gender)
     {
         var genderedEnding = gender == GrammaticalGender.Feminine ? "as" : "os";
         var map = new List<string>();
@@ -282,25 +281,19 @@ class SpanishNumberToWordsConverter : GenderedNumberToWordsConverter
     static string PluralizeGreaterThanMillion(string singularWord) =>
         singularWord.TrimEnd('ó', 'n') + "ones";
 
-    static Dictionary<string, long> numbersAndWordsDict = new()
-    {
-        {
-            "trillón", 1_000_000_000_000_000_000
-        },
-        {
-            "billón", 1_000_000_000_000
-        },
-        {
-            "millón", 1_000_000
-        }
-    };
+    static readonly KeyValuePair<string, long>[] NumbersAndWordsDict =
+    [
+        new KeyValuePair<string, long>("trillón", 1_000_000_000_000_000_000),
+        new KeyValuePair<string, long>("billón", 1_000_000_000_000),
+        new KeyValuePair<string, long>("millón", 1_000_000),
+    ];
 
     string ConvertGreaterThanMillion(in long inputNumber, out long remainder)
     {
         List<string> wordBuilder = [];
 
         remainder = inputNumber;
-        foreach (var numberAndWord in numbersAndWordsDict)
+        foreach (var numberAndWord in NumbersAndWordsDict)
         {
             if (remainder / numberAndWord.Value > 0)
             {

--- a/src/Humanizer/Localisation/NumberToWords/SwedishNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/SwedishNumberToWordsConverter.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class SwedishNumberToWordsConverter : GenderlessNumberToWordsConverter
 {
@@ -140,7 +140,7 @@ class SwedishNumberToWordsConverter : GenderlessNumberToWordsConverter
     public override string Convert(long input) =>
         Convert(input, GrammaticalGender.Neuter);
 
-    static string[] ordinalNumbers =
+    static readonly string[] OrdinalNumbers =
     [
         "nollte",
         "första",
@@ -176,7 +176,7 @@ class SwedishNumberToWordsConverter : GenderlessNumberToWordsConverter
 
         if (number <= 20)
         {
-            return ordinalNumbers[number];
+            return OrdinalNumbers[number];
         }
 
         // 21+

--- a/src/Humanizer/Localisation/NumberToWords/UkrainianNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/UkrainianNumberToWordsConverter.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class UkrainianNumberToWordsConverter : GenderedNumberToWordsConverter
 {
@@ -96,7 +96,7 @@ class UkrainianNumberToWordsConverter : GenderedNumberToWordsConverter
         return string.Join(" ", parts);
     }
 
-    static void CollectPartsUnderOneThousand(ICollection<string> parts, long number, GrammaticalGender gender)
+    static void CollectPartsUnderOneThousand(List<string> parts, long number, GrammaticalGender gender)
     {
         if (number >= 100)
         {
@@ -166,7 +166,7 @@ class UkrainianNumberToWordsConverter : GenderedNumberToWordsConverter
         return string.Concat(parts);
     }
 
-    static void CollectParts(ICollection<string> parts, ref long number, long divisor, GrammaticalGender gender, params string[] forms)
+    static void CollectParts(List<string> parts, ref long number, long divisor, GrammaticalGender gender, params string[] forms)
     {
         var result = Math.Abs(number / divisor);
         if (result == 0)
@@ -179,7 +179,7 @@ class UkrainianNumberToWordsConverter : GenderedNumberToWordsConverter
         number = Math.Abs(number % divisor);
     }
 
-    static void CollectOrdinalParts(ICollection<string> parts, ref int number, int divisor, GrammaticalGender gender, string prefixedForm, params string[] forms)
+    static void CollectOrdinalParts(List<string> parts, ref int number, int divisor, GrammaticalGender gender, string prefixedForm, params string[] forms)
     {
         if (number < divisor)
         {

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Wrote by Alois de Gouvello https://github.com/aloisdg
+// Wrote by Alois de Gouvello https://github.com/aloisdg
 
 // The MIT License (MIT)
 
@@ -29,15 +29,10 @@ namespace Humanizer;
 /// </summary>
 public static class MetricNumeralExtensions
 {
-    static readonly double BigLimit;
-    static readonly double SmallLimit;
+    const int limit = 27;
 
-    static MetricNumeralExtensions()
-    {
-        const int limit = 27;
-        BigLimit = Math.Pow(10, limit);
-        SmallLimit = Math.Pow(10, -limit);
-    }
+    static readonly double BigLimit = Math.Pow(10, limit);
+    static readonly double SmallLimit = Math.Pow(10, -limit);
 
     /// <summary>
     /// Symbols is a list of every symbols for the Metric system.

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -9,22 +9,18 @@ namespace Humanizer;
 /// </summary>
 public static class StringHumanizeExtensions
 {
-    static readonly Regex PascalCaseWordPartsRegex;
-    static readonly Regex FreestandingSpacingCharRegex;
+    static readonly Regex PascalCaseWordPartsRegex = new(
+        $"({OptionallyCapitalizedWord}|{IntegerAndOptionalLowercaseLetters}|{Acronym}|{SequenceOfOtherLetters}){MidSentencePunctuation}",
+        RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture | RegexOptions.Compiled);
+
+    static readonly Regex FreestandingSpacingCharRegex =
+        new(@"\s[-_]|[-_]\s", RegexOptions.Compiled);
 
     const string OptionallyCapitalizedWord = @"\p{Lu}?\p{Ll}+";
     const string IntegerAndOptionalLowercaseLetters = @"[0-9]+\p{Ll}*";
     const string Acronym = @"\p{Lu}+(?=\p{Lu}|[0-9]|\b)";
     const string SequenceOfOtherLetters = @"\p{Lo}+";
     const string MidSentencePunctuation = "[,;]?";
-
-    static StringHumanizeExtensions()
-    {
-        PascalCaseWordPartsRegex = new(
-            $"({OptionallyCapitalizedWord}|{IntegerAndOptionalLowercaseLetters}|{Acronym}|{SequenceOfOtherLetters}){MidSentencePunctuation}",
-            RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture | RegexOptions.Compiled);
-        FreestandingSpacingCharRegex = new(@"\s[-_]|[-_]\s", RegexOptions.Compiled);
-    }
 
     static string FromUnderscoreDashSeparatedWords(string input) =>
         string.Join(" ", input.Split(['_', '-']));

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 /// <summary>
 /// Humanizes TimeSpan into human readable form
@@ -9,7 +9,7 @@ public static class TimeSpanHumanizeExtensions
     const double _daysInAYear = 365.2425; // see https://en.wikipedia.org/wiki/Gregorian_calendar
     const double _daysInAMonth = _daysInAYear / 12;
 
-    static TimeUnit[] _timeUnits = Enum
+    static readonly TimeUnit[] _timeUnits = Enum
         .GetValues(typeof(TimeUnit))
         .Cast<TimeUnit>()
         .Reverse()
@@ -185,7 +185,7 @@ public static class TimeSpanHumanizeExtensions
         [noTimeValue];
 
     static bool IsContainingOnlyNullValue(IEnumerable<string?> timeParts) =>
-        timeParts.Count(x => x != null) == 0;
+        !timeParts.Any(x => x != null);
 
     static IEnumerable<string?> SetPrecisionOfTimeSpan(IEnumerable<string?> timeParts, int precision, bool countEmptyUnits)
     {

--- a/src/Humanizer/Transformer/ToTitleCase.cs
+++ b/src/Humanizer/Transformer/ToTitleCase.cs
@@ -1,11 +1,11 @@
-﻿namespace Humanizer;
+namespace Humanizer;
 
 class ToTitleCase : ICulturedStringTransformer
 {
     public string Transform(string input) =>
         Transform(input, null);
 
-    static Regex regex = new(@"(\w|[^\u0000-\u007F])+'?\w*", RegexOptions.Compiled);
+    static readonly Regex regex = new(@"(\w|[^\u0000-\u007F])+'?\w*", RegexOptions.Compiled);
 
     public string Transform(string input, CultureInfo? culture)
     {
@@ -16,7 +16,7 @@ class ToTitleCase : ICulturedStringTransformer
         foreach (Match word in matches)
         {
             var value = word.Value;
-            if (AllCapitals(value) || lookups.Contains(value))
+            if (AllCapitals(value) || IsArticleOrConjunctionOrPreposition(value))
             {
                 continue;
             }
@@ -46,14 +46,15 @@ class ToTitleCase : ICulturedStringTransformer
         return true;
     }
 
-    static FrozenSet<string> lookups;
+    private static bool IsArticleOrConjunctionOrPreposition(string word) =>
+        word is
 
-    static ToTitleCase()
-    {
-        var articles = new List<string> { "a", "an", "the" };
-        var conjunctions = new List<string> { "and", "as", "but", "if", "nor", "or", "so", "yet" };
-        var prepositions = new List<string> { "as", "at", "by", "for", "in", "of", "off", "on", "to", "up", "via" };
+            // articles
+            "a" or "an" or "the" or
 
-        lookups = articles.Concat(conjunctions).Concat(prepositions).ToFrozenSet();
-    }
+            // conjunctions
+            "and" or  "as" or  "but" or  "if" or  "nor" or  "or" or  "so" or  "yet" or
+
+            // prepositions
+            "as" or  "at" or  "by" or  "for" or  "in" or  "of" or  "off" or  "on" or  "to" or  "up" or  "via";
 }

--- a/src/Humanizer/Truncation/FixedNumberOfWordsTruncator.cs
+++ b/src/Humanizer/Truncation/FixedNumberOfWordsTruncator.cs
@@ -18,7 +18,7 @@ class FixedNumberOfWordsTruncator : ITruncator
             return value;
         }
 
-        var numberOfWords = value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Count();
+        var numberOfWords = value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length;
         if (numberOfWords <= length)
         {
             return value;


### PR DESCRIPTION
- Where possible, avoid explicit static ctors. They add overhead when accessing statics on a type. PGO can help avoid this overhead, but it's still better to avoid it by design.

- Where relevant, use switch instead of frozen dictionary/set. The frozen collections are great, but when all the data is known at compile time, optimizations performed by switch are generally as good (I confirmed they are in these cases), and switches have less memory overhead.

- Use readonly on static fields that never change. The JIT can optimize static readonly fields better than mutable statics.

- Using StartsWith is better than IndexOf != 0, as the latter needs to search the whole input rather than just checking the beginning.

- Delete unused methods.

- Using `List<T>` instead of `ICollection<T>`, `IReadOnlyList<T>`, or `IList<T>` in internal APIs allows better optimization, e.g. foreach'ing won't allocate, indexing can be inlined without help from dynamic PGO, etc.

- Use an array instead of a dictionary when the only consumers are enumerating.

- Use Length on an array instead of Count().

- Use !Any(predicate) instead of Count(predicate) == 0, as the latter needs to enumerate everything whereas the former can early exit.