### PR TITLE
Fix ToMetric() rounding boundary issue for doubles #1695

### DIFF
--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -484,12 +484,16 @@ public static class MetricNumeralExtensions
             return BuildMetricRepresentation(input, exponent, formats, decimals);
         }
 
+        if (decimals.HasValue)
+        {
+            input = Math.Round(input, decimals.Value);
+
+            if (Math.Abs(input) >= 1000)
+                return BuildMetricRepresentation(input, 1, formats, decimals);
+        }
+
         var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
-        var representation = decimals.HasValue
-            ? Math
-                .Round(input, decimals.Value)
-                .ToString(nfi)
-            : input.ToString(nfi);
+        var representation = input.ToString(nfi);
         var space = (formats & MetricNumeralFormats.WithSpace) == MetricNumeralFormats.WithSpace ? " " : string.Empty;
         return representation + space;
     }

--- a/tests/Humanizer.Tests/MetricNumeralTests.cs
+++ b/tests/Humanizer.Tests/MetricNumeralTests.cs
@@ -345,6 +345,10 @@ public class MetricNumeralTests
     [InlineData("1 milli", 1E-3, MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseName, null)]
     [InlineData("1 thousandth", 1E-3, MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseShortScaleWord, null)]
     [InlineData("1 thousandth", 1E-3, MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseLongScaleWord, null)]
+    [InlineData("1k", 999.9, null, 0)]
+    [InlineData("-1k", -999.9, null, 0)]
+    [InlineData("1k", 999.99, null, 1)]
+    [InlineData("999", 999.4, null, 0)]
     public void ToMetric(string expected, double input, MetricNumeralFormats? format, int? decimals) =>
         Assert.Equal(expected, input.ToMetric(format, decimals));
 


### PR DESCRIPTION
## Summary

`999.9.ToMetric(decimals: 0)` now returns `1k` instead of `1000`, with the same boundary behavior for negative values and other decimal precisions. The double overload rounds once before choosing the first metric tier and reuses that rounded value for plain-number formatting.

Fixes #1695

## Validation

- [x] `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 57,014 passed
- [x] `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 57,014 passed
- [x] `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 57,014 passed
- [x] `dotnet pack src/Humanizer/Humanizer.csproj -c Release` succeeded
- [x] `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` succeeded

## Contributor checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] Proper unit test coverage is included
- [x] No externally copied code was introduced
- [x] No unnecessary comments were added
- [x] XML documentation is unchanged because no public API changed
- [x] The PR is rebased on the latest `main`
- [x] The fixed issue is linked above
- [x] README changes are unnecessary because the public API and documented usage are unchanged
