### PR TITLE
Fix typo in README: change 'month' to 'months'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -328,7 +328,7 @@ TimeSpan.FromMilliseconds(2000).Humanize(maxUnit: TimeUnit.Millisecond) => "2000
 ```
 The default maxUnit is `TimeUnit.Week` because it gives exact results. You can increase this value to `TimeUnit.Month` or `TimeUnit.Year` which will give you an approximation based on 365.2425 days a year and 30.436875 days a month. Therefore, the months are alternating between 30 and 31 days in length and every fourth year is 366 days long.
 ```csharp
-TimeSpan.FromDays(486).Humanize(maxUnit: TimeUnit.Year, precision: 7) => "1 year, 3 months, 29 days" // One day further is 1 year, 4 month
+TimeSpan.FromDays(486).Humanize(maxUnit: TimeUnit.Year, precision: 7) => "1 year, 3 months, 29 days" // One day further is 1 year, 4 months
 TimeSpan.FromDays(517).Humanize(maxUnit: TimeUnit.Year, precision: 7) => "1 year, 4 months, 30 days" // This month has 30 days and one day further is 1 year, 5 months
 ```
 


### PR DESCRIPTION
I noticed a small typo in the [readme.md](https://github.com/Humanizr/Humanizer/blob/main/readme.md) on line **331**. In the timespan example, "4 month" was used instead of "4 months"; this PR corrects the pluralization.