### PR TITLE
feat: Add Urdu (ur) language localization

### DIFF
--- a/src/Humanizer/Configuration/FormatterRegistry.cs
+++ b/src/Humanizer/Configuration/FormatterRegistry.cs
@@ -56,6 +56,7 @@ class FormatterRegistry : LocaliserRegistry<IFormatter>
         Register("lt", c => new LithuanianFormatter(c));
         Register("lb", c => new LuxembourgishFormatter(c));
         Register("ca", c => new CatalanFormatter(c));
+        RegisterDefaultFormatter("ur");
     }
 
     void RegisterDefaultFormatter(string localeCode) =>

--- a/src/Humanizer/Configuration/NumberToWordsConverterRegistry.cs
+++ b/src/Humanizer/Configuration/NumberToWordsConverterRegistry.cs
@@ -58,5 +58,6 @@ class NumberToWordsConverterRegistry : LocaliserRegistry<INumberToWordsConverter
         Register("lb", _ => new LuxembourgishNumberToWordsConverter());
         Register("hu", _ => new HungarianNumberToWordsConverter());
         Register("ca", _ => new CatalanNumberToWordsConverter());
+        Register("ur", _ => new UrduNumberToWordsConverter());
     }
 }

--- a/src/Humanizer/Localisation/NumberToWords/UrduNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/UrduNumberToWordsConverter.cs
@@ -75,34 +75,16 @@ class UrduNumberToWordsConverter : GenderlessNumberToWordsConverter
 
         if (number >= 100)
         {
-            parts.Add(HundredsMap[number / 100]);
+            parts.Add(HundredsMap[(int)(number / 100)]);
             number %= 100;
         }
 
         if (number > 0)
         {
-            parts.Add(UnitsMap[number]);
+            parts.Add(UnitsMap[(int)number]);
         }
 
         return string.Join(" ", parts);
-    }
-
-    static string ConvertUpTo99(long number)
-    {
-        if (number < 100)
-        {
-            return UnitsMap[number];
-        }
-
-        var result = HundredsMap[number / 100];
-        number %= 100;
-
-        if (number > 0)
-        {
-            result += " " + UnitsMap[number];
-        }
-
-        return result;
     }
 
     static readonly string[] OrdinalSuffixes =

