### PR TITLE
Replace "ناقص" with "سالب" for negative number representation in Arabic

### DIFF
--- a/src/Humanizer.Tests/Localisation/ar/NumberToWordsTests.cs
+++ b/src/Humanizer.Tests/Localisation/ar/NumberToWordsTests.cs
@@ -15,12 +15,12 @@ public class NumberToWordsTests
         Assert.Equal(expected, number.ToWords());
 
     [Theory]
-    [InlineData("ناقص واحد", -1)]
-    [InlineData("ناقص اثنان", -2)]
-    [InlineData("ناقص اثنان و عشرون", -22)]
-    [InlineData("ناقص أحد عشر", -11)]
-    [InlineData("ناقص ثلاثة آلاف و خمس مئة و واحد", -3501)]
-    [InlineData("ناقص مليون و واحد", -1000001)]
+    [InlineData("سالب واحد", -1)]
+    [InlineData("سالب اثنان", -2)]
+    [InlineData("سالب اثنان و عشرون", -22)]
+    [InlineData("سالب أحد عشر", -11)]
+    [InlineData("سالب ثلاثة آلاف و خمس مئة و واحد", -3501)]
+    [InlineData("سالب مليون و واحد", -1000001)]
     public void ToWordsArabicNegative(string expected, int number) =>
         Assert.Equal(expected, number.ToWords());
 
@@ -46,8 +46,8 @@ public class NumberToWordsTests
     [InlineData(1111111111111111111L, "كوينتليون و مئة و أحد عشر كوادريليوناً و مئة و أحد عشر تريليوناً و مئة و أحد عشر ملياراً و مئة و أحد عشر مليوناً و مئة و أحد عشر ألفاً و مئة و أحد عشر")]
     [InlineData(10000000001L, "عشرة مليارات و واحد")]
     [InlineData(8750000500001L, "ثمانية تريليونات و سبع مئة و خمسون ملياراً و خمس مئة ألفاً و واحد")]
-    [InlineData(-10000000001L, "ناقص عشرة مليارات و واحد")]
-    [InlineData(-8750000500001L, "ناقص ثمانية تريليونات و سبع مئة و خمسون ملياراً و خمس مئة ألفاً و واحد")]
+    [InlineData(-10000000001L, "سالب عشرة مليارات و واحد")]
+    [InlineData(-8750000500001L, "سالب ثمانية تريليونات و سبع مئة و خمسون ملياراً و خمس مئة ألفاً و واحد")]
     public void ToWordsArabicLong(long number, string expected) =>
         Assert.Equal(expected, number.ToWords());
 

--- a/src/Humanizer/Localisation/NumberToWords/ArabicNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/ArabicNumberToWordsConverter.cs
@@ -23,7 +23,7 @@ class ArabicNumberToWordsConverter :
 
         if (number < 0)
         {
-            return $"ناقص {Convert(-number, gender)}";
+            return $"سالب {Convert(-number, gender)}";
         }
 
         var result = string.Empty;


### PR DESCRIPTION
I updated the Arabic representation of negative numbers from "ناقص" to "سالب" to provide a more accurate translation.

