### PR TITLE
Preserve ALL-CAPS pluralization for multi-letter inputs

### DIFF
--- a/src/Humanizer.Tests/InflectorTests.cs
+++ b/src/Humanizer.Tests/InflectorTests.cs
@@ -40,6 +40,13 @@ public class InflectorTests
         Assert.Equal(plural, singular.Pluralize(false));
     }
 
+    [Fact]
+    public void Pluralize_Preserves_AllCaps_Suffix()
+    {
+        Assert.Equal("SINGULAR TYPE NAMES", "SINGULAR TYPE NAME".Pluralize());
+        Assert.Equal("SINGULAR TYPE NAMES", "singular type name".Humanize(LetterCasing.AllCaps).Pluralize());
+    }
+
     [Theory]
     [ClassData(typeof(PluralTestSource))]
     public void Singularize(string singular, string plural) =>

--- a/src/Humanizer/Inflections/Vocabulary.cs
+++ b/src/Humanizer/Inflections/Vocabulary.cs
@@ -195,9 +195,36 @@ public partial class Vocabulary
     bool IsUncountable(string word) =>
         uncountables.Contains(word);
 
-    static string MatchUpperCase(string word, string replacement) =>
-        char.IsUpper(word[0]) &&
-        char.IsLower(replacement[0]) ? StringHumanizeExtensions.Concat(char.ToUpper(replacement[0]), replacement.AsSpan(1)) : replacement;
+    static string MatchUpperCase(string word, string replacement)
+    {
+        var lettersCount = 0;
+        var allLettersUpper = true;
+        foreach (var c in word)
+        {
+            if (char.IsLetter(c))
+            {
+                lettersCount++;
+                if (!char.IsUpper(c))
+                {
+                    allLettersUpper = false;
+                    break;
+                }
+            }
+        }
+
+        // If the input contains multiple letters and all of them are uppercase
+        // (e.g. an ALL CAPS phrase or acronym of length > 1), return the replacement
+        // fully uppercased so the plural suffix matches the input casing.
+        if (lettersCount > 1 && allLettersUpper)
+        {
+            return replacement.ToUpperInvariant();
+        }
+
+        return char.IsUpper(word[0]) && char.IsLower(replacement[0])
+            ? StringHumanizeExtensions.Concat(char.ToUpper(replacement[0]), replacement.AsSpan(1))
+            : replacement;
+    }
+
 
     /// <summary>
     /// If the word is the letter s, singular or plural, return the letter s singular


### PR DESCRIPTION
Fix: when input is ALL CAPS (multi-letter), pluralization should produce an ALL CAPS plural (e.g., 'SINGULAR TYPE NAME' -> 'SINGULAR TYPE NAMES').

Files changed: src/Humanizer/Inflections/Vocabulary.cs, src/Humanizer.Tests/InflectorTests.cs

This adds a check to uppercase the full replacement when the input contains multiple letters and is all uppercase, and adds tests to cover the behavior.

Runs tests: dotnet test (net8.0/net10.0) - all passing.