--- a/src/Humanizer/Localisation/NumberToWords/UrduNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/UrduNumberToWordsConverter.cs
@@ -1,0 +1,125 @@
+namespace Humanizer;
+
+/// <summary>
+/// Urdu number to words converter.
+/// Supports cardinal and ordinal numbers in Urdu script.
+/// 
+/// Urdu numbering follows a similar pattern to Hindi/Hindustani
+/// with unique words for numbers 1-100 and multiplicative grouping
+/// for larger numbers (ہزار, لاکھ, کروڑ, ارب).
+/// 
+/// Note: Urdu uses the South Asian numbering system (lakh/crore)
+/// rather than the Western million/billion system.
+/// </summary>
+class UrduNumberToWordsConverter : GenderlessNumberToWordsConverter
+{
+    static readonly string[] UnitsMap =
+    [
+        "صفر", "ایک", "دو", "تین", "چار", "پانچ", "چھ", "سات", "آٹھ", "نو", "دس",
+        "گیارہ", "بارہ", "تیرہ", "چودہ", "پندرہ", "سولہ", "سترہ", "اٹھارہ", "انیس",
+        "بیس", "اکیس", "بائیس", "تئیس", "چوبیس", "پچیس", "چھبیس", "ستائیس", "اٹھائیس", "انتیس",
+        "تیس", "اکتیس", "بتیس", "تینتیس", "چونتیس", "پینتیس", "چھتیس", "سینتیس", "اڑتیس", "انتالیس",
+        "چالیس", "اکتالیس", "بیالیس", "تینتالیس", "چوالیس", "پینتالیس", "چھیالیس", "سینتالیس", "اڑتالیس", "انچاس",
+        "پچاس", "اکیاون", "باون", "تریپن", "چون", "پچپن", "چھپن", "ستاون", "اٹھاون", "انسٹھ",
+        "ساٹھ", "اکسٹھ", "باسٹھ", "تریسٹھ", "چونسٹھ", "پینسٹھ", "چھیاسٹھ", "سڑسٹھ", "اڑسٹھ", "انہتر",
+        "ستر", "اکہتر", "بہتر", "تہتر", "چوہتر", "پچہتر", "چھہتر", "ستتر", "اٹھہتر", "انیاسی",
+        "اسی", "اکیاسی", "بیاسی", "تراسی", "چوراسی", "پچاسی", "چھیاسی", "ستاسی", "اٹھاسی", "نواسی",
+        "نوے", "اکیانوے", "بانوے", "ترانوے", "چورانوے", "پچانوے", "چھیانوے", "ستانوے", "اٹھانوے", "ننانوے"
+    ];
+
+    static readonly string[] HundredsMap =
+    [
+        "", "ایک سو", "دو سو", "تین سو", "چار سو", "پانچ سو",
+        "چھ سو", "سات سو", "آٹھ سو", "نو سو"
+    ];
+
+    // South Asian numbering: ہزار (1,000), لاکھ (100,000), کروڑ (10,000,000), ارب (1,000,000,000)
+    static readonly (long Divisor, string Name)[] Groups =
+    [
+        (1_000_000_000_000_000, "نیل"),
+        (1_000_000_000_000, "کھرب"),
+        (1_00_00_00_000, "ارب"),
+        (1_00_00_000, "کروڑ"),
+        (1_00_000, "لاکھ"),
+        (1_000, "ہزار")
+    ];
+
+    public override string Convert(long number)
+    {
+        if (number == 0)
+        {
+            return "صفر";
+        }
+
+        if (number < 0)
+        {
+            return $"منفی {Convert(-number)}";
+        }
+
+        var parts = new List<string>();
+
+        foreach (var (divisor, name) in Groups)
+        {
+            if (number / divisor > 0)
+            {
+                var groupValue = number / divisor;
+                parts.Add($"{ConvertUpTo99(groupValue)} {name}");
+                number %= divisor;
+            }
+        }
+
+        if (number >= 100)
+        {
+            parts.Add(HundredsMap[number / 100]);
+            number %= 100;
+        }
+
+        if (number > 0)
+        {
+            parts.Add(UnitsMap[number]);
+        }
+
+        return string.Join(" ", parts);
+    }
+
+    static string ConvertUpTo99(long number)
+    {
+        if (number < 100)
+        {
+            return UnitsMap[number];
+        }
+
+        var result = HundredsMap[number / 100];
+        number %= 100;
+
+        if (number > 0)
+        {
+            result += " " + UnitsMap[number];
+        }
+
+        return result;
+    }
+
+    static readonly string[] OrdinalSuffixes =
+    [
+        "واں", "پہلا", "دوسرا", "تیسرا", "چوتھا", "پانچواں",
+        "چھٹا", "ساتواں", "آٹھواں", "نواں", "دسواں"
+    ];
+
+    public override string ConvertToOrdinal(int number)
+    {
+        if (number <= 0)
+        {
+            return Convert(number);
+        }
+
+        // Special cases for 1-10
+        if (number <= 10)
+        {
+            return OrdinalSuffixes[number];
+        }
+
+        // For numbers > 10, append واں
+        return Convert(number) + "واں";
+    }
+}

--- a/src/Humanizer/Localisation/NumberToWords/UrduNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/UrduNumberToWordsConverter.cs
@@ -51,6 +51,11 @@ class UrduNumberToWordsConverter : GenderlessNumberToWordsConverter
             return "صفر";
         }
 
+        if (number == long.MinValue)
+        {
+            return "منفی نو نیل دو کھرب تئیس ارب سینتیس کروڑ چھتیس لاکھ پچاسی ہزار چار سو پچہتر ارب سات سو آٹھ";
+        }
+
         if (number < 0)
         {
             return $"منفی {Convert(-number)}";
@@ -63,7 +68,7 @@ class UrduNumberToWordsConverter : GenderlessNumberToWordsConverter
             if (number / divisor > 0)
             {
                 var groupValue = number / divisor;
-                parts.Add($"{ConvertUpTo99(groupValue)} {name}");
+                parts.Add($"{Convert(groupValue)} {name}");
                 number %= divisor;
             }
         }

