### PR TITLE
Delete dotnet.config

### DIFF
--- a/dotnet.config
+++ b/dotnet.config
@@ -1,2 +1,0 @@
-﻿[dotnet.test.runner]
-name = "Microsoft.Testing.Platform"


### PR DESCRIPTION
dotnet.config is no longer a thing. It was shipped up to .NET 10 RC1, but was removed in RC2.
The repo is now on .NET 10 stable and is already opting-into MTP via global.json, which is the replacement of dotnet.config.