### PR TITLE
fixed exception thrown in lithuanian language for DateHumanize_Now resource key

### DIFF
--- a/src/Humanizer.Tests/Localisation/lt/DateHumanizeTests.cs
+++ b/src/Humanizer.Tests/Localisation/lt/DateHumanizeTests.cs
@@ -1,7 +1,7 @@
 namespace lt;
 
 [UseCulture("lt")]
-public class DateHÍumanizeTests
+public class DateHumanizeTests
 {
     [Fact]
     public void Now() =>

--- a/src/Humanizer.Tests/Localisation/lt/DateHumanizeTests.cs
+++ b/src/Humanizer.Tests/Localisation/lt/DateHumanizeTests.cs
@@ -1,0 +1,9 @@
+namespace lt;
+
+[UseCulture("lt")]
+public class DateHÍumanizeTests
+{
+    [Fact]
+    public void Now() =>
+        DateHumanize.Verify("dabar", 0, TimeUnit.Millisecond, Tense.Past);
+}

--- a/src/Humanizer/Localisation/Formatters/LithuanianFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/LithuanianFormatter.cs
@@ -3,9 +3,11 @@
 class LithuanianFormatter(CultureInfo culture) :
     DefaultFormatter(culture)
 {
+    private static HashSet<string> keysWithoutNumbersForms = ["TimeSpanHumanize_Zero", "DateHumanize_Now"];
+
     protected override string GetResourceKey(string resourceKey, int number)
     {
-        if (resourceKey == "TimeSpanHumanize_Zero")
+        if (keysWithoutNumbersForms.Contains(resourceKey))
         {
             return resourceKey;
         }

--- a/src/Humanizer/Localisation/Formatters/LithuanianFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/LithuanianFormatter.cs
@@ -3,11 +3,11 @@
 class LithuanianFormatter(CultureInfo culture) :
     DefaultFormatter(culture)
 {
-    private static HashSet<string> keysWithoutNumbersForms = ["TimeSpanHumanize_Zero", "DateHumanize_Now"];
+    private static HashSet<string> keysWithoutNumberForms = ["TimeSpanHumanize_Zero", "DateHumanize_Now"];
 
     protected override string GetResourceKey(string resourceKey, int number)
     {
-        if (keysWithoutNumbersForms.Contains(resourceKey))
+        if (keysWithoutNumberForms.Contains(resourceKey))
         {
             return resourceKey;
         }


### PR DESCRIPTION
…source key

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures

fix for lt language: 
System.ArgumentException: The resource object with key 'DateHumanize_Now_Plural' was not found (Parameter 'resourceKey')