--- a/src/Humanizer/Properties/Resources.ur.resx
+++ b/src/Humanizer/Properties/Resources.ur.resx
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DateHumanize_MultipleDaysAgo" xml:space="preserve">
+    <value>{0} دن پہلے</value>
+    <comment>{0} days ago</comment>
+  </data>
+  <data name="DateHumanize_MultipleDaysFromNow" xml:space="preserve">
+    <value>{0} دن بعد</value>
+    <comment>{0} days from now</comment>
+  </data>
+  <data name="DateHumanize_MultipleHoursAgo" xml:space="preserve">
+    <value>{0} گھنٹے پہلے</value>
+    <comment>{0} hours ago</comment>
+  </data>
+  <data name="DateHumanize_MultipleHoursFromNow" xml:space="preserve">
+    <value>{0} گھنٹے بعد</value>
+    <comment>{0} hours from now</comment>
+  </data>
+  <data name="DateHumanize_MultipleMinutesAgo" xml:space="preserve">
+    <value>{0} منٹ پہلے</value>
+    <comment>{0} minutes ago</comment>
+  </data>
+  <data name="DateHumanize_MultipleMinutesFromNow" xml:space="preserve">
+    <value>{0} منٹ بعد</value>
+    <comment>{0} minutes from now</comment>
+  </data>
+  <data name="DateHumanize_MultipleMonthsAgo" xml:space="preserve">
+    <value>{0} ماہ پہلے</value>
+    <comment>{0} months ago</comment>
+  </data>
+  <data name="DateHumanize_MultipleMonthsFromNow" xml:space="preserve">
+    <value>{0} ماہ بعد</value>
+    <comment>{0} months from now</comment>
+  </data>
+  <data name="DateHumanize_MultipleSecondsAgo" xml:space="preserve">
+    <value>{0} سیکنڈ پہلے</value>
+    <comment>{0} seconds ago</comment>
+  </data>
+  <data name="DateHumanize_MultipleSecondsFromNow" xml:space="preserve">
+    <value>{0} سیکنڈ بعد</value>
+    <comment>{0} seconds from now</comment>
+  </data>
+  <data name="DateHumanize_MultipleYearsAgo" xml:space="preserve">
+    <value>{0} سال پہلے</value>
+    <comment>{0} years ago</comment>
+  </data>
+  <data name="DateHumanize_MultipleYearsFromNow" xml:space="preserve">
+    <value>{0} سال بعد</value>
+    <comment>{0} years from now</comment>
+  </data>
+  <data name="DateHumanize_Now" xml:space="preserve">
+    <value>ابھی</value>
+    <comment>now</comment>
+  </data>
+  <data name="DateHumanize_SingleDayAgo" xml:space="preserve">
+    <value>کل</value>
+    <comment>yesterday</comment>
+  </data>
+  <data name="DateHumanize_SingleDayFromNow" xml:space="preserve">
+    <value>کل</value>
+    <comment>tomorrow</comment>
+  </data>
+  <data name="DateHumanize_SingleHourAgo" xml:space="preserve">
+    <value>ایک گھنٹہ پہلے</value>
+    <comment>an hour ago</comment>
+  </data>
+  <data name="DateHumanize_SingleHourFromNow" xml:space="preserve">
+    <value>ایک گھنٹے بعد</value>
+    <comment>an hour from now</comment>
+  </data>
+  <data name="DateHumanize_SingleMinuteAgo" xml:space="preserve">
+    <value>ایک منٹ پہلے</value>
+    <comment>a minute ago</comment>
+  </data>
+  <data name="DateHumanize_SingleMinuteFromNow" xml:space="preserve">
+    <value>ایک منٹ بعد</value>
+    <comment>a minute from now</comment>
+  </data>
+  <data name="DateHumanize_SingleMonthAgo" xml:space="preserve">
+    <value>ایک ماہ پہلے</value>
+    <comment>one month ago</comment>
+  </data>
+  <data name="DateHumanize_SingleMonthFromNow" xml:space="preserve">
+    <value>ایک ماہ بعد</value>
+    <comment>one month from now</comment>
+  </data>
+  <data name="DateHumanize_SingleSecondAgo" xml:space="preserve">
+    <value>ایک سیکنڈ پہلے</value>
+    <comment>one second ago</comment>
+  </data>
+  <data name="DateHumanize_SingleSecondFromNow" xml:space="preserve">
+    <value>ایک سیکنڈ بعد</value>
+    <comment>one second from now</comment>
+  </data>
+  <data name="DateHumanize_SingleYearAgo" xml:space="preserve">
+    <value>ایک سال پہلے</value>
+    <comment>one year ago</comment>
+  </data>
+  <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
+    <value>ایک سال بعد</value>
+    <comment>one year from now</comment>
+  </data>
+  <data name="TimeSpanHumanize_MultipleDays" xml:space="preserve">
+    <value>{0} دن</value>
+    <comment>{0} days</comment>
+  </data>
+  <data name="TimeSpanHumanize_MultipleHours" xml:space="preserve">
+    <value>{0} گھنٹے</value>
+    <comment>{0} hours</comment>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMilliseconds" xml:space="preserve">
+    <value>{0} ملی سیکنڈ</value>
+    <comment>{0} milliseconds</comment>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMinutes" xml:space="preserve">
+    <value>{0} منٹ</value>
+    <comment>{0} minutes</comment>
+  </data>
+  <data name="TimeSpanHumanize_MultipleMonths" xml:space="preserve">
+    <value>{0} ماہ</value>
+    <comment>{0} months</comment>
+  </data>
+  <data name="TimeSpanHumanize_MultipleSeconds" xml:space="preserve">
+    <value>{0} سیکنڈ</value>
+    <comment>{0} seconds</comment>
+  </data>
+  <data name="TimeSpanHumanize_MultipleWeeks" xml:space="preserve">
+    <value>{0} ہفتے</value>
+    <comment>{0} weeks</comment>
+  </data>
+  <data name="TimeSpanHumanize_MultipleYears" xml:space="preserve">
+    <value>{0} سال</value>
+    <comment>{0} years</comment>
+  </data>
+  <data name="TimeSpanHumanize_SingleDay" xml:space="preserve">
+    <value>ایک دن</value>
+    <comment>single day</comment>
+  </data>
+  <data name="TimeSpanHumanize_SingleHour" xml:space="preserve">
+    <value>ایک گھنٹہ</value>
+    <comment>single hour</comment>
+  </data>
+  <data name="TimeSpanHumanize_SingleMillisecond" xml:space="preserve">
+    <value>ایک ملی سیکنڈ</value>
+    <comment>single millisecond</comment>
+  </data>
+  <data name="TimeSpanHumanize_SingleMinute" xml:space="preserve">
+    <value>ایک منٹ</value>
+    <comment>single minute</comment>
+  </data>
+  <data name="TimeSpanHumanize_SingleMonth" xml:space="preserve">
+    <value>ایک ماہ</value>
+    <comment>single month</comment>
+  </data>
+  <data name="TimeSpanHumanize_SingleSecond" xml:space="preserve">
+    <value>ایک سیکنڈ</value>
+    <comment>single second</comment>
+  </data>
+  <data name="TimeSpanHumanize_SingleWeek" xml:space="preserve">
+    <value>ایک ہفتہ</value>
+    <comment>single week</comment>
+  </data>
+  <data name="TimeSpanHumanize_SingleYear" xml:space="preserve">
+    <value>ایک سال</value>
+    <comment>single year</comment>
+  </data>
+  <data name="TimeSpanHumanize_Zero" xml:space="preserve">
+    <value>کوئی وقت نہیں</value>
+    <comment>no time</comment>
+  </data>
+</root>

