### PR TITLE
Potential fix for code scanning alert no. 24: Possible loss of precision

### DIFF
--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -223,7 +223,7 @@ public static class MetricNumeralExtensions
     /// <returns>A number build from a Metric representation</returns>
     static double BuildMetricNumber(string input, char last)
     {
-        double getExponent(List<char> symbols) => (symbols.IndexOf(last) + 1) * 3;
+        double getExponent(List<char> symbols) => (symbols.IndexOf(last) + 1) * 3.0;
         var number = double.Parse(input.Remove(input.Length - 1));
         var exponent = Math.Pow(10, Symbols[0]
             .Contains(last)


### PR DESCRIPTION
Potential fix for [https://github.com/Humanizr/Humanizer/security/code-scanning/24](https://github.com/Humanizr/Humanizer/security/code-scanning/24)

To ensure there's no possible overflow during integer multiplication, one operand should be cast to `double` before performing the multiplication. The clearest way is to cast the sum to `double`, or just the constant, or the entire expression, prior to multiplication.  
Edit the line in `BuildMetricNumber`, within `getExponent(List<char> symbols) => (symbols.IndexOf(last) + 1) * 3;`, casting one operand to `double`, i.e.:
- `getExponent(List<char> symbols) => ((double)symbols.IndexOf(last) + 1) * 3;`  
or  
- `getExponent(List<char> symbols) => (symbols.IndexOf(last) + 1) * 3.0;`

Either form ensures floating-point arithmetic, avoiding any possible integer overflow.

Only line 226 needs to be updated. No other code, imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
