### PR TITLE
Rework long.ToMetric for correct interpretation of decimals parameter

### DIFF
--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -421,7 +421,7 @@ public static class MetricNumeralExtensions
             {
                 if (fractionalPart > roundingPoint)
                     number += Math.Sign(number);
-                else
+                else if (fractionalPart == roundingPoint)
                 {
                     // Use banker's rounding for consistency with Math.Round used elsewhere on floats.
                     number += Math.Sign(number % 2);

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -204,7 +204,7 @@ public static class MetricNumeralExtensions
     /// <returns>A valid Metric representation</returns>
     public static string ToMetric(this long input, MetricNumeralFormats? formats = null, int? decimals = null)
     {
-        if (input.Equals(0) && (!decimals.HasValue || (decimals == 0)))
+        if (input.Equals(0))
         {
             return input.ToString();
         }
@@ -373,43 +373,63 @@ public static class MetricNumeralExtensions
             fractionalPart = Math.Abs(input % divisor);
         }
 
-        if (decimals.HasValue)
-        {
-            for (var i = decimals.Value; i < exponent; i++)
-            {
-                var roundUp = (i + 1 == exponent);
-
-                fractionalPart = (fractionalPart + (roundUp ? 5 : 0)) / 10;
-            }
-        }
-        else
-        {
+        if (!decimals.HasValue)
             decimals = exponent;
-        }
 
-        var symbol = Math.Sign(scale) == 1
-            ? Symbols[0][scale - 1]
-            : Symbols[1][-scale - 1];
+        var unitText =
+            Math.Sign(scale) switch
+            {
+                +1 => GetUnitText(Symbols[0][scale - 1], formats),
+                -1 => GetUnitText(Symbols[1][-scale - 1], formats),
+                _ => string.Empty
+            };
+
+        var fractionalPartCharacters = Array.Empty<char>();
+
+        if (decimals > 0)
+        {
+            fractionalPartCharacters = fractionalPart.ToString().PadLeft(exponent, '0').ToCharArray();
+
+            if (!decimals.HasValue || (decimals >= fractionalPartCharacters.Length))
+                decimals = fractionalPartCharacters.Length;
+            else if (fractionalPartCharacters[decimals.Value] >= '5')
+            {
+                // Apply rounding. Find a digit we can increment, carrying as needed.
+                for (var i = decimals.Value - 1; i >= 0; i--)
+                {
+                    if (fractionalPartCharacters[i] < '9')
+                    {
+                        fractionalPartCharacters[i]++;
+                        break;
+                    }
+
+                    fractionalPartCharacters[i] = '0'; // loop to carry
+                }
+            }
+
+            while ((decimals > 0) && (fractionalPartCharacters[decimals.Value - 1] == '0'))
+                decimals--;
+        }
 
         var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
 
         if (decimals == 0)
         {
+            if ((divisor > 1) && (fractionalPart >= divisor / 2))
+                number += Math.Sign(number);
+
             var space = formats.HasValue && formats.Value.HasFlag(MetricNumeralFormats.WithSpace) ? " " : string.Empty;
-            return number.ToString(nfi) + space + GetUnitText(symbol, formats);
+            return number.ToString(nfi) + space + unitText;
         }
         else
         {
-            var decimalPlaces = Math.Min(decimals.Value, exponent);
-            var extraZeroes = (decimals.Value - decimalPlaces);
             var space = formats.HasValue && formats.Value.HasFlag(MetricNumeralFormats.WithSpace) ? " " : string.Empty;
 
             return number.ToString(nfi)
                  + nfi.NumberDecimalSeparator
-                 + fractionalPart.ToString("d" + decimalPlaces)
-                 + (extraZeroes <= 0 ? string.Empty : new string('0', extraZeroes))
+                 + new string(fractionalPartCharacters, 0, decimals.Value)
                  + space
-                 + GetUnitText(symbol, formats);
+                 + unitText;
         }
     }
 

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -391,16 +391,37 @@ public static class MetricNumeralExtensions
                 decimals = fractionalPartCharacters.Length;
             else if (fractionalPartCharacters[decimals.Value] >= '5')
             {
-                // Apply rounding. Find a digit we can increment, carrying as needed.
-                for (var i = decimals.Value - 1; i >= 0; i--)
-                {
-                    if (fractionalPartCharacters[i] < '9')
-                    {
-                        fractionalPartCharacters[i]++;
-                        break;
-                    }
+                var isExactlyAtMidpoint =
+                    (fractionalPartCharacters[decimals.Value] == '5') &&
+                    (fractionalPartCharacters.AsSpan().Slice(decimals.Value + 1).IndexOfAnyExcept('0') < 0);
 
-                    fractionalPartCharacters[i] = '0'; // loop to carry
+                bool shouldRoundUp;
+
+                if (!isExactlyAtMidpoint)
+                    shouldRoundUp = true;
+                else
+                {
+                    var precedingDigit = fractionalPartCharacters[decimals.Value - 1] - '0';
+
+                    var precedingDigitIsOdd = (precedingDigit & 1) != 0;
+
+                    // Banker's rounding: 3.5 => 4, 4.5 => 4
+                    shouldRoundUp = precedingDigitIsOdd;
+                }
+
+                if (shouldRoundUp)
+                {
+                    // Apply rounding. Find a digit we can increment, carrying as needed.
+                    for (var i = decimals.Value - 1; i >= 0; i--)
+                    {
+                        if (fractionalPartCharacters[i] < '9')
+                        {
+                            fractionalPartCharacters[i]++;
+                            break;
+                        }
+
+                        fractionalPartCharacters[i] = '0'; // loop to carry
+                    }
                 }
             }
 

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -333,11 +333,8 @@ public static class MetricNumeralExtensions
         }
 
         var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
-        var representation = decimals > 0
-            ? $"{input.ToString(nfi)}{nfi.NumberDecimalSeparator}{new string('0', decimals.Value)}"
-            : input.ToString(nfi);
         var space = (formats & MetricNumeralFormats.WithSpace) == MetricNumeralFormats.WithSpace ? " " : string.Empty;
-        return representation + space;
+        return input.ToString(nfi) + space;
     }
 
     /// <summary>

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -193,7 +193,7 @@ public static class MetricNumeralExtensions
     /// </remarks>
     /// <param name="input">Number to convert to a Metric representation.</param>
     /// <param name="formats">A bitwise combination of <see cref="MetricNumeralFormats"/> enumeration values that format the metric representation.</param>