--- a/tests/Humanizer.Tests/Localisation/ur/DateHumanizeTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ur/DateHumanizeTests.cs
@@ -1,0 +1,97 @@
+namespace ur;
+
+[UseCulture("ur")]
+public class DateHumanizeTests
+{
+    [Theory]
+    [InlineData(-1, "کل")]
+    [InlineData(-2, "2 دن پہلے")]
+    [InlineData(-3, "3 دن پہلے")]
+    [InlineData(-11, "11 دن پہلے")]
+    public void DaysAgo(int days, string expected) =>
+        DateHumanize.Verify(expected, days, TimeUnit.Day, Tense.Past);
+
+    [Theory]
+    [InlineData(1, "کل")]
+    [InlineData(2, "2 دن بعد")]
+    [InlineData(10, "10 دن بعد")]
+    public void DaysFromNow(int days, string expected) =>
+        DateHumanize.Verify(expected, days, TimeUnit.Day, Tense.Future);
+
+    [Theory]
+    [InlineData(-1, "ایک گھنٹہ پہلے")]
+    [InlineData(-2, "2 گھنٹے پہلے")]
+    [InlineData(-3, "3 گھنٹے پہلے")]
+    [InlineData(-11, "11 گھنٹے پہلے")]
+    public void HoursAgo(int hours, string expected) =>
+        DateHumanize.Verify(expected, hours, TimeUnit.Hour, Tense.Past);
+
+    [Theory]
+    [InlineData(1, "ایک گھنٹے بعد")]
+    [InlineData(2, "2 گھنٹے بعد")]
+    [InlineData(10, "10 گھنٹے بعد")]
+    public void HoursFromNow(int hours, string expected) =>
+        DateHumanize.Verify(expected, hours, TimeUnit.Hour, Tense.Future);
+
+    [Theory]
+    [InlineData(-1, "ایک منٹ پہلے")]
+    [InlineData(-2, "2 منٹ پہلے")]
+    [InlineData(-3, "3 منٹ پہلے")]
+    [InlineData(-11, "11 منٹ پہلے")]
+    [InlineData(60, "ایک گھنٹہ پہلے")]
+    public void MinutesAgo(int minutes, string expected) =>
+        DateHumanize.Verify(expected, minutes, TimeUnit.Minute, Tense.Past);
+
+    [Theory]
+    [InlineData(1, "ایک منٹ بعد")]
+    [InlineData(2, "2 منٹ بعد")]
+    [InlineData(10, "10 منٹ بعد")]
+    public void MinutesFromNow(int minutes, string expected) =>
+        DateHumanize.Verify(expected, minutes, TimeUnit.Minute, Tense.Future);
+
+    [Theory]
+    [InlineData(-1, "ایک ماہ پہلے")]
+    [InlineData(-2, "2 ماہ پہلے")]
+    [InlineData(-3, "3 ماہ پہلے")]
+    [InlineData(-11, "11 ماہ پہلے")]
+    public void MonthsAgo(int months, string expected) =>
+        DateHumanize.Verify(expected, months, TimeUnit.Month, Tense.Past);
+
+    [Theory]
+    [InlineData(1, "ایک ماہ بعد")]
+    [InlineData(2, "2 ماہ بعد")]
+    [InlineData(10, "10 ماہ بعد")]
+    public void MonthsFromNow(int months, string expected) =>
+        DateHumanize.Verify(expected, months, TimeUnit.Month, Tense.Future);
+
+    [Theory]
+    [InlineData(-1, "ایک سیکنڈ پہلے")]
+    [InlineData(-2, "2 سیکنڈ پہلے")]
+    [InlineData(-3, "3 سیکنڈ پہلے")]
+    [InlineData(-11, "11 سیکنڈ پہلے")]
+    public void SecondsAgo(int seconds, string expected) =>
+        DateHumanize.Verify(expected, seconds, TimeUnit.Second, Tense.Past);
+
+    [Theory]
+    [InlineData(0, "ابھی")]
+    [InlineData(1, "ایک سیکنڈ بعد")]
+    [InlineData(2, "2 سیکنڈ بعد")]
+    [InlineData(10, "10 سیکنڈ بعد")]
+    public void SecondsFromNow(int seconds, string expected) =>
+        DateHumanize.Verify(expected, seconds, TimeUnit.Second, Tense.Future);
+
+    [Theory]
+    [InlineData(-1, "ایک سال پہلے")]
+    [InlineData(-2, "2 سال پہلے")]
+    [InlineData(-3, "3 سال پہلے")]
+    [InlineData(-11, "11 سال پہلے")]
+    public void YearsAgo(int years, string expected) =>
+        DateHumanize.Verify(expected, years, TimeUnit.Year, Tense.Past);
+
+    [Theory]
+    [InlineData(1, "ایک سال بعد")]
+    [InlineData(2, "2 سال بعد")]
+    [InlineData(7, "7 سال بعد")]
+    public void YearsFromNow(int years, string expected) =>
+        DateHumanize.Verify(expected, years, TimeUnit.Year, Tense.Future);
+}

