### PR TITLE
Add long.ToMetric and associated tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -994,6 +994,14 @@ Also, the reverse operation using the `FromMetric` extension.
 "100m".FromMetric() => 0.1
 ```
 
+The `int` and `long` data types are also supported:
+
+```C#
+((int)456789).ToMetric(decimals: 2) => "456.79k"
+((int)456789).ToMetric(decimals: 20) => "456.78900000000000000000k"
+long.MaxValue.ToMetric(decimals: 12) => "9.223372036855E"
+```
+
 
 ### ByteSize
 

--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -800,6 +800,7 @@ namespace Humanizer
         public static double FromMetric(this string input) { }
         public static string ToMetric(this double input, Humanizer.MetricNumeralFormats? formats = default, int? decimals = default) { }
         public static string ToMetric(this int input, Humanizer.MetricNumeralFormats? formats = default, int? decimals = default) { }
+        public static string ToMetric(this long input, Humanizer.MetricNumeralFormats? formats = default, int? decimals = default) { }
     }
     [System.Flags]
     public enum MetricNumeralFormats

--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -799,6 +799,7 @@ namespace Humanizer
         public static double FromMetric(this string input) { }
         public static string ToMetric(this double input, Humanizer.MetricNumeralFormats? formats = default, int? decimals = default) { }
         public static string ToMetric(this int input, Humanizer.MetricNumeralFormats? formats = default, int? decimals = default) { }
+        public static string ToMetric(this long input, Humanizer.MetricNumeralFormats? formats = default, int? decimals = default) { }
     }
     [System.Flags]
     public enum MetricNumeralFormats

--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -580,6 +580,7 @@ namespace Humanizer
         public static double FromMetric(this string input) { }
         public static string ToMetric(this double input, Humanizer.MetricNumeralFormats? formats = default, int? decimals = default) { }
         public static string ToMetric(this int input, Humanizer.MetricNumeralFormats? formats = default, int? decimals = default) { }
+        public static string ToMetric(this long input, Humanizer.MetricNumeralFormats? formats = default, int? decimals = default) { }
     }
     [System.Flags]
     public enum MetricNumeralFormats

--- a/src/Humanizer.Tests/MetricNumeralTests.cs
+++ b/src/Humanizer.Tests/MetricNumeralTests.cs
@@ -1,4 +1,4 @@
-﻿[UseCulture("en-US")]
+[UseCulture("en-US")]
 public class MetricNumeralTests
 {
     // Return a sequence of -24 -> 26
@@ -74,6 +74,49 @@ public class MetricNumeralTests
                 .ToString("0.##E+0", CultureInfo.InvariantCulture));
         Assert.True(isEquals);
     }
+
+    [Theory]
+    [InlineData(0, 0, "0")]
+    [InlineData(0, 1, "0.0")]
+    [InlineData(0, 3, "0.000")]
+    [InlineData(0, 20, "0.00000000000000000000")]
+    [InlineData(123, 0, "123")]
+    [InlineData(123, 1, "123.0")]
+    [InlineData(123, 3, "123.000")]
+    [InlineData(123, 20, "123.00000000000000000000")]
+    [InlineData(123456, null, "123.456k")]
+    [InlineData(123456, 0, "123k")]
+    [InlineData(123456, 1, "123.5k")]
+    [InlineData(123456, 2, "123.46k")]
+    [InlineData(123456, 3, "123.456k")]
+    [InlineData(123456, 20, "123.45600000000000000000k")]
+    [InlineData(123456789, null, "123.456789M")]
+    [InlineData(123456789, 0, "123M")]
+    [InlineData(123456789, 1, "123.5M")]
+    [InlineData(123456789, 2, "123.46M")]
+    [InlineData(123456789, 3, "123.457M")]
+    [InlineData(123456789, 5, "123.45679M")]
+    [InlineData(123456789, 20, "123.45678900000000000000M")]
+    [InlineData(123456789987, 5, "123.45679G")]
+    [InlineData(123456789987, 20, "123.45678998700000000000G")]
+    [InlineData(123456789987654, 5, "123.45679T")]
+    [InlineData(123456789987654, 20, "123.45678998765400000000T")]
+    [InlineData(123456789987654321, 5, "123.45679P")]
+    [InlineData(123456789987654321, 20, "123.45678998765432100000P")]
+    [InlineData(9223372036854775807, null, "9.223372036854775807E")]
+    [InlineData(9223372036854775807, 0, "9E")]
+    [InlineData(9223372036854775807, 3, "9.223E")]
+    [InlineData(9223372036854775807, 20, "9.22337203685477580700E")]
+    [InlineData(-1, null, "-1")]
+    [InlineData(-123, null, "-123")]
+    [InlineData(-123456, null, "-123.456k")]
+    [InlineData(-123456789, null, "-123.456789M")]
+    [InlineData(-9223372036854775808, null, "-9.223372036854775808E")]
+    [InlineData(-9223372036854775808, 0, "-9E")]
+    [InlineData(-9223372036854775808, 3, "-9.223E")]
+    [InlineData(-9223372036854775808, 20, "-9.22337203685477580800E")]
+    public void TestAllSymbolsAsLong(long subject, int? decimals, string expected) =>
+        Assert.Equal(expected, subject.ToMetric(decimals: decimals));
 
     [Theory]
     [InlineData("1.3M", 1300000, null, null)]

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -161,6 +161,34 @@ public static class MetricNumeralExtensions
     /// <param name="decimals">If not null it is the numbers of decimals to round the number to</param>
     /// <example>
     /// <code>
+    /// 1000.ToMetric() => "1k"
+    /// 123.ToMetric() => "123"
+    /// 1E-1.ToMetric() => "100m"
+    /// </code>
+    /// </example>
+    /// <returns>A valid Metric representation</returns>
+    public static string ToMetric(this long input, MetricNumeralFormats? formats = null, int? decimals = null)
+    {
+        if (input.Equals(0) && (!decimals.HasValue || (decimals == 0)))
+        {
+            return input.ToString();
+        }
+
+        return BuildRepresentation(input, formats, decimals);
+    }
+
+    /// <summary>
+    /// Converts a number into a valid and Human-readable Metric representation.
+    /// </summary>
+    /// <remarks>
+    /// Inspired by a snippet from Thom Smith.
+    /// See <a href="http://stackoverflow.com/questions/12181024/formatting-a-number-with-a-metric-prefix">this link</a> for more.
+    /// </remarks>
+    /// <param name="input">Number to convert to a Metric representation.</param>
+    /// <param name="formats">A bitwise combination of <see cref="MetricNumeralFormats"/> enumeration values that format the metric representation.</param>
+    /// <param name="decimals">If not null it is the numbers of decimals to round the number to</param>
+    /// <example>
+    /// <code>
     /// 1000d.ToMetric() => "1k"
     /// 123d.ToMetric() => "123"
     /// 1E-1.ToMetric() => "100m"
@@ -240,6 +268,110 @@ public static class MetricNumeralExtensions
     static string ReplaceNameBySymbol(string input) =>
         UnitPrefixes.Aggregate(input, (current, unitPrefix) =>
             current.Replace(unitPrefix.Value.Name, unitPrefix.Key.ToString()));
+
+    /// <summary>
+    /// Build a Metric representation of the number.
+    /// </summary>
+    /// <param name="input">Number to convert to a Metric representation.</param>
+    /// <param name="formats">A bitwise combination of <see cref="MetricNumeralFormats"/> enumeration values that format the metric representation.</param>
+    /// <param name="decimals">If not null it is the numbers of decimals to round the number to</param>
+    /// <returns>A number in a Metric representation</returns>
+    static string BuildRepresentation(long input, MetricNumeralFormats? formats, int? decimals)
+    {
+        var number = Math.Abs(input / 10);
+        var exponent = 0;
+
+        while (number > 0)
+        {
+            exponent++;
+            number /= 10;
+        }
+
+        var scale = exponent / 3;
+
+        if (!scale.Equals(0)) return BuildMetricRepresentation(input, scale, formats, decimals);
+
+        var representation = decimals > 0
+            ? $"{input}.{new string('0', decimals.Value)}"
+            : input.ToString();
+        if ((formats & MetricNumeralFormats.WithSpace) == MetricNumeralFormats.WithSpace)
+        {
+            representation += " ";
+        }
+
+        return representation;
+    }
+
+    /// <summary>
+    /// Build a Metric representation of the number.
+    /// </summary>
+    /// <param name="input">Number to convert to a Metric representation.</param>
+    /// <param name="scale">Number of times number should be divided by 1000.</param>
+    /// <param name="formats">A bitwise combination of <see cref="MetricNumeralFormats"/> enumeration values that format the metric representation.</param>
+    /// <param name="decimals">If not null it is the numbers of decimals to round the number to</param>
+    /// <returns>A number in a Metric representation</returns>
+    static string BuildMetricRepresentation(long input, int scale, MetricNumeralFormats? formats, int? decimals)
+    {
+        // Convert back to actual exponent (number of 10s places)
+        var exponent = scale * 3;
+
+        var divisor = 1L;
+
+        for (var i=0; i < scale; i++)
+        {
+            divisor *= 1000;
+        }
+
+        var number = input / divisor;
+        var fractionalPart = Math.Abs(input % divisor); // input could be negative
+
+        if (Math.Abs(number) >= 1000 && exponent < Symbols[0].Count * 3)
+        {
+            exponent += 3;
+            scale++;
+            divisor *= 1000;
+
+            number = input / divisor;
+            fractionalPart = Math.Abs(input % divisor);
+        }
+
+        if (decimals.HasValue)
+        {
+            for (var i = decimals.Value; i < exponent; i++)
+            {
+                var roundUp = (i + 1 == exponent);
+
+                fractionalPart = (fractionalPart + (roundUp ? 5 : 0)) / 10;
+            }
+        }
+        else
+        {
+            decimals = exponent;
+        }
+
+        var symbol = Math.Sign(scale) == 1
+            ? Symbols[0][scale - 1]
+            : Symbols[1][-scale - 1];
+
+        if (decimals == 0)
+        {
+            return number
+                 + (formats.HasValue && formats.Value.HasFlag(MetricNumeralFormats.WithSpace) ? " " : string.Empty)
+                 + GetUnitText(symbol, formats);
+        }
+        else
+        {
+            var decimalPlaces = Math.Min(decimals.Value, exponent);
+            var extraZeroes = (decimals.Value - decimalPlaces);
+
+            return number
+                 + CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator
+                 + fractionalPart.ToString("d" + decimalPlaces)
+                 + (extraZeroes <= 0 ? "" : new string('0', extraZeroes))
+                 + (formats.HasValue && formats.Value.HasFlag(MetricNumeralFormats.WithSpace) ? " " : string.Empty)
+                 + GetUnitText(symbol, formats);
+        }
+    }
 
     /// <summary>
     /// Build a Metric representation of the number.


### PR DESCRIPTION
This PR:
- Adds extension method long.ToMetric to MetricNumeralExtensions.cs, alongside int.ToMetric and double.ToMetric. Since a `double` can't represent every possible `long`, and the caller *could* ask for more decimal places than `double` can store, it has its own bespoke implementation.
- Adds tests for long.ToMetric() in MetricNumeralTests.cs.
- Updates the approved API surface area.

Closes: #1425

_La checklista_:
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc. (NB: I gave preference to consistency with adjacent code. For instance, `double.ToMetric` has one-line blocks with braces.)
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage

🚫 If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
     - There were in fact 213 test failures, but all of them were in `ku\DateHumanizeTests` and `ku\TimeSpanHumanizeTests` and are completely unrelated to this PR.