-    /// <param name="decimals">If not null it is the numbers of decimals to round the number to</param>
+    /// <param name="decimals">The maximum number of fractional digits to include. If null, all available precision is preserved. Trailing zeros are omitted.</param>
     /// <example>
     /// <code>
     /// 1000.ToMetric() => "1k"

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -415,8 +415,18 @@ public static class MetricNumeralExtensions
 
         if (decimals == 0)
         {
-            if ((divisor > 1) && (fractionalPart >= divisor / 2))
-                number += Math.Sign(number);
+            var roundingPoint = divisor / 2;
+
+            if (divisor > 1)
+            {
+                if (fractionalPart > roundingPoint)
+                    number += Math.Sign(number);
+                else
+                {
+                    // Use banker's rounding for consistency with Math.Round used elsewhere on floats.
+                    number += Math.Sign(number % 2);
+                }
+            }
 
             var space = formats.HasValue && formats.Value.HasFlag(MetricNumeralFormats.WithSpace) ? " " : string.Empty;
             return number.ToString(nfi) + space + unitText;

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -426,6 +426,13 @@ public static class MetricNumeralExtensions
                     // Use banker's rounding for consistency with Math.Round used elsewhere on floats.
                     number += Math.Sign(number % 2);
                 }
+
+                if (Math.Abs(number) == 1000)
+                {
+                    number /= 1000;
+                    scale++;
+                    unitText = GetUnitText(Symbols[0][scale - 1], formats);
+                }
             }
 
             var space = formats.HasValue && formats.Value.HasFlag(MetricNumeralFormats.WithSpace) ? " " : string.Empty;

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -1612,7 +1612,7 @@ public class CoverageGapTests
         Assert.False(string.IsNullOrWhiteSpace(999_999_999_999_999_999L.ToMetric(MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseShortScaleWord, 3)));
         Assert.False(string.IsNullOrWhiteSpace(999_999_999_999_999_999d.ToMetric(MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseLongScaleWord, 4)));
         Assert.False(string.IsNullOrWhiteSpace(long.MaxValue.ToMetric()));
-        Assert.Equal("123.0 ", 123L.ToMetric(MetricNumeralFormats.WithSpace, 1));
+        Assert.Equal("123 ", 123L.ToMetric(MetricNumeralFormats.WithSpace, 1));
         Assert.Equal("1m", InvokePrivate<string>(
             typeof(MetricNumeralExtensions),
             null,

--- a/tests/Humanizer.Tests/MetricNumeralTests.cs
+++ b/tests/Humanizer.Tests/MetricNumeralTests.cs
@@ -92,14 +92,6 @@ public class MetricNumeralTests
             }
         }
 