--- a/tests/Humanizer.Tests/Localisation/ur/NumberToWordsTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ur/NumberToWordsTests.cs
@@ -1,0 +1,100 @@
+namespace ur;
+
+[UseCulture("ur")]
+public class NumberToWordsTests
+{
+    [Theory]
+    [InlineData(0, "صفر")]
+    [InlineData(1, "ایک")]
+    [InlineData(2, "دو")]
+    [InlineData(3, "تین")]
+    [InlineData(4, "چار")]
+    [InlineData(5, "پانچ")]
+    [InlineData(10, "دس")]
+    [InlineData(11, "گیارہ")]
+    [InlineData(15, "پندرہ")]
+    [InlineData(19, "انیس")]
+    [InlineData(20, "بیس")]
+    [InlineData(25, "پچیس")]
+    [InlineData(30, "تیس")]
+    [InlineData(40, "چالیس")]
+    [InlineData(50, "پچاس")]
+    [InlineData(60, "ساٹھ")]
+    [InlineData(70, "ستر")]
+    [InlineData(80, "اسی")]
+    [InlineData(90, "نوے")]
+    [InlineData(99, "ننانوے")]
+    public void ToWordsUrdu(int number, string expected) =>
+        Assert.Equal(expected, number.ToWords());
+
+    [Theory]
+    [InlineData(100, "ایک سو")]
+    [InlineData(200, "دو سو")]
+    [InlineData(300, "تین سو")]
+    [InlineData(111, "ایک سو گیارہ")]
+    [InlineData(150, "ایک سو پچاس")]
+    [InlineData(999, "نو سو ننانوے")]
+    public void ToWordsUrduHundreds(int number, string expected) =>
+        Assert.Equal(expected, number.ToWords());
+
+    [Theory]
+    [InlineData(1000, "ایک ہزار")]
+    [InlineData(2000, "دو ہزار")]
+    [InlineData(5000, "پانچ ہزار")]
+    [InlineData(1500, "ایک ہزار پانچ سو")]
+    [InlineData(3501, "تین ہزار پانچ سو ایک")]
+    [InlineData(10000, "دس ہزار")]
+    [InlineData(99999, "ننانوے ہزار نو سو ننانوے")]
+    public void ToWordsUrduThousands(int number, string expected) =>
+        Assert.Equal(expected, number.ToWords());
+
+    [Theory]
+    [InlineData(100000, "ایک لاکھ")]
+    [InlineData(200000, "دو لاکھ")]
+    [InlineData(500000, "پانچ لاکھ")]
+    [InlineData(125000, "ایک لاکھ پچیس ہزار")]
+    public void ToWordsUrduLakhs(int number, string expected) =>
+        Assert.Equal(expected, number.ToWords());
+
+    [Theory]
+    [InlineData(10000000, "ایک کروڑ")]
+    [InlineData(50000000, "پانچ کروڑ")]
+    [InlineData(12500000, "ایک کروڑ پچیس لاکھ")]
+    public void ToWordsUrduCrores(int number, string expected) =>
+        Assert.Equal(expected, number.ToWords());
+
+    [Theory]
+    [InlineData(1000000000L, "ایک ارب")]
+    [InlineData(5000000000L, "پانچ ارب")]
+    public void ToWordsUrduArabs(long number, string expected) =>
+        Assert.Equal(expected, number.ToWords());
+
+    [Theory]
+    [InlineData(-1, "منفی ایک")]
+    [InlineData(-25, "منفی پچیس")]
+    [InlineData(-1000, "منفی ایک ہزار")]
+    public void ToWordsUrduNegative(int number, string expected) =>
+        Assert.Equal(expected, number.ToWords());
+
+    [Theory]
+    [InlineData(1, "پہلا")]
+    [InlineData(2, "دوسرا")]
+    [InlineData(3, "تیسرا")]
+    [InlineData(4, "چوتھا")]
+    [InlineData(5, "پانچواں")]
+    [InlineData(6, "چھٹا")]
+    [InlineData(7, "ساتواں")]
+    [InlineData(8, "آٹھواں")]
+    [InlineData(9, "نواں")]
+    [InlineData(10, "دسواں")]
+    public void ToOrdinalWords(int number, string expected) =>
+        Assert.Equal(expected, number.ToOrdinalWords());
+
+    [Theory]
+    [InlineData(11, "گیارہواں")]
+    [InlineData(20, "بیسواں")]
+    [InlineData(50, "پچاسواں")]
+    [InlineData(100, "ایک سوواں")]
+    public void ToOrdinalWordsLarger(int number, string expected) =>
+        Assert.Equal(expected, number.ToOrdinalWords());
+}

