### PR TITLE
Fix TitleCase not capitalizing the first word when it is an article, conjunction, or preposition (#1658)

### DIFF
--- a/src/Humanizer.Tests/TransformersTests.cs
+++ b/src/Humanizer.Tests/TransformersTests.cs
@@ -39,6 +39,7 @@
     [InlineData("a great article", "A Great Article")]
     [InlineData("yet another conjunction", "Yet Another Conjunction")]
     [InlineData("by this preposition", "By This Preposition")]
+    [InlineData("NASA and the future", "NASA and the Future")]
     public void TransformToTitleCase_FirstWordExceptions(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Transform(To.TitleCase));
 }

--- a/src/Humanizer/Transformer/ToTitleCase.cs
+++ b/src/Humanizer/Transformer/ToTitleCase.cs
@@ -28,17 +28,17 @@ partial class ToTitleCase : ICulturedStringTransformer
         foreach (Match word in matches)
         {
             var value = word.Value;
-
-            if(AllCapitals(value))
-            {
-                continue;
-            }
-            if (!isFirstWord && IsArticleOrConjunctionOrPreposition(value))
-            {
-                continue;
-            }
-
+            var currentIsFirst = isFirstWord;
             isFirstWord = false;
+
+            if (AllCapitals(value))
+            {
+                continue;
+            }
+            if (!currentIsFirst && IsArticleOrConjunctionOrPreposition(value))
+            {
+                continue;
+            }
 
             builder[word.Index] = textInfo.ToUpper(value[0]);
             Overwrite(builder, word.Index + 1, textInfo.ToLower(value[1..]));


### PR DESCRIPTION
This PR fixes an issue where ToTitleCase failed to capitalize the first word when that word was an article, conjunction, or preposition. This resulted in incorrect output. According to standard English title‑casing rules, the first word must always be capitalized, regardless of its part of speech.

Fixes [#1658](https://github.com/Humanizr/Humanizer/issues/1658)