-        // Verify banker's rounding is used
-        data.Add(2400, 0, "2k");
-        data.Add(2500, 0, "2k");
-        data.Add(2600, 0, "3k");
-        data.Add(3400, 0, "3k");
-        data.Add(3500, 0, "4k");
-        data.Add(3600, 0, "4k");
-
         // 1,000-999,999
         foreach (var value in (long[])[23456, 123456, 123056, 123999])
         {
@@ -220,6 +212,21 @@ public class MetricNumeralTests
                 data.Add(value, decimals, expected);
             }
         }
+
+        // Verify banker's rounding is used
+        data.Add(2400, 0, "2k");
+        data.Add(2500, 0, "2k");
+        data.Add(2600, 0, "3k");
+        data.Add(3400, 0, "3k");
+        data.Add(3500, 0, "4k");
+        data.Add(3600, 0, "4k");
+
+        // Verify scale changes due to rounding are handled.
+        data.Add(999500, 0, "1M");
+        data.Add(999600000, 0, "1G");
+        data.Add(999700000000, 0, "1T");
+        data.Add(999500000000001, 0, "1P");
+        data.Add(999500000000000000, 0, "1E");
 
         foreach (var positiveTestCase in data.ToList())
         {

--- a/tests/Humanizer.Tests/MetricNumeralTests.cs
+++ b/tests/Humanizer.Tests/MetricNumeralTests.cs
@@ -92,6 +92,14 @@ public class MetricNumeralTests
             }
         }
 
+        // Verify banker's rounding is used
+        data.Add(2400, 0, "2k");
+        data.Add(2500, 0, "2k");
+        data.Add(2600, 0, "3k");
+        data.Add(3400, 0, "3k");
+        data.Add(3500, 0, "4k");
+        data.Add(3600, 0, "4k");
+
         // 1,000-999,999
         foreach (var value in (long[])[23456, 123456, 123056, 123999])
         {

--- a/tests/Humanizer.Tests/MetricNumeralTests.cs
+++ b/tests/Humanizer.Tests/MetricNumeralTests.cs
@@ -81,6 +81,9 @@ public class MetricNumeralTests
         static decimal RemoveTrailingZeroes(ref decimal value)
             => value /= 1.000000000000000000000000000000000M;
 
+        static string FormatExpected(decimal value, string suffix) =>
+            value.ToString(CultureInfo.InvariantCulture) + suffix;
+
         var data = new TheoryData<long, int?, string>();
 
         // 0-999
@@ -88,7 +91,7 @@ public class MetricNumeralTests
         {
             foreach (var decimals in (int?[])[null, 0, 1, 3, 20])
             {
-                data.Add(value, decimals, value.ToString());
+                data.Add(value, decimals, value.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -106,7 +109,7 @@ public class MetricNumeralTests
 
                 RemoveTrailingZeroes(ref truncatedValue);
 
-                var expected = truncatedValue + "k";
+                var expected = FormatExpected(truncatedValue, "k");
 
                 data.Add(value, decimals, expected);
             }
@@ -126,7 +129,7 @@ public class MetricNumeralTests
 
                 RemoveTrailingZeroes(ref truncatedValue);
 
-                var expected = truncatedValue + "M";
+                var expected = FormatExpected(truncatedValue, "M");
 
                 data.Add(value, decimals, expected);
             }
@@ -146,7 +149,7 @@ public class MetricNumeralTests
 
                 RemoveTrailingZeroes(ref truncatedValue);
 
-                var expected = truncatedValue + "G";
+                var expected = FormatExpected(truncatedValue, "G");
 
                 data.Add(value, decimals, expected);
             }
@@ -166,7 +169,7 @@ public class MetricNumeralTests
 
                 RemoveTrailingZeroes(ref truncatedValue);
 
-                var expected = truncatedValue + "T";
+                var expected = FormatExpected(truncatedValue, "T");
 
                 data.Add(value, decimals, expected);
             }
@@ -186,7 +189,7 @@ public class MetricNumeralTests
 
                 RemoveTrailingZeroes(ref truncatedValue);
 
-                var expected = truncatedValue + "P";
+                var expected = FormatExpected(truncatedValue, "P");
 
                 data.Add(value, decimals, expected);
             }