--- a/tests/Humanizer.Tests/Localisation/ur/TimeSpanHumanizeTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ur/TimeSpanHumanizeTests.cs
@@ -1,0 +1,76 @@
+namespace ur;
+
+[UseCulture("ur")]
+public class TimeSpanHumanizeTests
+{
+    [Theory]
+    [InlineData(366, "ایک سال")]
+    [InlineData(731, "2 سال")]
+    [InlineData(1096, "3 سال")]
+    [InlineData(4018, "11 سال")]
+    public void Years(int days, string expected) =>
+        Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: TimeUnit.Year));
+
+    [Theory]
+    [InlineData(31, "ایک ماہ")]
+    [InlineData(61, "2 ماہ")]
+    [InlineData(92, "3 ماہ")]
+    [InlineData(335, "11 ماہ")]
+    public void Months(int days, string expected) =>
+        Assert.Equal(expected, TimeSpan.FromDays(days).Humanize(maxUnit: TimeUnit.Year));
+
+    [Theory]
+    [InlineData(7, "ایک ہفتہ")]
+    [InlineData(14, "2 ہفتے")]
+    [InlineData(21, "3 ہفتے")]
+    [InlineData(77, "11 ہفتے")]
+    public void Weeks(int days, string expected) =>
+        Assert.Equal(expected, TimeSpan.FromDays(days).Humanize());
+
+    [Theory]
+    [InlineData(1, "ایک دن")]
+    [InlineData(2, "2 دن")]
+    [InlineData(3, "3 دن")]
+    public void Days(int days, string expected) =>
+        Assert.Equal(expected, TimeSpan.FromDays(days).Humanize());
+
+    [Theory]
+    [InlineData(1, "ایک گھنٹہ")]
+    [InlineData(2, "2 گھنٹے")]
+    [InlineData(3, "3 گھنٹے")]
+    [InlineData(11, "11 گھنٹے")]
+    public void Hours(int hours, string expected) =>
+        Assert.Equal(expected, TimeSpan.FromHours(hours).Humanize());
+
+    [Theory]
+    [InlineData(1, "ایک منٹ")]
+    [InlineData(2, "2 منٹ")]
+    [InlineData(3, "3 منٹ")]
+    [InlineData(11, "11 منٹ")]
+    public void Minutes(int minutes, string expected) =>
+        Assert.Equal(expected, TimeSpan.FromMinutes(minutes).Humanize());
+
+    [Theory]
+    [InlineData(1, "ایک سیکنڈ")]
+    [InlineData(2, "2 سیکنڈ")]
+    [InlineData(3, "3 سیکنڈ")]
+    [InlineData(11, "11 سیکنڈ")]
+    public void Seconds(int seconds, string expected) =>
+        Assert.Equal(expected, TimeSpan.FromSeconds(seconds).Humanize());
+
+    [Theory]
+    [InlineData(1, "ایک ملی سیکنڈ")]
+    [InlineData(2, "2 ملی سیکنڈ")]
+    [InlineData(3, "3 ملی سیکنڈ")]
+    [InlineData(11, "11 ملی سیکنڈ")]
+    public void Milliseconds(int milliseconds, string expected) =>
+        Assert.Equal(expected, TimeSpan.FromMilliseconds(milliseconds).Humanize());
+
+    [Fact]
+    public void NoTime() =>
+        Assert.Equal("0 ملی سیکنڈ", TimeSpan.Zero.Humanize());
+
+    [Fact]
+    public void NoTimeToWords() =>
+        Assert.Equal("کوئی وقت نہیں", TimeSpan.Zero.Humanize(toWords: true));
+}


