### PR TITLE
Fix pascalization and camelization to never return strings with spaces

### DIFF
--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -25,7 +25,7 @@ namespace Humanizer;
 
 public static partial class InflectorExtensions
 {
-    private const string PascalizePattern = @"(?:[ _-]+|^)([a-zA-Z])";
+    private const string PascalizePattern = @"(?:[ _-]+|^)(.)";
     private const string UnderscorePattern1 = @"([\p{Lu}]+)([\p{Lu}][\p{Ll}])";
     private const string UnderscorePattern2 = @"([\p{Ll}\d])([\p{Lu}])";
     private const string UnderscorePattern3 = @"[-\s]";

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -115,6 +115,8 @@ public class InflectorTests
     [InlineData("customer_first_name", "CustomerFirstName")]
     [InlineData("customer_first_name goes here", "CustomerFirstNameGoesHere")]
     [InlineData("customer name", "CustomerName")]
+    [InlineData("customer name 1", "CustomerName1")]
+    [InlineData("customer name $", "CustomerName$")]
     [InlineData("customer   name", "CustomerName")]
     [InlineData("customer-first-name", "CustomerFirstName")]
     [InlineData("_customer-first-name", "CustomerFirstName")]
@@ -131,6 +133,8 @@ public class InflectorTests
     [InlineData("customer_first_name", "customerFirstName")]
     [InlineData("customer_first_name goes here", "customerFirstNameGoesHere")]
     [InlineData("customer name", "customerName")]
+    [InlineData("customer name 1", "customerName1")]
+    [InlineData("customer name $", "customerName$")]
     [InlineData("customer   name", "customerName")]
     [InlineData("", "")]
     public void Camelize(string input, string expectedOutput) =>


### PR DESCRIPTION
Pull request #1299 introduced a regression on pascalization and camelization.

Before #1299 (no space):
✅ "Address Line 1".Pascalize() → `AddressLine1`

After #1299 (space between Line and 1):
❌ "Address Line 1".Pascalize() → `AddressLine 1`

This fixes the regression.