@@ -207,7 +210,7 @@ public class MetricNumeralTests
 
                 RemoveTrailingZeroes(ref truncatedValue);
 
-                var expected = truncatedValue + "E";
+                var expected = FormatExpected(truncatedValue, "E");
 
                 data.Add(value, decimals, expected);
             }
@@ -352,4 +355,18 @@ public class MetricNumeralTests
     [InlineData(-1E-27)]
     public void ToMetricOnInvalid(double input) =>
         Assert.Throws<ArgumentOutOfRangeException>(() => input.ToMetric());
+}
+
+[UseCulture("de-DE")]
+public class MetricNumeralTestDataTests
+{
+    [Fact]
+    public void LongTestCaseExpectationsUseInvariantCulture()
+    {
+        var testCase = MetricNumeralTests
+            .GenerateLongToMetricTestCases()
+            .Single(x => x.Data.Item1 == 1245 && x.Data.Item2 == 2);
+
+        Assert.Equal("1.24k", testCase.Data.Item3);
+    }
 }

--- a/tests/Humanizer.Tests/MetricNumeralTests.cs
+++ b/tests/Humanizer.Tests/MetricNumeralTests.cs
@@ -93,7 +93,7 @@ public class MetricNumeralTests
         }
 
         // 1,000-999,999