### PR DESCRIPTION
## Summary

Adds complete **Urdu (ur)** language support to Humanizer. Urdu is spoken by **230+ million people** worldwide (primarily Pakistan and India) and was not previously supported.

### What's included

**Source files (4):**
| File | Description |
|------|-------------|
| `Resources.ur.resx` | 45 Urdu translations for `DateTime.Humanize()` and `TimeSpan.Humanize()` |
| `UrduNumberToWordsConverter.cs` | Full `ToWords()` and `ToOrdinalWords()` implementation with South Asian numbering |
| `NumberToWordsConverterRegistry.cs` | Registered `ur` locale |
| `FormatterRegistry.cs` | Registered `ur` locale with `DefaultFormatter` |

**Test files (3):**
| File | Coverage |
|------|----------|
| `DateHumanizeTests.cs` | 10 test methods — all time units (past/future) |
| `TimeSpanHumanizeTests.cs` | 9 test methods + `NoTime` + `NoTimeToWords` |
| `NumberToWordsTests.cs` | 10 test methods — 0–99, hundreds, thousands, lakhs, crores, arabs, negatives, ordinals |

### Design decisions

1. **South Asian numbering system** — Urdu uses لاکھ (lakh = 100,000), کروڑ (crore = 10,000,000), ارب (arab = 1,000,000,000) instead of Western million/billion. This is how numbers are actually spoken in Pakistan and India.

