### PR TITLE
Improve bit size validation in ByteSize.cs

### DIFF
--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -467,17 +467,13 @@ public struct ByteSize(double byteSize) :
             case ByteSymbol:
                 if (sizePart.SequenceEqual(BitSymbol))
                 {
-                    // Bits
-                    if (number % 1 != 0) // Can't have partial bits
-                    {
-                        return false;
-                    }
-
-                    result = FromBits((long) number);
+                    if (!double.IsFinite(number)) return false;
+                    if (number != Math.Truncate(number)) return false;
+                    if (number < long.MinValue || number > long.MaxValue) return false;
+                    result = FromBits((long)number);
                 }
                 else
                 {
-                    // Bytes
                     result = FromBytes(number);
                 }
 


### PR DESCRIPTION
This pull request updates the bit parsing logic in the `ByteSize` class to improve input validation when parsing bit values. The main change is a more comprehensive check for valid bit numbers, ensuring only finite, whole numbers within the range of a 64-bit integer are accepted.

Validation improvements for bit parsing:

* Enhanced the validation in the `TryParse` method of `ByteSize.cs` to reject non-finite, non-integer, and out-of-range values when parsing bits, making the input handling more robust.