-        foreach (var value in (long[])[23456, 123456, 123056, 123999])
+        foreach (var value in (long[])[1245, 23456, 123456, 123056, 123999])
         {
             foreach (var decimals in (int?[])[null, 0, 1, 2, 3, 20])
             {
@@ -113,7 +113,7 @@ public class MetricNumeralTests
         }
 
         // 1,000,000-999,999,999
-        foreach (var value in (long[])[23456789, 123456789, 123050709])
+        foreach (var value in (long[])[23456789, 123456785, 123050709])
         {
             foreach (var decimals in (int?[])[null, 0, 1, 2, 3, 4, 5, 6, 20])
             {
@@ -133,7 +133,7 @@ public class MetricNumeralTests
         }
 
         // 1,000,000,000-999,999,999,999
-        foreach (var value in (long[])[23456789123, 123456789123, 123050709020])
+        foreach (var value in (long[])[23456789165, 123456789123, 123050709020])
         {
             foreach (var decimals in (int?[])[null, 0, 1, 2, 3, 7, 8, 9, 20])
             {
@@ -153,7 +153,7 @@ public class MetricNumeralTests
         }
 
         // 1,000,000,000,000-999,999,999,999,999
-        foreach (var value in (long[])[23456789123456, 123456789123456, 123050709020406])
+        foreach (var value in (long[])[23456789123456, 123456789123465, 123050709020406])
         {
             foreach (var decimals in (int?[])[null, 0, 1, 2, 3, 10, 11, 12, 20])
             {
@@ -173,7 +173,7 @@ public class MetricNumeralTests
         }
 
         // 1,000,000,000,000,000-999,999,999,999,999,999
-        foreach (var value in (long[])[23456789123456789, 123456789123456789, 123050709020406080])
+        foreach (var value in (long[])[23456789123456789, 123456789123456785, 123050709020406080])
         {
             foreach (var decimals in (int?[])[null, 0, 1, 2, 3, 13, 14, 15, 20])
             {
@@ -192,7 +192,7 @@ public class MetricNumeralTests
             }
         }
         // 1,000,000,000,000,000,000-
-        foreach (var value in (long[])[1_001_002_003_004_005_006, 2_305_079_902_040_799_020, long.MaxValue])
+        foreach (var value in (long[])[1_001_002_003_004_006_005, 2_305_079_902_040_799_020, long.MaxValue])
         {
             for (var decimalsValue = -1; decimalsValue <= 20; decimalsValue++)
             {

--- a/tests/Humanizer.Tests/MetricNumeralTests.cs
+++ b/tests/Humanizer.Tests/MetricNumeralTests.cs
@@ -75,6 +75,159 @@ public class MetricNumeralTests
         Assert.True(isEquals);
     }
 
+    public static TheoryData<long, int?, string> GenerateLongToMetricTestCases()
+    {
+        // Dividing by 1.000...M removes all trailing zeros by changing the scale factor.
+        static decimal RemoveTrailingZeroes(ref decimal value)
+            => value /= 1.000000000000000000000000000000000M;
+
+        var data = new TheoryData<long, int?, string>();
+
+        // 0-999
+        foreach (var value in (long[])[0, 123])
+        {
+            foreach (var decimals in (int?[])[null, 0, 1, 3, 20])
+            {
+                data.Add(value, decimals, value.ToString());
+            }
+        }
+
+        // 1,000-999,999
+        foreach (var value in (long[])[23456, 123456, 123056, 123999])
+        {
+            foreach (var decimals in (int?[])[null, 0, 1, 2, 3, 20])
+            {
+                var scaledValue = value * 0.001M;
+
+                var truncatedValue =
+                    decimals.HasValue
+                    ? Math.Round(scaledValue, decimals.Value)
+                    : scaledValue;
+
+                RemoveTrailingZeroes(ref truncatedValue);
+
+                var expected = truncatedValue + "k";
+
+                data.Add(value, decimals, expected);
+            }
+        }
+
+        // 1,000,000-999,999,999
+        foreach (var value in (long[])[23456789, 123456789, 123050709])
+        {
+            foreach (var decimals in (int?[])[null, 0, 1, 2, 3, 4, 5, 6, 20])
+            {
+                var scaledValue = value * 0.000001M;
+
+                var truncatedValue =
+                    decimals.HasValue
+                    ? Math.Round(scaledValue, decimals.Value)
+                    : scaledValue;
+
+                RemoveTrailingZeroes(ref truncatedValue);
+
+                var expected = truncatedValue + "M";
+
+                data.Add(value, decimals, expected);
+            }
+        }
+
+        // 1,000,000,000-999,999,999,999
+        foreach (var value in (long[])[23456789123, 123456789123, 123050709020])
+        {
+            foreach (var decimals in (int?[])[null, 0, 1, 2, 3, 7, 8, 9, 20])
+            {
+                var scaledValue = value * 0.000000001M;
+
+                var truncatedValue =
+                    decimals.HasValue
+                    ? Math.Round(scaledValue, decimals.Value)
+                    : scaledValue;
+
+                RemoveTrailingZeroes(ref truncatedValue);
+
+                var expected = truncatedValue + "G";
+
+                data.Add(value, decimals, expected);
+            }
+        }
+
+        // 1,000,000,000,000-999,999,999,999,999
+        foreach (var value in (long[])[23456789123456, 123456789123456, 123050709020406])
+        {
+            foreach (var decimals in (int?[])[null, 0, 1, 2, 3, 10, 11, 12, 20])
+            {
+                var scaledValue = value * 0.000000000001M;
+
+                var truncatedValue =
+                    decimals.HasValue
+                    ? Math.Round(scaledValue, decimals.Value)
+                    : scaledValue;
+
+                RemoveTrailingZeroes(ref truncatedValue);
+
+                var expected = truncatedValue + "T";
+
+                data.Add(value, decimals, expected);
+            }
+        }
+
+        // 1,000,000,000,000,000-999,999,999,999,999,999
+        foreach (var value in (long[])[23456789123456789, 123456789123456789, 123050709020406080])
+        {
+            foreach (var decimals in (int?[])[null, 0, 1, 2, 3, 13, 14, 15, 20])
+            {
+                var scaledValue = value * 0.000000000000001M;
+
+                var truncatedValue =
+                    decimals.HasValue
+                    ? Math.Round(scaledValue, decimals.Value)
+                    : scaledValue;
+
+                RemoveTrailingZeroes(ref truncatedValue);
+
+                var expected = truncatedValue + "P";
+
+                data.Add(value, decimals, expected);
+            }
+        }
+        // 1,000,000,000,000,000,000-
+        foreach (var value in (long[])[1_001_002_003_004_005_006, 2_305_079_902_040_799_020, long.MaxValue])
+        {
+            for (var decimalsValue = -1; decimalsValue <= 20; decimalsValue++)
+            {
+                var decimals = decimalsValue < 0 ? null : (int?)decimalsValue;
+
+                var scaledValue = value * 0.000000000000000001M;
+
+                var truncatedValue =
+                    decimals.HasValue
+                    ? Math.Round(scaledValue, decimals.Value)
+                    : scaledValue;
+
+                RemoveTrailingZeroes(ref truncatedValue);
+
+                var expected = truncatedValue + "E";
+
+                data.Add(value, decimals, expected);
+            }
+        }
+
+        foreach (var positiveTestCase in data.ToList())
+        {
+            var negativeValue = -positiveTestCase.Data.Item1;
+            var decimals = positiveTestCase.Data.Item2;
+            var negativeExpected =
+                negativeValue != 0
+                ? "-" + positiveTestCase.Data.Item3
+                : positiveTestCase.Data.Item3;
+
+            data.Add(negativeValue, decimals, negativeExpected);
+        }
+
+        return data;
+    }
+
     [Theory]
     [InlineData("999", 999)]
     [InlineData("1k", 1000)]
@@ -86,45 +239,7 @@ public class MetricNumeralTests
         Assert.Equal(expected, subject.ToMetric());
 
     [Theory]
-    [InlineData(0, 0, "0")]
-    [InlineData(0, 1, "0.0")]
-    [InlineData(0, 3, "0.000")]
-    [InlineData(0, 20, "0.00000000000000000000")]
-    [InlineData(123, 0, "123")]
-    [InlineData(123, 1, "123.0")]
-    [InlineData(123, 3, "123.000")]
-    [InlineData(123, 20, "123.00000000000000000000")]
-    [InlineData(123456, null, "123.456k")]
-    [InlineData(123456, 0, "123k")]
-    [InlineData(123456, 1, "123.5k")]
-    [InlineData(123456, 2, "123.46k")]
-    [InlineData(123456, 3, "123.456k")]
-    [InlineData(123456, 20, "123.45600000000000000000k")]
-    [InlineData(123456789, null, "123.456789M")]
-    [InlineData(123456789, 0, "123M")]
-    [InlineData(123456789, 1, "123.5M")]
-    [InlineData(123456789, 2, "123.46M")]
-    [InlineData(123456789, 3, "123.457M")]
-    [InlineData(123456789, 5, "123.45679M")]
-    [InlineData(123456789, 20, "123.45678900000000000000M")]
-    [InlineData(123456789987, 5, "123.45679G")]
-    [InlineData(123456789987, 20, "123.45678998700000000000G")]
-    [InlineData(123456789987654, 5, "123.45679T")]
-    [InlineData(123456789987654, 20, "123.45678998765400000000T")]
-    [InlineData(123456789987654321, 5, "123.45679P")]
-    [InlineData(123456789987654321, 20, "123.45678998765432100000P")]
-    [InlineData(9223372036854775807, null, "9.223372036854775807E")]
-    [InlineData(9223372036854775807, 0, "9E")]
-    [InlineData(9223372036854775807, 3, "9.223E")]
-    [InlineData(9223372036854775807, 20, "9.22337203685477580700E")]
-    [InlineData(-1, null, "-1")]
-    [InlineData(-123, null, "-123")]
-    [InlineData(-123456, null, "-123.456k")]
-    [InlineData(-123456789, null, "-123.456789M")]
-    [InlineData(-9223372036854775808, null, "-9.223372036854775808E")]
-    [InlineData(-9223372036854775808, 0, "-9E")]
-    [InlineData(-9223372036854775808, 3, "-9.223E")]
-    [InlineData(-9223372036854775808, 20, "-9.22337203685477580800E")]
+    [MemberData(nameof(GenerateLongToMetricTestCases))]
     public void TestAllSymbolsAsLong(long subject, int? decimals, string expected) =>
         Assert.Equal(expected, subject.ToMetric(decimals: decimals));
 


### PR DESCRIPTION
This PR:

- Replaces the test suite for the long.ToMetric extension method with a much more comprehensive set using a `TheoryData` generator, and uses an interpretation of the `decimals` parameter in line with `int.ToMetric` and `double.ToMetric` in the process.

- Makes all the tests pass by reworking the implementation of the `ToMetric(long, ..)` extension method and its underlying helper `BuildRepresentation(long, ..)` correspondingly.

This amends the implementation merged in #1596 to correct this misinterpretation. Thanks to @petervanleeuwen for noticing it 🙂 

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
     - In `ToMetric(this long, ..)`, there is a one-line block with braces. The reason is consistency with the existing code in `ToMetric(this int, ..)` and `ToMetric(this double, ..)`. If you prefer, I can add a commit that updates all of them to follow this style point.
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage
 - [x] (N/A) If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
    - I put a comment next to a loop whose purpose isn't hard to discern but for which understanding how one iteration's effects tie into the next would add a handful of unnecessary seconds to the reader's day.
    - I used comments to denote number ranges in the test case generator. The separation reads better to my eye. Can remove them if they're deemed inappropriate.
 - [x] (N/A) Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] (N/A) Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
    - I don't see `build.cmd` or `build.ps1` in the source tree, but the solution builds and all tests discovered by the Test Explorer pass.

Fixes: #1699
