### PR TITLE
Potential fix for code scanning alert no. 28: Missed opportunity to use Where

### DIFF
--- a/src/Humanizer/Localisation/NumberToWords/SpanishNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/SpanishNumberToWordsConverter.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 namespace Humanizer;
 
 class SpanishNumberToWordsConverter : GenderedNumberToWordsConverter
@@ -293,21 +294,20 @@ class SpanishNumberToWordsConverter : GenderedNumberToWordsConverter
         List<string> wordBuilder = [];
 
         remainder = inputNumber;
-        foreach (var numberAndWord in NumbersAndWordsDict)
+        foreach (var numberAndWord in NumbersAndWordsDict.Where(numberAndWord => remainder / numberAndWord.Value > 0))
         {
-            if (remainder / numberAndWord.Value > 0)
+            if (remainder / numberAndWord.Value == 1)
             {
-                if (remainder / numberAndWord.Value == 1)
-                {
-                    wordBuilder.Add($"un {numberAndWord.Key}");
-                }
-                else
-                {
-                    wordBuilder.Add(remainder / numberAndWord.Value % 10 == 1 ? $"{Convert(remainder / numberAndWord.Value, WordForm.Abbreviation, GrammaticalGender.Masculine)} {PluralizeGreaterThanMillion(numberAndWord.Key)}" : $"{Convert(remainder / numberAndWord.Value)} {PluralizeGreaterThanMillion(numberAndWord.Key)}");
-                }
-
-                remainder %= numberAndWord.Value;
+                wordBuilder.Add($"un {numberAndWord.Key}");
             }
+            else
+            {
+                wordBuilder.Add(remainder / numberAndWord.Value % 10 == 1
+                    ? $"{Convert(remainder / numberAndWord.Value, WordForm.Abbreviation, GrammaticalGender.Masculine)} {PluralizeGreaterThanMillion(numberAndWord.Key)}"
+                    : $"{Convert(remainder / numberAndWord.Value)} {PluralizeGreaterThanMillion(numberAndWord.Key)}");
+            }
+
+            remainder %= numberAndWord.Value;
         }
 
         return BuildWord(wordBuilder);


### PR DESCRIPTION
Potential fix for [https://github.com/Humanizr/Humanizer/security/code-scanning/28](https://github.com/Humanizr/Humanizer/security/code-scanning/28)

To fix the problem, we should use LINQ's `Where` extension method to filter `NumbersAndWordsDict` so that only entries with `remainder / numberAndWord.Value > 0` are included in the loop iteration, which removes the unnecessary branch and makes the code more readable and idiomatic. Specifically, edit the `foreach` statement in `ConvertGreaterThanMillion` (lines 296-311 in `src/Humanizer/Localisation/NumberToWords/SpanishNumberToWordsConverter.cs`) to iterate over `NumbersAndWordsDict.Where(numberAndWord => remainder / numberAndWord.Value > 0)` and remove the now-unnecessary `if` and the reduced indentation of the loop body. This requires adding a `using System.Linq;` directive at the top of the file if it is not already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