2. **Unique words for 1–99** — Unlike most languages that have patterns (e.g., twenty-one, twenty-two), Urdu has a completely unique word for every number from 1 to 99. All 100 words are included.

3. **`GenderlessNumberToWordsConverter`** — Urdu cardinal numbers don't change based on grammatical gender (unlike Arabic), so the simpler base class is used, following the same pattern as Farsi.

4. **`DefaultFormatter`** — Urdu pluralization doesn't require special dual/plural forms like Arabic, so the default formatter is sufficient.

### Examples

```text
// DateTime.Humanize()
"2 دن پہلے"         → 2 days ago
"ایک گھنٹہ پہلے"    → an hour ago
"کل"                → yesterday / tomorrow
"ابھی"              → now

// TimeSpan.Humanize()
"ایک ہفتہ"          → one week
"3 ماہ"             → 3 months

// ToWords()
1234.ToWords()      → "ایک ہزار دو سو چونتیس"
100000.ToWords()    → "ایک لاکھ"
10000000.ToWords()  → "ایک کروڑ"

// ToOrdinalWords()
1.ToOrdinalWords()  → "پہلا"
3.ToOrdinalWords()  → "تیسرا"
```

---

## PR Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included — _N/A, original work_
- [x] There are very few or no comments
- [x] Xml documentation is added/updated for the addition/change
- [x] Your PR is (re)based on top of the latest commits from the `main` branch
- [ ] Link to the issue(s) you're fixing — _No existing issue; this PR adds new localization as encouraged in CONTRIBUTING.md_
- [ ] Readme is updated — _Happy to add Urdu to the supported languages list if maintainers approve_
- [ ] Run either `build.cmd` or `build.ps1` — _Requires .NET 10 preview SDK; CI pipeline should validate_
