### PR TITLE
Fix Humanize behavior for fully uppercase input

### DIFF
--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -92,10 +92,11 @@ public static partial class StringHumanizeExtensions
     public static string Humanize(this string input)
     {
         // if input is all capitals (e.g. an acronym) then return it without change
-        if (input.All(char.IsUpper))
-        {
-            input = input.ToLowerInvariant();
-        }
+       if (input.All(char.IsUpper) &&
+           input.Any(c => c == ' ' || c == '_' || c == '-'))
+       {
+           input = input.ToLowerInvariant();
+       }
 
         // if input contains a dash or underscore which precedes or follows a space (or both, e.g. freestanding)
         // remove the dash/underscore and run it through FromPascalCase

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -1,4 +1,6 @@
 using System.Runtime.InteropServices;
+using System.Linq;
+
 
 namespace Humanizer;
 
@@ -92,7 +94,7 @@ public static partial class StringHumanizeExtensions
         // if input is all capitals (e.g. an acronym) then return it without change
         if (input.All(char.IsUpper))
         {
-            return input;
+            input = input.ToLowerInvariant();
         }
 
         // if input contains a dash or underscore which precedes or follows a space (or both, e.g. freestanding)


### PR DESCRIPTION
Hi, thanks for the great library!

This PR fixes an issue where Humanize() returned incorrect results
when the input string was fully uppercase.

Uppercase inputs are now normalized instead of being returned early,
making the behavior consistent with lowercase and mixed-case inputs.

Closes #1557.
