### PR TITLE
Improve ordinal and clock notation hot paths

### DIFF
--- a/.flow/epics/fn-15-optimize-string-transformation-fast.json
+++ b/.flow/epics/fn-15-optimize-string-transformation-fast.json
@@ -1,0 +1,18 @@
+{
+  "branch_name": "codex/performance-hotspots-net11",
+  "completion_review_status": "unknown",
+  "completion_reviewed_at": null,
+  "created_at": "2026-04-19T16:35:20.604656Z",
+  "default_impl": null,
+  "default_review": null,
+  "default_sync": null,
+  "depends_on_epics": [],
+  "id": "fn-15-optimize-string-transformation-fast",
+  "next_task": 1,
+  "plan_review_status": "ship",
+  "plan_reviewed_at": "2026-04-19T16:45:22.328400Z",
+  "spec_path": ".flow/specs/fn-15-optimize-string-transformation-fast.md",
+  "status": "open",
+  "title": "Optimize string transformation fast paths",
+  "updated_at": "2026-04-19T16:45:22.328610Z"
+}

--- a/.flow/epics/fn-16-performance-follow-up-hot-paths.json
+++ b/.flow/epics/fn-16-performance-follow-up-hot-paths.json
@@ -1,0 +1,13 @@
+{
+  "branch_name": "codex/performance-hotspots-net11",
+  "created_at": "2026-04-20T21:38:47.374121Z",
+  "depends_on_epics": [],
+  "id": "fn-16-performance-follow-up-hot-paths",
+  "next_task": 1,
+  "plan_review_status": "unknown",
+  "plan_reviewed_at": null,
+  "spec_path": ".flow/specs/fn-16-performance-follow-up-hot-paths.md",
+  "status": "done",
+  "title": "Performance follow-up hot paths",
+  "updated_at": "2026-04-20T21:54:03.818776Z"
+}

--- a/.flow/epics/fn-17-address-pr-1732-review-feedback.json
+++ b/.flow/epics/fn-17-address-pr-1732-review-feedback.json
@@ -1,0 +1,13 @@
+{
+  "branch_name": "codex/performance-hotspots-net11",
+  "created_at": "2026-04-20T22:05:49.220890Z",
+  "depends_on_epics": [],
+  "id": "fn-17-address-pr-1732-review-feedback",
+  "next_task": 1,
+  "plan_review_status": "unknown",
+  "plan_reviewed_at": null,
+  "spec_path": ".flow/specs/fn-17-address-pr-1732-review-feedback.md",
+  "status": "done",
+  "title": "Address PR 1732 review feedback",
+  "updated_at": "2026-04-20T22:17:44.004606Z"
+}

--- a/.flow/epics/fn-18-address-follow-up-pr-1732-review-thread.json
+++ b/.flow/epics/fn-18-address-follow-up-pr-1732-review-thread.json
@@ -1,0 +1,13 @@
+{
+  "branch_name": "fn-18-address-follow-up-pr-1732-review-thread",
+  "created_at": "2026-04-20T22:19:01.460095Z",
+  "depends_on_epics": [],
+  "id": "fn-18-address-follow-up-pr-1732-review-thread",
+  "next_task": 1,
+  "plan_review_status": "unknown",
+  "plan_reviewed_at": null,
+  "spec_path": ".flow/specs/fn-18-address-follow-up-pr-1732-review-thread.md",
+  "status": "done",
+  "title": "Address follow-up PR #1732 review thread",
+  "updated_at": "2026-04-20T22:23:14.840830Z"
+}

--- a/.flow/specs/fn-15-optimize-string-transformation-fast.md
+++ b/.flow/specs/fn-15-optimize-string-transformation-fast.md
@@ -1,0 +1,222 @@
+# Optimize String Transformation Fast Paths
+
+## Goal & Context
+
+Improve the next set of Humanizer performance hotspots after PR #1732 by replacing regex/LINQ/multi-pass string shaping in common ASCII-heavy string APIs with allocation-conscious span scanners while preserving existing Unicode, culture, and target-framework behavior through explicit fallback paths.
+
+This epic intentionally builds on the current branch `codex/performance-hotspots-net11`. PR #1732 already improves several non-string hotspots and partially improves `ToTitleCase`; this plan targets follow-on string transformation work and must keep PR hygiene clear by separating pre-existing branch changes from changes made for this epic.
+
+Primary target surfaces:
+
+- `StringHumanizeExtensions.Humanize()` and `Humanize(LetterCasing)` in `src/Humanizer/StringHumanizeExtensions.cs`
+- `ToTitleCase.Transform(...)` in `src/Humanizer/Transformer/ToTitleCase.cs`
+- Inflector case transforms in `src/Humanizer/InflectorExtensions.cs`: `Pascalize`, `Camelize`, `Underscore`, `Kebaberize`, and indirectly `Titleize`
+- English article sort helpers in `src/Humanizer/ArticlePrefixSort.cs`
+- Benchmark coverage in `src/Benchmarks`
+- Regression coverage in `tests/Humanizer.Tests`
+
+The current local benchmark artifacts indicate the largest remaining measured string hotspot is title casing at longer input sizes. Representative local artifacts show `TransformersBenchmarks.TitleCase` at roughly `24.5 us / 73 KB` for 1000 chars and `AllTransforms` at roughly `23.7 us / 77 KB` for 1000 chars. Exact numbers must be refreshed in task 1 because artifacts and branch contents can drift.
+
+## Required Sequencing
+
+1. Establish benchmark and correctness baseline.
+2. Decide and document the Rune/downlevel policy before implementation tasks begin.
+3. Implement each fast path behind tests and objective benchmark criteria.
+4. Run final validation and PR hygiene checks.
+
+Tasks 2-5 depend on task 6 as well as task 1 so implementation cannot start before the Rune/downlevel decision is made explicit.
+
+## Rune / Polyfill Decision Gate
+
+Do not lead with `System.Text.Rune` for performance. The .NET docs describe `Rune` as useful when code explicitly handles Unicode scalar values or surrogate pairs, and also state it is unnecessary for exact `char` matches or known `char` delimiters. These target methods are hot mostly because of regex, match allocation, LINQ, `StringBuilder` copies, and repeated whole-string transforms. For ASCII identifier inputs, Rune decoding would usually add work rather than remove it.
+
+Implementation policy:
+
+- Use ASCII/span scanners as the primary fast path.
+- Preserve existing regex/culture paths as fallback when input contains non-ASCII, punctuation edge cases, apostrophe forms, culture-sensitive casing, or behavior that is not yet proven equivalent.
+- Add Rune only if a separate approved task explicitly improves supplementary-plane Unicode correctness.
+- Do not add a dependency or source import solely to make Rune available on `net48` or `netstandard2.0` for these perf fast paths.
+- The final diff for this epic must contain no new `System.Text.Rune` usage, no new Polyfill Rune-specific import, and no new package/reference change for Rune unless a separate approved task is created first.
+
+Polyfill note: the referenced SimonCropp/Polyfill commit adds extension methods such as `string.Contains(Rune)` and `StringBuilder.Append(Rune)`, but the raw source is guarded with `#if !NET11_0_OR_GREATER && NETCOREAPP3_0_OR_GREATER` and uses `System.Text.Rune`. That means it relies on the platform already providing `System.Text.Rune`; it does not solve Humanizer's `net48` or `netstandard2.0` Rune availability. If downlevel Rune support is ever desired, that is a separate dependency/design decision, not a prerequisite for this string performance epic.
+
+Relevant external references checked during planning:
+
+- Polyfill commit: https://github.com/SimonCropp/Polyfill/commit/b710fcacfc84276688190f46c13f55bbf253f15f
+- Polyfill raw `Polyfill_String_Rune.cs`: https://raw.githubusercontent.com/SimonCropp/Polyfill/b710fcacfc84276688190f46c13f55bbf253f15f/src/Polyfill/Polyfill_String_Rune.cs
+- Microsoft Rune docs: https://learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-text-rune
+
+## Culture And Casing Rules
+
+ASCII input does not imply ASCII output. Turkish and Azeri casing can map ASCII `i`/`I` to non-ASCII `İ`/`ı`, and Humanizer exposes culture-aware casing through `TextInfo` and `UseCulture` tests.
+
+Fast-path rules:
+
+- Do not use arithmetic ASCII casing such as `c | 0x20`, `c - 32`, or invariant-only assumptions in public string transforms unless tests prove equivalence for that exact path.
+- Prefer `culture.TextInfo.ToUpper(char)` / `ToLower(char)` or an existing culture-aware path for casing changes.
+- If a proposed fast path cannot handle a culture where ASCII casing is non-invariant, fallback to the existing implementation for that culture.
+- Required tests must cover `UseCulture("tr-TR")` for `Humanize`, `Humanize(LetterCasing.Title)`, `ToTitleCase`, `Pascalize`, `Camelize`, `Underscore`, and `Kebaberize`, or document why a method is culture-invariant today and prove unchanged behavior.
+
+## Downlevel Allocation Strategy
+
+Humanizer targets `net11.0`, `net10.0`, `net8.0`, `net48`, and `netstandard2.0`. Any single-allocation write path must account for all targets.
+
+Rules:
+
+- Use `string.Create` only behind target-framework guards where it is available.
+- For downlevel targets, use existing compat helpers or add narrow internal helpers that preserve current compile support.
+- Every implementation task that introduces `string.Create`, span writes, or stack buffers must include `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp-output>` evidence proving all library TFMs compile.
+
+## Architecture & Implementation Strategy
+
+### 1. Benchmark First
+
+Before changing implementation, add or refresh deterministic benchmarks that isolate intended fast paths and fallback paths separately. Random strings are acceptable only when seeded and separated from targeted ASCII scanner cases.
+
+Benchmark dimensions should include:
+
+- `Humanize()` fast path and fallback cases.
+- `ToTitleCase` fast path and fallback cases.
+- Inflector transforms fast path and fallback cases.
+- English article sort positive and negative cases.
+
+Benchmark acceptance thresholds:
+
+- For a task's primary ASCII fast-path benchmark with baseline allocations above 500 B, allocated bytes should drop by at least 25% or the task must document why the validated behavior constraints make that target inappropriate.
+- For primary ASCII fast-path benchmarks below 500 B baseline allocation, allocation count or bytes should not increase, and mean should improve by at least 10% or be explicitly justified.
+- Fallback/non-ASCII benchmarks must not regress mean or allocated bytes by more than 10% outside benchmark noise; any apparent regression requires re-run or explanation.
+- Benchmarks must report both mean and allocation deltas in completion evidence.
+
+### 2. Add Golden Behavior Tests Before Rewrites
+
+Before replacing regex logic, add focused tests for the exact behavior being preserved. Do not rely only on existing examples.
+
+Required test categories:
+
+- Existing ASCII outputs for `Humanize`, `Titleize`, `Pascalize`, `Camelize`, `Underscore`, `Kebaberize`.
+- Acronym behavior, especially all-uppercase whole input and uppercase runs inside mixed identifiers.
+- Punctuation, digit, symbol, leading/trailing/consecutive separator behavior.
+- Non-ASCII behavior, including existing `CanHumanizeOtherUnicodeLetter` style cases.
+- Culture-sensitive casing, including Turkish tests described above.
+- Article prefix/suffix sorting behavior for `The`, `the`, `A`, `a`, `An`, `an`, plus Unicode word tails, `_`, digit tails, trailing punctuation, multiple spaces, and non-space whitespace.
+
+### 3. `ToTitleCase` Follow-On Fast Path
+
+Current branch already removed the frozen minor-word set and avoids some match string allocations. The next step is a deeper ASCII fast path that avoids regex match enumeration and full `StringBuilder` copy for common ASCII sentence-like inputs.
+
+Proposed design:
+
+- Add an internal scanner that detects word spans using ASCII rules compatible with the current regex for ASCII inputs: letters/digits/underscore plus optional apostrophe continuation where current behavior supports it.
+- If the input contains non-ASCII, fallback to the current regex/culture implementation unless Unicode-equivalent scanning is proven with tests.
+- For ASCII words, avoid `StringBuilder` when no characters need changing; return input unchanged.
+- When changes are needed, allocate the destination string once on supported TFMs; use downlevel helpers on older TFMs.
+- Preserve first-word capitalization and minor-word skip semantics exactly.
+
+Risks:
+
+- Regex `\w` includes underscore and Unicode word characters; scanner must match ASCII cases and fallback otherwise.
+- Apostrophe handling must match the current `+'?\w*` shape.
+- All-caps detection must not change acronym preservation.
+- Turkish/Azeri casing must remain culture-correct or must fallback.
+
+### 4. `Humanize()` PascalCase / Separator Fast Path
+
+The current PascalCase path uses regex matches, LINQ, `string.Join`, word lowercasing, a whole-result uppercase scan, and a final concat. Replace only the common ASCII identifier path first.
+
+Proposed design:
+
+- Keep existing fast path for all-uppercase acronym input, replacing LINQ `All` with a simple loop.
+- Replace freestanding separator regex with a span scanner that preserves current semantics.
+- For `_` and `-` separated inputs, preserve current behavior that replaces separators with spaces without lowercasing.
+- For ASCII Pascal/camel identifiers, emit a single string by scanning boundaries.
+- If non-ASCII, punctuation omission, or acronym boundary behavior cannot be proven equivalent, call the existing regex implementation.
+
+Risks:
+
+- Existing regex strips some punctuation by omission; scanner must not accidentally keep punctuation unless tests say so.
+- `\p{Lo}` handling is important for other-letter Unicode cases; fallback is preferred.
+- Current behavior around mixed acronym inputs is subtle and must be covered before implementation.
+
+### 5. Inflector Case Transform Fast Paths
+
+The inflector methods currently lean on regex replacement chains. Add dedicated ASCII fast paths before regex fallback.
+
+Proposed design:
+
+- `Pascalize`: scan separators (`space`, `_`, `-`) and word starts; preserve current behavior for non-letter characters captured after separators.
+- `Camelize`: use the same internal worker with a lower-first option rather than Pascalize + second allocation.
+- `Underscore`: replace the three-regex chain with an ASCII scanner that inserts `_` at the same uppercase acronym and lower/digit-to-upper boundaries, maps `-` and whitespace to `_`, and applies culture-aware lowercasing or fallback.
+- `Kebaberize`: write directly with `-` separators rather than `Underscore().Dasherize()` to avoid a second allocation.
+- `Titleize`: benefit indirectly from `Humanize` + `TitleCase`; do not add bespoke logic unless benchmark evidence shows it remains hot.
+
+Risks:
+
+- The current branch already broadened `PascalizePattern` to capture any char after separators; tests must preserve digit/symbol behavior.
+- Regex replacement semantics for consecutive separators and leading separators must be captured by tests.
+- `ToLower()` is current-culture in current implementation; fast paths must preserve that behavior through `TextInfo` or fallback.
+
+### 6. English Article Sort Span Rewrite
+
+This is lower-impact but low-risk only if parser parity is precise.
+
+Proposed design:
+
+- Replace `ArticleRegex().IsMatch(item)` with a local span prefix parser that matches current behavior for `^((The)|(the)|(a)|(A)|(An)|(an))\s\w+`.
+- Preserve prefix matching semantics and trimming behavior.
+- Include explicit tests for non-ASCII word tails (`The Éclair`, `An Æon`), `_` and digit word tails, trailing punctuation after a valid word (`The Theater!`), multiple spaces, and non-space whitespace.
+- For non-space whitespace, explicitly preserve current regex behavior unless a separate behavior-change decision is made.
+- Keep `Array.Sort(transformed)` behavior unchanged.
+
+### 7. Verification Matrix
+
+Implementation is not complete until these pass, adjusted only for host capability:
+
+- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0`
+- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0`
+- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0`; if skipped, include `dotnet --list-runtimes` evidence showing the runtime is absent.
+- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp-output>`
+- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
+- `git diff --check`
+- targeted benchmarks for changed surfaces on `net10.0` and `net11.0`
+
+For each implementation PR, capture:
+
+- before/after mean and allocation for each targeted benchmark
+- correctness test command output
+- list of fast-path fallback triggers and why they exist
+- PR notes separating pre-existing branch changes from this epic's changes
+
+## Task Breakdown
+
+1. Benchmark and behavior baseline for string transforms.
+2. `ToTitleCase` ASCII scanner and single-allocation/downlevel-safe write path.
+3. `Humanize()` PascalCase/separator scanner and fallback partition.
+4. Inflector fast paths for `Pascalize`, `Camelize`, `Underscore`, `Kebaberize`.
+5. English article sort span parser.
+6. Rune/downlevel decision gate and optional supplementary-plane behavior tests.
+7. Final benchmark comparison, format, pack, test matrix, and PR notes.
+
+## Acceptance Criteria
+
+- [ ] Each optimized method has pre-change behavior tests for edge cases before implementation changes land.
+- [ ] The Rune/downlevel decision is complete before implementation tasks begin.
+- [ ] ASCII fast paths avoid regex and LINQ allocations on benchmarked common cases.
+- [ ] Non-ASCII and culture-sensitive cases either remain on existing fallback or are proven equivalent with targeted tests.
+- [ ] No new Rune dependency/import/API usage is added without a separate approved task.
+- [ ] `net48` and `netstandard2.0` compatibility is preserved and proven by pack.
+- [ ] Benchmark results meet the objective thresholds above or document why a target was intentionally rejected.
+- [ ] CI validation and local formatting/pack/diff checks pass before PR handoff.
+
+## Boundaries
+
+Out of scope for this epic:
+
+- Rewriting pluralization/singularization vocabulary internals.
+- Changing public API contracts or documented outputs.
+- Adding broad grapheme-cluster support to truncation APIs.
+- Importing a Rune shim for `net48`/`netstandard2.0`.
+- Reworking the benchmark GitHub workflow beyond adding benchmark coverage needed for this work.
+
+## Decision Context
+
+The main engineering decision is to optimize by removing unnecessary machinery on common ASCII inputs, not by making all string code Unicode-scalar-aware. This matches the benchmark evidence and the .NET guidance for `Rune`: use Rune when code needs Unicode scalar semantics or surrogate-pair correctness; do not use it for known `char` delimiters or ASCII identifier scanning. The fallback-first approach preserves Humanizer's broad locale behavior while giving the common string transformation APIs a faster path.

--- a/.flow/specs/fn-16-performance-follow-up-hot-paths.md
+++ b/.flow/specs/fn-16-performance-follow-up-hot-paths.md
@@ -1,0 +1,26 @@
+# Performance follow-up hot paths
+
+## Goal & Context
+Follow up PR #1732 after .NET 8 became available on the host. Broaden benchmark coverage to .NET 8 and optimize the remaining meaningful hotspots identified from benchmark comparison artifacts: phrase clock template expansion, multi-part TimeSpan humanization, collection formatting, ByteSize string formatting, and misleading ordinal benchmark setup overhead.
+
+## Architecture & Data Models
+Keep runtime changes inside existing Humanizer formatting components. Prefer allocation reductions and one-pass loops over broader API or behavior changes. Benchmark-only changes belong under `src/Benchmarks`; CI benchmark matrix changes belong in `.github/workflows/benchmarks-baseline-vs-current.yml`.
+
+## API Contracts
+No public API changes. Existing extension method output and culture-specific formatting must remain identical.
+
+## Edge Cases & Constraints
+Preserve one-shot enumerable support in collection formatting. Preserve `countEmptyUnits` TimeSpan precision semantics. Preserve locale-specific phrase-clock Eifeler/day-period behavior. Preserve custom `IFormatProvider` handling in ByteSize.
+
+## Acceptance Criteria
+- [ ] Benchmark project and workflow include `net8.0` coverage.
+- [ ] Ordinal benchmarks do not allocate `CultureInfo` inside benchmark methods.
+- [ ] Runtime hot-path changes keep existing exact-output tests passing.
+- [ ] Targeted tests pass on net8.0, net10.0, and net11.0.
+- [ ] `dotnet pack`, `verify-packages.ps1`, and formatting verification pass.
+
+## Boundaries
+Do not add risky semantic rewrites, locale behavior changes, or new public APIs. Do not attempt .NET Framework validation on macOS.
+
+## Decision Context
+The current PR already won the large string transformation hotspots. The remaining useful work is constrained to measurable hot paths with low behavior risk and better benchmark coverage across all modern supported TFMs.

--- a/.flow/specs/fn-17-address-pr-1732-review-feedback.md
+++ b/.flow/specs/fn-17-address-pr-1732-review-feedback.md
@@ -1,0 +1,29 @@
+# Address PR 1732 review feedback
+
+## Goal & Context
+Re-read all inline review feedback on PR #1732, including historical and bot review threads that the watcher did not surface as new items, then address every actionable comment on the current branch.
+
+## Architecture & Data Models
+Keep changes scoped to the files touched by PR feedback. Prefer direct fixes over broad rewrites. Use GitHub review thread state as the source of truth for what remains unresolved.
+
+## API Contracts
+No public API changes unless a review comment explicitly requires one.
+
+## Edge Cases & Constraints
+Do not reply multiple times to the same non-actionable comment. Resolve actionable review threads only after a fixing commit is pushed. Preserve existing benchmark and validation behavior.
+
+## Acceptance Criteria
+- [ ] Enumerate all PR review threads/comments.
+- [ ] Patch all actionable unresolved feedback.
+- [ ] Reply once to non-actionable unresolved feedback if needed.
+- [ ] Run targeted validation for changed files.
+- [ ] Commit and push the review-feedback fixes.
+
+## Boundaries
+Do not chase unrelated CI failures unless they are caused by the review-feedback fixes.
+
+## Decision Context
+The user indicated multiple PR feedback items were missed, so review thread enumeration must happen directly through GitHub rather than relying only on watcher deltas.
+
+## Process Note
+For this PR and similar babysitting work, a watcher snapshot that reports no new review items is not enough to claim feedback is clean. Always enumerate GitHub `reviewThreads`, including unresolved outdated threads, and explicitly reconcile each unresolved item before reporting that review feedback is addressed.

--- a/.flow/specs/fn-18-address-follow-up-pr-1732-review-thread.md
+++ b/.flow/specs/fn-18-address-follow-up-pr-1732-review-thread.md
@@ -1,0 +1,13 @@
+# Address Follow-up PR #1732 Review Thread
+
+## Goal & Context
+A fresh GitHub reviewThreads enumeration after commit 44657a04 found one additional unresolved Copilot thread on ArticlePrefixSort. The helper intended to preserve .NET Regex \w behavior omitted U+200C and U+200D join controls.
+
+## Acceptance Criteria
+- [ ] Include U+200C ZERO WIDTH NON-JOINER and U+200D ZERO WIDTH JOINER in the helper that mirrors Regex \w.
+- [ ] Add a regression test proving article prefix rearrangement still occurs for those join controls.
+- [ ] Re-run targeted tests, format verification, and push the branch.
+- [ ] Resolve the review thread after the fix is pushed.
+
+## Boundaries
+No unrelated ArticlePrefixSort behavior changes.

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.1.json
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-19T16:36:36.853331Z",
+  "depends_on": [],
+  "epic": "fn-15-optimize-string-transformation-fast",
+  "id": "fn-15-optimize-string-transformation-fast.1",
+  "priority": 1,
+  "spec_path": ".flow/tasks/fn-15-optimize-string-transformation-fast.1.md",
+  "status": "todo",
+  "title": "Benchmark and behavior baseline for string transforms",
+  "updated_at": "2026-04-19T16:43:50.089604Z"
+}

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.1.md
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.1.md
@@ -1,0 +1,23 @@
+## Description
+
+Refresh the benchmark and correctness baseline for the string transformation surfaces before rewriting implementation code. This task exists to prevent optimizing against stale artifacts or under-specified behavior.
+
+Cover benchmark cases for `Humanize`, `ToTitleCase`, inflector case transforms, and English article sorting. Split deterministic fast-path benchmark cases from fallback/non-ASCII cases so improvements are visible rather than averaged away.
+
+Add/adjust focused tests for ASCII, acronym, separator, punctuation, digit/symbol, non-ASCII, and culture-sensitive cases before changing production code.
+
+## Acceptance Criteria
+
+- Benchmark coverage exists for the targeted APIs on `net10.0` and `net11.0`.
+- Benchmarks are deterministic per parameter and separate ASCII fast-path inputs from fallback/non-ASCII inputs.
+- Tests encode current behavior for acronym boundaries, freestanding separators, punctuation stripping, digit/symbol preservation, non-ASCII fallback inputs, and Turkish/culture-sensitive casing where applicable.
+- Tests include `UseCulture("tr-TR")` coverage for every target method or explicitly document why current behavior is culture-invariant.
+- Running the targeted tests passes before implementation changes begin.
+- Baseline benchmark mean and allocation figures are captured in task completion evidence.
+
+## Done summary
+Established benchmark/test baseline and current comparison for string transform hotspots.
+## Evidence
+- Commits:
+- Tests: Full net10.0 and net11.0 Humanizer.Tests passed; net8.0 blocked until system .NET 8 install is completed.
+- PRs:

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.2.json
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.2.json
@@ -1,0 +1,17 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-19T16:36:40.733999Z",
+  "depends_on": [
+    "fn-15-optimize-string-transformation-fast.1",
+    "fn-15-optimize-string-transformation-fast.6"
+  ],
+  "epic": "fn-15-optimize-string-transformation-fast",
+  "id": "fn-15-optimize-string-transformation-fast.2",
+  "priority": 2,
+  "spec_path": ".flow/tasks/fn-15-optimize-string-transformation-fast.2.md",
+  "status": "todo",
+  "title": "Optimize ToTitleCase ASCII fast path",
+  "updated_at": "2026-04-19T16:43:50.249796Z"
+}

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.2.md
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.2.md
@@ -1,0 +1,22 @@
+## Description
+
+Implement a deeper ASCII fast path for `ToTitleCase.Transform(...)` in `src/Humanizer/Transformer/ToTitleCase.cs`, building on the current branch's partial allocation reductions.
+
+The fast path should avoid regex match enumeration and full `StringBuilder` copy for common ASCII sentence-like inputs. It must fallback for non-ASCII, unsupported apostrophe/word shapes, or any culture/input shape whose behavior is not proven equivalent.
+
+## Acceptance Criteria
+
+- Depends on the Rune/downlevel decision gate task; implementation must not start before that task is complete.
+- ASCII title-case benchmarks improve with objective evidence: if baseline allocation is above 500 B, allocated bytes drop by at least 25%; otherwise allocations do not increase and mean improves by at least 10% or the task documents why the target was rejected.
+- Fallback/non-ASCII title-case benchmarks do not regress mean or allocation by more than 10% outside benchmark noise.
+- Existing and new title-case tests pass for minor words, all-caps acronym words, apostrophes, Turkish/Azeri culture-sensitive casing, and Unicode fallback inputs.
+- Implementation does not use arithmetic/invariant ASCII casing for public output unless tests prove exact equivalence.
+- Every `string.Create` or span-write path is guarded or backed by a downlevel helper so `net48` and `netstandard2.0` compile under `dotnet pack`.
+- No new `System.Text.Rune`, Polyfill Rune-specific API, or package reference appears in the diff.
+
+## Done summary
+Implemented ASCII fast path for ToTitleCase while preserving regex fallback for non-ASCII.
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.3.json
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.3.json
@@ -1,0 +1,17 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-19T16:36:45.719582Z",
+  "depends_on": [
+    "fn-15-optimize-string-transformation-fast.1",
+    "fn-15-optimize-string-transformation-fast.6"
+  ],
+  "epic": "fn-15-optimize-string-transformation-fast",
+  "id": "fn-15-optimize-string-transformation-fast.3",
+  "priority": 3,
+  "spec_path": ".flow/tasks/fn-15-optimize-string-transformation-fast.3.md",
+  "status": "todo",
+  "title": "Optimize Humanize PascalCase and separator paths",
+  "updated_at": "2026-04-19T16:43:50.405294Z"
+}

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.3.md
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.3.md
@@ -1,0 +1,22 @@
+## Description
+
+Optimize `StringHumanizeExtensions.Humanize()` common paths in `src/Humanizer/StringHumanizeExtensions.cs`.
+
+Replace regex/LINQ-heavy PascalCase and freestanding separator detection with ASCII span scanners where behavior is straightforward. Keep the existing regex implementation available as the fallback for non-ASCII, punctuation-heavy, culture-sensitive, or ambiguous inputs.
+
+## Acceptance Criteria
+
+- Depends on the Rune/downlevel decision gate task; implementation must not start before that task is complete.
+- `Humanize PascalCase`, mixed acronym, underscore, dash, and freestanding separator benchmarks improve under the epic's objective benchmark thresholds.
+- Existing behavior for all-uppercase acronym inputs, `I`, punctuation omission, underscores/dashes, other-letter Unicode tests, and Turkish `UseCulture("tr-TR")` cases is preserved.
+- Fast paths use culture-aware casing or fallback; no arithmetic/invariant ASCII casing is used for public output unless tests prove exact equivalence.
+- Fallback boundaries are documented in code comments only where needed for maintainability.
+- Every `string.Create` or span-write path is guarded or backed by a downlevel helper so `net48` and `netstandard2.0` compile under `dotnet pack`.
+- No new `System.Text.Rune`, Polyfill Rune-specific API, or package reference appears in the diff.
+
+## Done summary
+Implemented ASCII PascalCase Humanize fast path and manual freestanding separator scan.
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.4.json
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.4.json
@@ -1,0 +1,18 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-19T16:36:50.806994Z",
+  "depends_on": [
+    "fn-15-optimize-string-transformation-fast.1",
+    "fn-15-optimize-string-transformation-fast.3",
+    "fn-15-optimize-string-transformation-fast.6"
+  ],
+  "epic": "fn-15-optimize-string-transformation-fast",
+  "id": "fn-15-optimize-string-transformation-fast.4",
+  "priority": 4,
+  "spec_path": ".flow/tasks/fn-15-optimize-string-transformation-fast.4.md",
+  "status": "todo",
+  "title": "Optimize inflector case transform fast paths",
+  "updated_at": "2026-04-19T16:43:50.565488Z"
+}

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.4.md
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.4.md
@@ -1,0 +1,24 @@
+## Description
+
+Optimize inflector case transformation methods in `src/Humanizer/InflectorExtensions.cs`: `Pascalize`, `Camelize`, `Underscore`, and `Kebaberize`.
+
+Introduce shared internal ASCII scanning helpers where doing so removes real duplication without obscuring behavior. Avoid chaining transformations when a direct single-allocation write can produce the final output.
+
+## Acceptance Criteria
+
+- Depends on the Rune/downlevel decision gate task; implementation must not start before that task is complete.
+- Benchmarks for `Pascalize`, `Camelize`, `Underscore`, and `Kebaberize` meet the epic's objective fast-path thresholds or document why a target was rejected.
+- Tests preserve behavior for leading/trailing/consecutive separators, acronym boundaries, lower/digit-to-upper transitions, dash/space/underscore mapping, and current branch behavior that preserves non-letter characters captured after separators.
+- Turkish `UseCulture("tr-TR")` tests cover `Pascalize`, `Camelize`, `Underscore`, and `Kebaberize`, or the task documents and proves current culture-invariance for a specific method.
+- `Camelize` does not allocate a full PascalCase intermediate solely to lowercase the first character on fast-path inputs.
+- `Kebaberize` writes hyphenated output directly rather than relying on `Underscore().Dasherize()` for fast-path inputs.
+- `Underscore`/`Kebaberize` preserve Unicode lowercasing through fallback or culture-aware casing.
+- Every `string.Create` or span-write path is guarded or backed by a downlevel helper so `net48` and `netstandard2.0` compile under `dotnet pack`.
+- No new `System.Text.Rune`, Polyfill Rune-specific API, or package reference appears in the diff.
+
+## Done summary
+Implemented ASCII fast paths for Pascalize, Camelize, Underscore, and Kebaberize.
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.5.json
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.5.json
@@ -1,0 +1,17 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-19T16:36:58.653512Z",
+  "depends_on": [
+    "fn-15-optimize-string-transformation-fast.1",
+    "fn-15-optimize-string-transformation-fast.6"
+  ],
+  "epic": "fn-15-optimize-string-transformation-fast",
+  "id": "fn-15-optimize-string-transformation-fast.5",
+  "priority": 5,
+  "spec_path": ".flow/tasks/fn-15-optimize-string-transformation-fast.5.md",
+  "status": "todo",
+  "title": "Replace English article regex with span parser",
+  "updated_at": "2026-04-19T16:43:50.725353Z"
+}

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.5.md
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.5.md
@@ -1,0 +1,23 @@
+## Description
+
+Replace the English article prefix regex in `src/Humanizer/ArticlePrefixSort.cs` with a span-based parser for the exact small grammar it recognizes today.
+
+The parser must preserve current `^((The)|(the)|(a)|(A)|(An)|(an))\s\w+` behavior, including Unicode `\w` and `\s` semantics, unless a separate behavior-change decision is made and documented.
+
+## Acceptance Criteria
+
+- Depends on the Rune/downlevel decision gate task; implementation must not start before that task is complete.
+- `EnglishArticleBenchmarks.AppendArticlePrefix` improves or remains neutral and avoids regex work on covered fast-path inputs.
+- Tests cover positive prefixes, non-article lookalikes, punctuation-only tails, non-ASCII word tails (`The Éclair`, `An Æon`), `_` and digit word tails, trailing punctuation after a valid word (`The Theater!`), multiple spaces, and non-space whitespace.
+- Non-space whitespace behavior is explicitly preserved or explicitly documented as a deliberate behavior change before implementation.
+- `PrependArticleSuffix` behavior remains unchanged.
+- Sort order continues to use `Array.Sort(transformed)` unchanged.
+- Every `string.Create` or span-write path is guarded or backed by a downlevel helper so `net48` and `netstandard2.0` compile under `dotnet pack`.
+- No new `System.Text.Rune`, Polyfill Rune-specific API, or package reference appears in the diff.
+
+## Done summary
+Replaced English article-prefix regex with a span parser and added edge coverage.
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.6.json
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.6.json
@@ -1,0 +1,16 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-19T16:37:02.496591Z",
+  "depends_on": [
+    "fn-15-optimize-string-transformation-fast.1"
+  ],
+  "epic": "fn-15-optimize-string-transformation-fast",
+  "id": "fn-15-optimize-string-transformation-fast.6",
+  "priority": 6,
+  "spec_path": ".flow/tasks/fn-15-optimize-string-transformation-fast.6.md",
+  "status": "todo",
+  "title": "Document Rune decision and optional Unicode scalar tests",
+  "updated_at": "2026-04-19T16:43:50.875382Z"
+}

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.6.md
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.6.md
@@ -1,0 +1,20 @@
+## Description
+
+Complete the Rune/downlevel decision gate before implementation tasks begin. Optionally add supplementary-plane behavior tests that document current behavior, but do not expand this task into a broad Unicode rewrite.
+
+The current plan is not to use Rune for hot ASCII fast paths. The referenced Polyfill Rune commit only adds extension methods for `NETCOREAPP3_0_OR_GREATER` targets that already have `System.Text.Rune`; it does not provide Rune for Humanizer's `net48` or `netstandard2.0` targets.
+
+## Acceptance Criteria
+
+- The epic/task evidence records the final decision: no Rune-led implementation for this epic, no downlevel Rune dependency, and regex/culture fallback for unsupported Unicode/culture cases.
+- Implementation tasks 2-5 depend on this task.
+- A guardrail is documented for implementers: final diff must contain no new `System.Text.Rune`, Polyfill Rune-specific API, or package reference unless a separate approved task is created first.
+- If supplementary-plane behavior tests are added, they document current behavior without forcing a broad Unicode rewrite.
+- The task identifies the downlevel allocation strategy: guarded `string.Create` on supported TFMs plus existing or new narrow compat helpers for `net48`/`netstandard2.0`.
+
+## Done summary
+Resolved Rune decision: do not introduce Rune fast paths for this change.
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.7.json
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.7.json
@@ -1,0 +1,20 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-19T16:37:07.365172Z",
+  "depends_on": [
+    "fn-15-optimize-string-transformation-fast.2",
+    "fn-15-optimize-string-transformation-fast.3",
+    "fn-15-optimize-string-transformation-fast.4",
+    "fn-15-optimize-string-transformation-fast.5",
+    "fn-15-optimize-string-transformation-fast.6"
+  ],
+  "epic": "fn-15-optimize-string-transformation-fast",
+  "id": "fn-15-optimize-string-transformation-fast.7",
+  "priority": 7,
+  "spec_path": ".flow/tasks/fn-15-optimize-string-transformation-fast.7.md",
+  "status": "todo",
+  "title": "Final benchmark comparison and validation signoff",
+  "updated_at": "2026-04-19T16:43:51.017275Z"
+}

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.7.md
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.7.md
@@ -1,0 +1,23 @@
+## Description
+
+Run final validation and benchmark comparison after implementation tasks land.
+
+Collect test, pack, format, diff, and benchmark evidence sufficient for PR review. Confirm there are no material regressions on unchanged string surfaces and that fallback behavior is still covered.
+
+## Acceptance Criteria
+
+- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` passes.
+- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` passes.
+- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` passes unless the runtime is absent; if skipped, include `dotnet --list-runtimes` evidence.
+- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp-output>` succeeds without new warnings and proves `net48`/`netstandard2.0` compile.
+- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` passes.
+- `git diff --check` passes.
+- Targeted benchmarks are compared before/after and summarized with mean + allocation changes against the objective thresholds in the epic.
+- Final PR notes include fast paths added, fallback policy, Rune decision, remaining performance opportunities, and a clear separation of pre-existing branch changes from this epic's changes.
+
+## Done summary
+Completed validation pass for implemented performance changes.
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.8.json
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.8.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-19T22:01:47.178835Z",
+  "depends_on": [],
+  "epic": "fn-15-optimize-string-transformation-fast",
+  "id": "fn-15-optimize-string-transformation-fast.8",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-15-optimize-string-transformation-fast.8.md",
+  "status": "todo",
+  "title": "Follow-up TitleCase ASCII loop micro-optimization",
+  "updated_at": "2026-04-19T22:15:59.602479Z"
+}

--- a/.flow/tasks/fn-15-optimize-string-transformation-fast.8.md
+++ b/.flow/tasks/fn-15-optimize-string-transformation-fast.8.md
@@ -1,0 +1,17 @@
+## Description
+
+Make a narrow follow-up pass on the TitleCase ASCII fast path: remove avoidable scans and culture calls while preserving Unicode fallback and Turkic I casing behavior.
+
+## Acceptance Criteria
+
+- ASCII TitleCase avoids the separate up-front non-ASCII scan.
+- Ordinary ASCII cultures avoid per-character TextInfo casing calls while Turkish/Azeri still use culture-aware casing.
+- Non-ASCII input still falls back to the regex/culture path.
+- Benchmarks cover changed ASCII paths and tests pass on available TFMs.
+
+## Done summary
+Optimized the TitleCase ASCII fast path by merging non-ASCII detection into the main scan, using ordinal ASCII casing for non-Turkic cultures, preserving Turkish/Azeri culture-sensitive casing, and adding benchmark coverage for additional ASCII title-case paths.
+## Evidence
+- Commits:
+- Tests: dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0 -- --filter-class TransformersTests, dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0 -- --filter-class TransformersTests, dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0, dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0, dotnet pack src/Humanizer/Humanizer.csproj -c Release -o /tmp/humanizer-titlecase-pack, pwsh tests/verify-packages.ps1 -PackageVersion 3.5.0-preview.19.g89f4f0a08c -PackagesDirectory /tmp/humanizer-titlecase-pack, dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic, git diff --check
+- PRs:

--- a/.flow/tasks/fn-16-performance-follow-up-hot-paths.1.json
+++ b/.flow/tasks/fn-16-performance-follow-up-hot-paths.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-20T21:39:16.729234Z",
+  "depends_on": [],
+  "epic": "fn-16-performance-follow-up-hot-paths",
+  "id": "fn-16-performance-follow-up-hot-paths.1",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-16-performance-follow-up-hot-paths.1.md",
+  "status": "todo",
+  "title": "Broaden benchmark coverage and optimize remaining formatting hot paths",
+  "updated_at": "2026-04-20T21:39:16.729661Z"
+}

--- a/.flow/tasks/fn-16-performance-follow-up-hot-paths.1.md
+++ b/.flow/tasks/fn-16-performance-follow-up-hot-paths.1.md
@@ -1,0 +1,18 @@
+# fn-16-performance-follow-up-hot-paths.1 Broaden benchmark coverage and optimize remaining formatting hot paths
+
+## Description
+TBD
+
+## Acceptance
+- [ ] TBD
+
+## Done summary
+Broadened benchmark coverage to net8.0 and added ByteSize/collection benchmark fixtures.
+Removed CultureInfo allocation from ordinal benchmark methods.
+Optimized phrase-clock template expansion with cached template plans and pre-parsed literal/placeholder segments.
+Optimized multi-part TimeSpan humanization by building precision-limited parts in one pass.
+Optimized default collection formatting and ByteSize string formatting to reduce LINQ/string.Format overhead.
+## Evidence
+- Commits:
+- Tests: dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0, dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0, dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0, dotnet pack src/Humanizer/Humanizer.csproj -c Release -o artifacts/packages/perf-followup-final, pwsh -NoProfile -File tests/verify-packages.ps1 -PackageVersion 3.5.0-preview.20.g869cf91776 -PackagesDirectory artifacts/packages/perf-followup-final, dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic, dotnet build src/Benchmarks/Benchmarks.csproj -c Release -f net8.0, dotnet build src/Benchmarks/Benchmarks.csproj -c Release -f net10.0, dotnet build src/Benchmarks/Benchmarks.csproj -c Release -f net11.0, dotnet run -c Release --project src/Benchmarks/Benchmarks.csproj -f net8.0 -- --filter *ByteSizeBenchmarks* --job short --warmupCount 1 --iterationCount 1, dotnet run -c Release --project src/Benchmarks/Benchmarks.csproj -f net8.0 -- --filter *TimeOnlyToClockNotationConverterBenchmarks* --job short --warmupCount 1 --iterationCount 1, dotnet run -c Release --project src/Benchmarks/Benchmarks.csproj -f net8.0 -- --filter *CollectionHumanizeBenchmarks* *FormatterBenchmarks.RussianTimeSpanHumanizeMultiPart* --job short --warmupCount 1 --iterationCount 1
+- PRs:

--- a/.flow/tasks/fn-17-address-pr-1732-review-feedback.1.json
+++ b/.flow/tasks/fn-17-address-pr-1732-review-feedback.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-20T22:06:05.813573Z",
+  "depends_on": [],
+  "epic": "fn-17-address-pr-1732-review-feedback",
+  "id": "fn-17-address-pr-1732-review-feedback.1",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-17-address-pr-1732-review-feedback.1.md",
+  "status": "todo",
+  "title": "Reconcile and address all PR review threads",
+  "updated_at": "2026-04-20T22:06:05.814089Z"
+}

--- a/.flow/tasks/fn-17-address-pr-1732-review-feedback.1.md
+++ b/.flow/tasks/fn-17-address-pr-1732-review-feedback.1.md
@@ -1,0 +1,14 @@
+# fn-17-address-pr-1732-review-feedback.1 Reconcile and address all PR review threads
+
+## Description
+TBD
+
+## Acceptance
+- [ ] TBD
+
+## Done summary
+Addressed all unresolved PR #1732 review threads by enumerating GitHub reviewThreads directly: removed benchmark workflow signature-validation weakening, tightened Unicode word-character classification, used direct loops/helpers for CodeQL readability feedback, changed negative ordinal formatting to use NumberFormatInfo formatting, and replaced repeated phrase string concatenation with measured StringBuilder assembly. Added regression tests for article-prefix Roman numeral behavior and custom negative ordinal formatting parity. Added a Flow process note requiring explicit reviewThreads reconciliation for future PR babysitting.
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-18-address-follow-up-pr-1732-review-thread.1.json
+++ b/.flow/tasks/fn-18-address-follow-up-pr-1732-review-thread.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-20T22:19:09.711353Z",
+  "depends_on": [],
+  "epic": "fn-18-address-follow-up-pr-1732-review-thread",
+  "id": "fn-18-address-follow-up-pr-1732-review-thread.1",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-18-address-follow-up-pr-1732-review-thread.1.md",
+  "status": "todo",
+  "title": "Patch Regex word join-control parity",
+  "updated_at": "2026-04-20T22:19:09.711772Z"
+}

--- a/.flow/tasks/fn-18-address-follow-up-pr-1732-review-thread.1.md
+++ b/.flow/tasks/fn-18-address-follow-up-pr-1732-review-thread.1.md
@@ -1,0 +1,14 @@
+# fn-18-address-follow-up-pr-1732-review-thread.1 Patch Regex word join-control parity
+
+## Description
+TBD
+
+## Acceptance
+- [ ] TBD
+
+## Done summary
+Addressed the follow-up PR #1732 review thread for Regex word-character parity by including U+200C ZERO WIDTH NON-JOINER and U+200D ZERO WIDTH JOINER in ArticlePrefixSort.IsRegexWordCharacter, and added regression coverage for both join-control characters.
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.github/workflows/benchmarks-baseline-vs-current.yml
+++ b/.github/workflows/benchmarks-baseline-vs-current.yml
@@ -157,9 +157,6 @@ jobs:
 
           {
             echo '<configuration>'
-            echo '  <config>'
-            echo '    <add key="signatureValidationMode" value="accept" />'
-            echo '  </config>'
             echo '  <packageSources>'
             echo '    <clear />'
             echo '    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />'

--- a/.github/workflows/benchmarks-baseline-vs-current.yml
+++ b/.github/workflows/benchmarks-baseline-vs-current.yml
@@ -143,20 +143,22 @@ jobs:
       
       - name: Clone and Build ResultsComparer
         run: |
-          git clone --depth 1 https://github.com/dotnet/performance
+          git clone --depth 1 https://github.com/dotnet/performance "$RUNNER_TEMP/performance"
 
-          cat > "$RUNNER_TEMP/performance-nuget.config" <<'EOF'
-          <?xml version="1.0" encoding="utf-8"?>
-          <configuration>
-            <packageSources>
-              <clear />
-              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-              <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
-            </packageSources>
-          </configuration>
-          EOF
+          {
+            echo '<configuration>'
+            echo '  <config>'
+            echo '    <add key="signatureValidationMode" value="accept" />'
+            echo '  </config>'
+            echo '  <packageSources>'
+            echo '    <clear />'
+            echo '    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />'
+            echo '    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />'
+            echo '  </packageSources>'
+            echo '</configuration>'
+          } > "$RUNNER_TEMP/performance-nuget.config"
 
-          dotnet restore performance/src/tools/ResultsComparer/ResultsComparer.csproj \
+          dotnet restore "$RUNNER_TEMP/performance/src/tools/ResultsComparer/ResultsComparer.csproj" \
             -p:PERFLAB_TARGET_FRAMEWORKS=net10.0 \
             --configfile "$RUNNER_TEMP/performance-nuget.config"
       
@@ -190,7 +192,7 @@ jobs:
 
           echo "Comparing results for $tfm..."
           compare_exit=0
-          dotnet run --no-restore --project performance/src/tools/ResultsComparer/ResultsComparer.csproj -c Release -p:PERFLAB_TARGET_FRAMEWORKS=net10.0 -f net10.0 --base "${{ steps.results.outputs.baseline_results }}" --diff "${{ steps.results.outputs.current_results }}" --threshold "5%" > "comparisons/diff-$tfm.md" || compare_exit=$?
+          dotnet run --no-restore --project "$RUNNER_TEMP/performance/src/tools/ResultsComparer/ResultsComparer.csproj" -c Release -p:PERFLAB_TARGET_FRAMEWORKS=net10.0 -f net10.0 --base "${{ steps.results.outputs.baseline_results }}" --diff "${{ steps.results.outputs.current_results }}" --threshold "5%" > "comparisons/diff-$tfm.md" || compare_exit=$?
 
           if [ ! -s "comparisons/diff-$tfm.md" ] || grep -q "The build failed" "comparisons/diff-$tfm.md"; then
             cat "comparisons/diff-$tfm.md" >&2 || true

--- a/.github/workflows/benchmarks-baseline-vs-current.yml
+++ b/.github/workflows/benchmarks-baseline-vs-current.yml
@@ -143,7 +143,22 @@ jobs:
       
       - name: Clone and Build ResultsComparer
         run: |
-          git clone --depth 1 https://github.com/dotnet/performance          
+          git clone --depth 1 https://github.com/dotnet/performance
+
+          cat > "$RUNNER_TEMP/performance-nuget.config" <<'EOF'
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+              <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+            </packageSources>
+          </configuration>
+          EOF
+
+          dotnet restore performance/src/tools/ResultsComparer/ResultsComparer.csproj \
+            -p:PERFLAB_TARGET_FRAMEWORKS=net10.0 \
+            --configfile "$RUNNER_TEMP/performance-nuget.config"
       
       - name: Locate Benchmark Results
         id: results
@@ -174,7 +189,20 @@ jobs:
           tfm="${{ matrix.targetFramework }}"
 
           echo "Comparing results for $tfm..."
-          dotnet run --project performance/src/tools/ResultsComparer/ResultsComparer.csproj -c Release -p:PERFLAB_TARGET_FRAMEWORKS=net10.0 -f net10.0 --base "${{ steps.results.outputs.baseline_results }}" --diff "${{ steps.results.outputs.current_results }}" --threshold "5%" > "comparisons/diff-$tfm.md" || true
+          compare_exit=0
+          dotnet run --no-restore --project performance/src/tools/ResultsComparer/ResultsComparer.csproj -c Release -p:PERFLAB_TARGET_FRAMEWORKS=net10.0 -f net10.0 --base "${{ steps.results.outputs.baseline_results }}" --diff "${{ steps.results.outputs.current_results }}" --threshold "5%" > "comparisons/diff-$tfm.md" || compare_exit=$?
+
+          if [ ! -s "comparisons/diff-$tfm.md" ] || grep -q "The build failed" "comparisons/diff-$tfm.md"; then
+            cat "comparisons/diff-$tfm.md" >&2 || true
+            if [ "$compare_exit" -ne 0 ]; then
+              exit "$compare_exit"
+            fi
+            exit 1
+          fi
+
+          if [ "$compare_exit" -ne 0 ]; then
+            echo "ResultsComparer exited with code $compare_exit; uploaded comparison report for inspection."
+          fi
       
       - name: Append Comparison to Summary
         run: |

--- a/.github/workflows/benchmarks-baseline-vs-current.yml
+++ b/.github/workflows/benchmarks-baseline-vs-current.yml
@@ -30,13 +30,18 @@ jobs:
       fail-fast: false
       matrix:
         kind: [baseline, current]
-        targetFramework: [net10.0, net11.0]
+        targetFramework: [net8.0, net10.0, net11.0]
     
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Setup .NET 10
         uses: actions/setup-dotnet@v5
@@ -110,7 +115,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        targetFramework: [net10.0, net11.0]
+        targetFramework: [net8.0, net10.0, net11.0]
     
     steps:
       - name: Checkout repository
@@ -130,6 +135,11 @@ jobs:
           name: humanizer-bdn-current-${{ matrix.targetFramework }}-json
           path: current
       
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Setup .NET 10
         uses: actions/setup-dotnet@v5
         with:

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net11.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net11.0;net10.0;net8.0</TargetFrameworks>
     <UseBaselinePackage Condition="'$(UseBaselinePackage)' == ''">false</UseBaselinePackage>
     <BaselinePackageVersion Condition="'$(BaselinePackageVersion)' == ''">3.0.10</BaselinePackageVersion>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/src/Benchmarks/ByteSizeBenchmarks.cs
+++ b/src/Benchmarks/ByteSizeBenchmarks.cs
@@ -1,0 +1,27 @@
+namespace Benchmarks;
+
+/// <summary>
+/// Benchmarks common ByteSize formatting paths.
+/// </summary>
+[MemoryDiagnoser]
+public class ByteSizeBenchmarks
+{
+    static readonly ByteSize size = ByteSize.FromMegabytes(10.501);
+    static readonly CultureInfo frenchCulture = new("fr");
+
+    [Benchmark(Description = "ByteSize ToString default")]
+    public string ByteSizeToStringDefault() =>
+        size.ToString();
+
+    [Benchmark(Description = "ByteSize ToString culture")]
+    public string ByteSizeToStringCulture() =>
+        size.ToString(frenchCulture);
+
+    [Benchmark(Description = "ByteSize ToString format")]
+    public string ByteSizeToStringFormat() =>
+        size.ToString("0.## MB", frenchCulture);
+
+    [Benchmark(Description = "ByteSize ToFullWords")]
+    public string ByteSizeToFullWords() =>
+        size.ToFullWords(provider: frenchCulture);
+}

--- a/src/Benchmarks/CollectionHumanizeBenchmarks.cs
+++ b/src/Benchmarks/CollectionHumanizeBenchmarks.cs
@@ -1,0 +1,24 @@
+namespace Benchmarks;
+
+/// <summary>
+/// Benchmarks collection humanization paths with trimming, filtering, and formatter delegates.
+/// </summary>
+[MemoryDiagnoser]
+public class CollectionHumanizeBenchmarks
+{
+    static readonly string[] strings = ["Alpha", " Beta ", "Gamma", "", "Delta"];
+    static readonly int?[] nullableInts = [1, null, 3, 4];
+    static readonly object?[] objects = ["Alpha", null, " Gamma ", 4];
+
+    [Benchmark(Description = "Collection Humanize strings")]
+    public string CollectionHumanizeStrings() =>
+        strings.Humanize();
+
+    [Benchmark(Description = "Collection Humanize string formatter")]
+    public string CollectionHumanizeStringFormatter() =>
+        nullableInts.Humanize(value => value?.ToString() ?? "");
+
+    [Benchmark(Description = "Collection Humanize object formatter")]
+    public string CollectionHumanizeObjectFormatter() =>
+        objects.Humanize(value => value ?? "");
+}

--- a/src/Benchmarks/FormatterBenchmarks.cs
+++ b/src/Benchmarks/FormatterBenchmarks.cs
@@ -27,6 +27,18 @@ public class FormatterBenchmarks
     public string RussianTimeSpanHumanize() =>
         russianSample.Humanize(culture: russianCulture);
 
+    [Benchmark(Description = "Russian TimeSpan Humanize multi-part")]
+    public string RussianTimeSpanHumanizeMultiPart() =>
+        russianSample.Humanize(precision: 3, culture: russianCulture);
+
+    [Benchmark(Description = "Russian TimeSpan Humanize zero")]
+    public string RussianTimeSpanHumanizeZero() =>
+        TimeSpan.Zero.Humanize(culture: russianCulture);
+
+    [Benchmark(Description = "Russian TimeSpan Humanize words")]
+    public string RussianTimeSpanHumanizeWords() =>
+        russianSample.Humanize(culture: russianCulture, toWords: true);
+
     [Benchmark(Description = "Arabic DataUnitHumanize")]
     public string ArabicDataUnitHumanize() =>
         arabicFormatter.DataUnitHumanize(DataUnit.Gigabyte, 2, toSymbol: false);

--- a/src/Benchmarks/InflectorBenchmarks.cs
+++ b/src/Benchmarks/InflectorBenchmarks.cs
@@ -10,6 +10,10 @@ public class InflectorBenchmarks
     public string Pascalize() =>
         "some_title for_an article".Pascalize();
 
+    [Benchmark(Description = "Pascalize digit and symbol")]
+    public string PascalizeDigitAndSymbol() =>
+        "customer name $".Pascalize();
+
     [Benchmark(Description = "Camelize")]
     public string Camelize() =>
         "some_title for_an article".Camelize();
@@ -18,6 +22,10 @@ public class InflectorBenchmarks
     public string Underscore() =>
         "SomeClassName".Underscore();
 
+    [Benchmark(Description = "Underscore acronym")]
+    public string UnderscoreAcronym() =>
+        "HTMLParserName".Underscore();
+
     [Benchmark(Description = "Dasherize")]
     public string Dasherize() =>
         "some_text_string".Dasherize();
@@ -25,6 +33,10 @@ public class InflectorBenchmarks
     [Benchmark(Description = "Kebaberize")]
     public string Kebaberize() =>
         "PascalCaseString".Kebaberize();
+
+    [Benchmark(Description = "Kebaberize acronym")]
+    public string KebaberizeAcronym() =>
+        "HTMLParserName".Kebaberize();
 
     [Benchmark(Description = "Titleize")]
     public string Titleize() =>

--- a/src/Benchmarks/MetricNumeralBenchmarks.cs
+++ b/src/Benchmarks/MetricNumeralBenchmarks.cs
@@ -18,6 +18,18 @@ public class MetricNumeralBenchmarks
     public string ToMetricMega() =>
         1000000.ToMetric();
 
+    [Benchmark(Description = "ToMetric boundary")]
+    public string ToMetricBoundary() =>
+        999500.ToMetric();
+
+    [Benchmark(Description = "ToMetric giga")]
+    public string ToMetricGiga() =>
+        int.MaxValue.ToMetric();
+
+    [Benchmark(Description = "ToMetric formatted")]
+    public string ToMetricFormatted() =>
+        1230.ToMetric(MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseName, 2);
+
     [Benchmark(Description = "ToMetric milli")]
     public string ToMetricMilli() =>
         0.001.ToMetric();

--- a/src/Benchmarks/OrdinalBenchmarks.cs
+++ b/src/Benchmarks/OrdinalBenchmarks.cs
@@ -6,23 +6,28 @@ namespace Benchmarks;
 [MemoryDiagnoser]
 public class OrdinalBenchmarks
 {
+    static readonly CultureInfo dutchCulture = new("nl");
+    static readonly CultureInfo turkishCulture = new("tr");
+    static readonly CultureInfo greekCulture = new("el");
+    static readonly CultureInfo finnishCulture = new("fi");
+
     [Benchmark(Description = "English Ordinalize")]
     public string EnglishOrdinalize() =>
         42.Ordinalize();
 
     [Benchmark(Description = "Dutch Ordinalize")]
     public string DutchOrdinalize() =>
-        42.Ordinalize(new CultureInfo("nl"));
+        42.Ordinalize(dutchCulture);
 
     [Benchmark(Description = "Turkish Ordinalize")]
     public string TurkishOrdinalize() =>
-        42.Ordinalize(new CultureInfo("tr"));
+        42.Ordinalize(turkishCulture);
 
     [Benchmark(Description = "Greek Ordinalize")]
     public string GreekOrdinalize() =>
-        42.Ordinalize(new CultureInfo("el"));
+        42.Ordinalize(greekCulture);
 
     [Benchmark(Description = "Finnish Ordinalize")]
     public string FinnishOrdinalize() =>
-        42.Ordinalize(new CultureInfo("fi"));
+        42.Ordinalize(finnishCulture);
 }

--- a/src/Benchmarks/StringHumanizeBenchmarks.cs
+++ b/src/Benchmarks/StringHumanizeBenchmarks.cs
@@ -10,6 +10,10 @@ public class StringHumanizeBenchmarks
     public string HumanizePascalCase() =>
         "PascalCaseInputStringToBeHumanized".Humanize();
 
+    [Benchmark(Description = "Humanize acronym PascalCase")]
+    public string HumanizeAcronymPascalCase() =>
+        "HTMLToJSONConverter".Humanize();
+
     [Benchmark(Description = "Humanize with underscore")]
     public string HumanizeUnderscore() =>
         "Underscored_input_string_is_turned_INTO_sentence".Humanize();
@@ -25,4 +29,8 @@ public class StringHumanizeBenchmarks
     [Benchmark(Description = "Humanize mixed format")]
     public string HumanizeMixed() =>
         "HTML_to_JSON_Converter".Humanize();
+
+    [Benchmark(Description = "Humanize Unicode fallback")]
+    public string HumanizeUnicodeFallback() =>
+        "JeNeParlePasFrançais".Humanize();
 }

--- a/src/Benchmarks/TransformersBenchmarks.cs
+++ b/src/Benchmarks/TransformersBenchmarks.cs
@@ -22,6 +22,8 @@ public class TransformersBenchmarks
 
     readonly Random random = new(RAND_SEED);
     string input = null!;
+    string asciiTitleInput = null!;
+    string unicodeTitleInput = null!;
 
     [Params(10, 100, 1000)]
     public int StringLen;
@@ -36,6 +38,8 @@ public class TransformersBenchmarks
         }
 
         input = new(chars);
+        asciiTitleInput = string.Join(' ', Enumerable.Repeat("the quick BROWN fox jumps over NASA by night", Math.Max(1, StringLen / 48)));
+        unicodeTitleInput = string.Join(' ', Enumerable.Repeat("élève οΣΟΣ Straße", Math.Max(1, StringLen / 18)));
     }
 
     [Benchmark]
@@ -57,4 +61,12 @@ public class TransformersBenchmarks
     [Benchmark]
     public string TitleCase() =>
         input.Transform(To.TitleCase);
+
+    [Benchmark]
+    public string TitleCaseAsciiWords() =>
+        asciiTitleInput.Transform(To.TitleCase);
+
+    [Benchmark]
+    public string TitleCaseUnicodeFallback() =>
+        unicodeTitleInput.Transform(To.TitleCase);
 }

--- a/src/Benchmarks/TransformersBenchmarks.cs
+++ b/src/Benchmarks/TransformersBenchmarks.cs
@@ -23,6 +23,8 @@ public class TransformersBenchmarks
     readonly Random random = new(RAND_SEED);
     string input = null!;
     string asciiTitleInput = null!;
+    string asciiAlreadyTitleInput = null!;
+    string asciiAllCapsInput = null!;
     string unicodeTitleInput = null!;
 
     [Params(10, 100, 1000)]
@@ -39,6 +41,8 @@ public class TransformersBenchmarks
 
         input = new(chars);
         asciiTitleInput = string.Join(' ', Enumerable.Repeat("the quick BROWN fox jumps over NASA by night", Math.Max(1, StringLen / 48)));
+        asciiAlreadyTitleInput = string.Join(' ', Enumerable.Repeat("The Quick Brown Fox Jumps by NASA at Night", Math.Max(1, StringLen / 43)));
+        asciiAllCapsInput = string.Join(' ', Enumerable.Repeat("NASA FBI CIA", Math.Max(1, StringLen / 12)));
         unicodeTitleInput = string.Join(' ', Enumerable.Repeat("élève οΣΟΣ Straße", Math.Max(1, StringLen / 18)));
     }
 
@@ -65,6 +69,14 @@ public class TransformersBenchmarks
     [Benchmark]
     public string TitleCaseAsciiWords() =>
         asciiTitleInput.Transform(To.TitleCase);
+
+    [Benchmark]
+    public string TitleCaseAlreadyFormattedAscii() =>
+        asciiAlreadyTitleInput.Transform(To.TitleCase);
+
+    [Benchmark]
+    public string TitleCaseAllCapsAscii() =>
+        asciiAllCapsInput.Transform(To.TitleCase);
 
     [Benchmark]
     public string TitleCaseUnicodeFallback() =>

--- a/src/Humanizer/ArticlePrefixSort.cs
+++ b/src/Humanizer/ArticlePrefixSort.cs
@@ -3,21 +3,8 @@ namespace Humanizer;
 /// <summary>
 /// Contains methods for removing, appending and prepending article prefixes for sorting strings ignoring the article.
 /// </summary>
-public static partial class EnglishArticle
+public static class EnglishArticle
 {
-    private const string ArticlePattern = @"^((The)|(the)|(a)|(A)|(An)|(an))\s\w+";
-
-#if NET7_0_OR_GREATER
-    [GeneratedRegex(ArticlePattern)]
-    private static partial Regex ArticleRegexGenerated();
-
-    private static Regex ArticleRegex() => ArticleRegexGenerated();
-#else
-    private static readonly Regex ArticleRegexField = new(ArticlePattern, RegexOptions.Compiled);
-
-    private static Regex ArticleRegex() => ArticleRegexField;
-#endif
-
     /// <summary>
     /// Removes the prefixed article and appends it to the same string.
     /// </summary>
@@ -36,13 +23,11 @@ public static partial class EnglishArticle
         {
             var item = items[i]
                 .AsSpan();
-            if (ArticleRegex().IsMatch(item))
+            if (TryGetArticlePrefixLength(item, out var articleLength))
             {
-                var indexOf = item.IndexOf(' ');
-                var removed = item[indexOf..]
+                var removed = item[articleLength..]
                     .TrimStart();
-                var article = item[..indexOf]
-                    .TrimEnd();
+                var article = item[..articleLength];
                 transformed[i] = $"{removed} {article}";
             }
             else
@@ -56,6 +41,63 @@ public static partial class EnglishArticle
         Array.Sort(transformed);
         return transformed;
     }
+
+    static bool TryGetArticlePrefixLength(ReadOnlySpan<char> item, out int articleLength)
+    {
+        articleLength = 0;
+        if (IsArticle(item, "The"))
+        {
+            articleLength = 3;
+            return true;
+        }
+
+        if (IsArticle(item, "the"))
+        {
+            articleLength = 3;
+            return true;
+        }
+
+        if (IsArticle(item, "a"))
+        {
+            articleLength = 1;
+            return true;
+        }
+
+        if (IsArticle(item, "A"))
+        {
+            articleLength = 1;
+            return true;
+        }
+
+        if (IsArticle(item, "An"))
+        {
+            articleLength = 2;
+            return true;
+        }
+
+        if (IsArticle(item, "an"))
+        {
+            articleLength = 2;
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool IsArticle(ReadOnlySpan<char> item, string article)
+    {
+        var articleLength = article.Length;
+        return item.Length > articleLength + 1 &&
+            item[..articleLength].SequenceEqual(article) &&
+            item[articleLength] == ' ' &&
+            IsRegexWordCharacter(item[articleLength + 1]);
+    }
+
+    static bool IsRegexWordCharacter(char c) =>
+        c == '_' ||
+        char.IsLetterOrDigit(c) ||
+        CharUnicodeInfo.GetUnicodeCategory(c) is UnicodeCategory.ConnectorPunctuation
+            or UnicodeCategory.NonSpacingMark;
 
     /// <summary>
     /// Removes the previously appended article and prepends it to the same string.

--- a/src/Humanizer/ArticlePrefixSort.cs
+++ b/src/Humanizer/ArticlePrefixSort.cs
@@ -94,9 +94,13 @@ public static class EnglishArticle
     }
 
     static bool IsRegexWordCharacter(char c) =>
-        c == '_' ||
-        char.IsLetterOrDigit(c) ||
-        CharUnicodeInfo.GetUnicodeCategory(c) is UnicodeCategory.ConnectorPunctuation
+        CharUnicodeInfo.GetUnicodeCategory(c) is UnicodeCategory.UppercaseLetter
+            or UnicodeCategory.LowercaseLetter
+            or UnicodeCategory.TitlecaseLetter
+            or UnicodeCategory.ModifierLetter
+            or UnicodeCategory.OtherLetter
+            or UnicodeCategory.DecimalDigitNumber
+            or UnicodeCategory.ConnectorPunctuation
             or UnicodeCategory.NonSpacingMark;
 
     /// <summary>

--- a/src/Humanizer/ArticlePrefixSort.cs
+++ b/src/Humanizer/ArticlePrefixSort.cs
@@ -94,6 +94,7 @@ public static class EnglishArticle
     }
 
     static bool IsRegexWordCharacter(char c) =>
+        c is '\u200C' or '\u200D' ||
         CharUnicodeInfo.GetUnicodeCategory(c) is UnicodeCategory.UppercaseLetter
             or UnicodeCategory.LowercaseLetter
             or UnicodeCategory.TitlecaseLetter

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -209,7 +209,10 @@ public struct ByteSize(double byteSize) :
             provider = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(culture);
         }
 
-        return string.Format(provider, "{0:0.##} {1}", LargestWholeNumberValue, GetLargestWholeNumberSymbol(culture));
+        return string.Concat(
+            LargestWholeNumberValue.ToString("0.##", provider),
+            " ",
+            GetLargestWholeNumberSymbol(culture));
     }
 
     public readonly string ToString(string? format) =>
@@ -230,7 +233,7 @@ public struct ByteSize(double byteSize) :
 
         if (format.IndexOfAny(['#', '0']) < 0)
         {
-            format = "0.## " + format;
+            format = string.Concat("0.## ", format);
         }
 
         format = format.Replace("#.##", "0.##");
@@ -291,7 +294,10 @@ public struct ByteSize(double byteSize) :
             ? "0"
             : formattedLargeWholeNumberValue;
 
-        return $"{formattedLargeWholeNumberValue} {(toSymbol ? GetLargestWholeNumberSymbol(culture) : GetLargestWholeNumberFullWord(culture))}";
+        return string.Concat(
+            formattedLargeWholeNumberValue,
+            " ",
+            toSymbol ? GetLargestWholeNumberSymbol(culture) : GetLargestWholeNumberFullWord(culture));
     }
 
     /// <summary>

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -385,9 +385,9 @@ public static partial class InflectorExtensions
 
     static bool IsAscii(string input)
     {
-        foreach (var c in input)
+        for (var i = 0; i < input.Length; i++)
         {
-            if (c > '\u007F')
+            if (input[i] > '\u007F')
             {
                 return false;
             }

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -171,9 +171,11 @@ public static partial class InflectorExtensions
     /// </code>
     /// </example>
     public static string Pascalize(this string input) =>
-        PascalizeRegex().Replace(input, match => match
-            .Groups[1]
-            .Value.ToUpper());
+        TryPascalizeAscii(input, lowerFirst: false, out var result)
+            ? result
+            : PascalizeRegex().Replace(input, match => match
+                .Groups[1]
+                .Value.ToUpper());
 
     /// <summary>
     /// Converts a string to camelCase (lowerCamelCase) by capitalizing the first letter of each word
@@ -197,12 +199,51 @@ public static partial class InflectorExtensions
     /// </example>
     public static string Camelize(this string input)
     {
+        if (TryPascalizeAscii(input, lowerFirst: true, out var result))
+        {
+            return result;
+        }
+
         var word = input.Pascalize();
         return word.Length > 0
             ? StringHumanizeExtensions.Concat(
                 char.ToLower(word[0]),
                 word.AsSpan(1))
             : word;
+    }
+
+    static bool TryPascalizeAscii(string input, bool lowerFirst, [NotNullWhen(true)] out string? result)
+    {
+        result = null;
+        if (!IsAscii(input))
+        {
+            return false;
+        }
+
+        var textInfo = CultureInfo.CurrentCulture.TextInfo;
+        var buffer = new char[input.Length];
+        var pos = 0;
+        var capitalizeNext = true;
+        for (var i = 0; i < input.Length; i++)
+        {
+            var c = input[i];
+            if (c is ' ' or '_' or '-')
+            {
+                capitalizeNext = true;
+                continue;
+            }
+
+            if (capitalizeNext)
+            {
+                c = pos == 0 && lowerFirst ? textInfo.ToLower(c) : textInfo.ToUpper(c);
+                capitalizeNext = false;
+            }
+
+            buffer[pos++] = c;
+        }
+
+        result = new(buffer, 0, pos);
+        return true;
     }
 
     /// <summary>
@@ -225,11 +266,13 @@ public static partial class InflectorExtensions
     /// </code>
     /// </example>
     public static string Underscore(this string input) =>
-        UnderscoreRegex3()
-            .Replace(
-                UnderscoreRegex2().Replace(
-                    UnderscoreRegex1().Replace(input, "$1_$2"), "$1_$2"), "_")
-            .ToLower();
+        TryUnderscoreAscii(input, separator: '_', replaceUnderscore: false, out var result)
+            ? result
+            : UnderscoreRegex3()
+                .Replace(
+                    UnderscoreRegex2().Replace(
+                        UnderscoreRegex1().Replace(input, "$1_$2"), "$1_$2"), "_")
+                .ToLower();
 
     /// <summary>
     /// Replaces all underscores in the string with dashes (hyphens).
@@ -289,6 +332,76 @@ public static partial class InflectorExtensions
     /// </code>
     /// </example>
     public static string Kebaberize(this string input) =>
-        Underscore(input)
-            .Dasherize();
+        TryUnderscoreAscii(input, separator: '-', replaceUnderscore: true, out var result)
+            ? result
+            : Underscore(input)
+                .Dasherize();
+
+    static bool TryUnderscoreAscii(string input, char separator, bool replaceUnderscore, [NotNullWhen(true)] out string? result)
+    {
+        result = null;
+        if (!IsAscii(input))
+        {
+            return false;
+        }
+
+        var textInfo = CultureInfo.CurrentCulture.TextInfo;
+        var buffer = new char[Math.Max(1, input.Length * 2)];
+        var pos = 0;
+        for (var i = 0; i < input.Length; i++)
+        {
+            var c = input[i];
+            if (c == '-' || char.IsWhiteSpace(c) || (replaceUnderscore && c == '_'))
+            {
+                buffer[pos++] = separator;
+                continue;
+            }
+
+            if (IsAsciiUpper(c))
+            {
+                if (pos > 0 && buffer[pos - 1] != separator &&
+                    (IsPreviousLowerOrDigit(input, i) || IsAcronymBoundary(input, i)))
+                {
+                    buffer[pos++] = separator;
+                }
+
+                buffer[pos++] = textInfo.ToLower(c);
+                continue;
+            }
+
+            buffer[pos++] = textInfo.ToLower(c);
+        }
+
+        result = new(buffer, 0, pos);
+        return true;
+    }
+
+    static bool IsPreviousLowerOrDigit(string input, int index) =>
+        index > 0 && (IsAsciiLower(input[index - 1]) || IsAsciiDigit(input[index - 1]));
+
+    static bool IsAcronymBoundary(string input, int index) =>
+        index > 0 && IsAsciiUpper(input[index - 1]) &&
+        index + 1 < input.Length && IsAsciiLower(input[index + 1]);
+
+    static bool IsAscii(string input)
+    {
+        foreach (var c in input)
+        {
+            if (c > '\u007F')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    static bool IsAsciiUpper(char c) =>
+        c is >= 'A' and <= 'Z';
+
+    static bool IsAsciiLower(char c) =>
+        c is >= 'a' and <= 'z';
+
+    static bool IsAsciiDigit(char c) =>
+        c is >= '0' and <= '9';
 }

--- a/src/Humanizer/Localisation/CollectionFormatters/DefaultCollectionFormatter.cs
+++ b/src/Humanizer/Localisation/CollectionFormatters/DefaultCollectionFormatter.cs
@@ -27,9 +27,7 @@ class DefaultCollectionFormatter(string defaultSeparator) : ICollectionFormatter
         ArgumentNullException.ThrowIfNull(collection);
         ArgumentNullException.ThrowIfNull(objectFormatter);
 
-        return HumanizeDisplayStrings(
-            collection.Select(objectFormatter),
-            separator);
+        return HumanizeDisplayStrings(collection, objectFormatter, separator);
     }
 
     public string Humanize<T>(IEnumerable<T> collection, Func<T, object?> objectFormatter, string separator)
@@ -37,23 +35,52 @@ class DefaultCollectionFormatter(string defaultSeparator) : ICollectionFormatter
         ArgumentNullException.ThrowIfNull(collection);
         ArgumentNullException.ThrowIfNull(objectFormatter);
 
-        return HumanizeDisplayStrings(
-            collection
-                .Select(objectFormatter)
-                .Select(o => o?.ToString()),
-            separator);
+        return HumanizeDisplayObjects(collection, objectFormatter, separator);
     }
 
-    string HumanizeDisplayStrings(IEnumerable<string?> strings, string separator)
+    string HumanizeDisplayStrings<T>(IEnumerable<T> collection, Func<T, string?> objectFormatter, string separator)
     {
-        // Materialize once so the filtered display count and the final join can share the same sequence.
-        // Re-enumerating here would be wrong for one-shot enumerables and would change the allocation profile.
-        var itemsArray = strings
-            .Select(item => item == null ? string.Empty : item.Trim())
-            .Where(item => !string.IsNullOrWhiteSpace(item))
-            .ToArray();
+        var items = CreateDisplayItems(collection);
+        foreach (var item in collection)
+        {
+            AddDisplayString(items, objectFormatter(item));
+        }
 
-        var count = itemsArray.Length;
+        return HumanizeDisplayItems(items, separator);
+    }
+
+    string HumanizeDisplayObjects<T>(IEnumerable<T> collection, Func<T, object?> objectFormatter, string separator)
+    {
+        var items = CreateDisplayItems(collection);
+        foreach (var item in collection)
+        {
+            AddDisplayString(items, objectFormatter(item)?.ToString());
+        }
+
+        return HumanizeDisplayItems(items, separator);
+    }
+
+    static List<string> CreateDisplayItems<T>(IEnumerable<T> collection) =>
+        collection switch
+        {
+            ICollection<T> items => new(items.Count),
+            IReadOnlyCollection<T> items => new(items.Count),
+            _ => []
+        };
+
+    static void AddDisplayString(List<string> items, string? item)
+    {
+        if (string.IsNullOrWhiteSpace(item))
+        {
+            return;
+        }
+
+        items.Add(item!.Trim());
+    }
+
+    string HumanizeDisplayItems(List<string> items, string separator)
+    {
+        var count = items.Count;
 
         if (count == 0)
         {
@@ -62,25 +89,40 @@ class DefaultCollectionFormatter(string defaultSeparator) : ICollectionFormatter
 
         if (count == 1)
         {
-            return itemsArray[0];
+            return items[0];
         }
 
         var conjunctionFormat = GetConjunctionFormatString(count);
         if (conjunctionFormat == "{0} {1} {2}")
         {
-            // Fast path: avoid string.Format for default format.
-            return string.Concat(
-                string.Join(", ", itemsArray, 0, itemsArray.Length - 1),
-                " ",
-                separator,
-                " ",
-                itemsArray[^1]);
+            return count == 2
+                ? string.Concat(items[0], " ", separator, " ", items[1])
+                : string.Concat(JoinLeadingItems(items), " ", separator, " ", items[^1]);
         }
 
         return string.Format(conjunctionFormat,
-            string.Join(", ", itemsArray, 0, itemsArray.Length - 1),
+            JoinLeadingItems(items),
             separator,
-            itemsArray[^1]);
+            items[^1]);
+    }
+
+    static string JoinLeadingItems(List<string> items)
+    {
+        var count = items.Count - 1;
+        if (count == 1)
+        {
+            return items[0];
+        }
+
+        var builder = new StringBuilder();
+        builder.Append(items[0]);
+        for (var i = 1; i < count; i++)
+        {
+            builder.Append(", ");
+            builder.Append(items[i]);
+        }
+
+        return builder.ToString();
     }
 
     /// <summary>

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -327,21 +327,69 @@ public class DefaultFormatter : IFormatter
 
     static string JoinPhraseParts(string? first, string? second, string? third, string? fourth)
     {
-        var result = AppendPhrasePart(null, first);
-        result = AppendPhrasePart(result, second);
-        result = AppendPhrasePart(result, third);
-        return AppendPhrasePart(result, fourth) ?? string.Empty;
+        var partCount = 0;
+        var totalLength = 0;
+        MeasurePhrasePart(first, ref partCount, ref totalLength);
+        MeasurePhrasePart(second, ref partCount, ref totalLength);
+        MeasurePhrasePart(third, ref partCount, ref totalLength);
+        MeasurePhrasePart(fourth, ref partCount, ref totalLength);
+
+        if (partCount == 0)
+        {
+            return string.Empty;
+        }
+
+        if (partCount == 1)
+        {
+            return FirstPhrasePart(first, second, third, fourth);
+        }
+
+        var builder = new StringBuilder(totalLength + partCount - 1);
+        AppendPhrasePart(builder, first);
+        AppendPhrasePart(builder, second);
+        AppendPhrasePart(builder, third);
+        AppendPhrasePart(builder, fourth);
+        return builder.ToString();
     }
 
-    static string? AppendPhrasePart(string? result, string? part)
+    static void MeasurePhrasePart(string? part, ref int partCount, ref int totalLength)
     {
         if (string.IsNullOrWhiteSpace(part))
         {
-            return result;
+            return;
         }
 
-        return result is null
-            ? part
-            : string.Concat(result, " ", part);
+        partCount++;
+        totalLength += part!.Length;
+    }
+
+    static string FirstPhrasePart(string? first, string? second, string? third, string? fourth)
+    {
+        if (!string.IsNullOrWhiteSpace(first))
+        {
+            return first!;
+        }
+
+        if (!string.IsNullOrWhiteSpace(second))
+        {
+            return second!;
+        }
+
+        return !string.IsNullOrWhiteSpace(third) ? third! : fourth!;
+    }
+
+    static void AppendPhrasePart(StringBuilder builder, string? part)
+    {
+        if (string.IsNullOrWhiteSpace(part))
+        {
+            return;
+        }
+
+        if (builder.Length > 0)
+        {
+            builder.Append(' ');
+        }
+
+        builder.Append(part);
     }
 }

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -325,6 +325,23 @@ public class DefaultFormatter : IFormatter
             .Trim();
     }
 
-    static string JoinPhraseParts(params string?[] parts) =>
-        string.Join(" ", parts.Where(static part => !string.IsNullOrWhiteSpace(part)));
+    static string JoinPhraseParts(string? first, string? second, string? third, string? fourth)
+    {
+        var result = AppendPhrasePart(null, first);
+        result = AppendPhrasePart(result, second);
+        result = AppendPhrasePart(result, third);
+        return AppendPhrasePart(result, fourth) ?? string.Empty;
+    }
+
+    static string? AppendPhrasePart(string? result, string? part)
+    {
+        if (string.IsNullOrWhiteSpace(part))
+        {
+            return result;
+        }
+
+        return result is null
+            ? part
+            : string.Concat(result, " ", part);
+    }
 }

--- a/src/Humanizer/Localisation/TimeToClockNotation/PhraseClockNotationConverter.cs
+++ b/src/Humanizer/Localisation/TimeToClockNotation/PhraseClockNotationConverter.cs
@@ -10,6 +10,7 @@ namespace Humanizer;
 class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOnlyToClockNotationConverter
 {
     readonly PhraseClockNotationProfile profile = profile;
+    readonly Dictionary<string, TemplatePlan> templatePlans = BuildTemplatePlans(profile);
 
     /// <summary>
     /// Converts the given time using the phrase-clock profile.
@@ -392,50 +393,40 @@ class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOn
 
     string ExpandTemplate(string template, int hour, int normalizedMinutes, string minuteSuffix)
     {
-        var hourWords = template.Contains("{hour}") ? ResolveHourExpression(hour) : "";
-        var nextHourWords = template.Contains("{nextHour}") ? ResolveHourExpression(hour + 1) : "";
-        var minuteWords = template.Contains("{minutes}") ? ResolveMinuteExpression(normalizedMinutes) : "";
-        var reverseMinuteWords = template.Contains("{minutesReverse}") && normalizedMinutes > 0 ? ResolveMinuteWords(60 - normalizedMinutes) : "";
-        var halfMinuteWords = template.Contains("{minutesFromHalf}") ? ResolveHalfMinuteWords(normalizedMinutes) : "";
-        var article = template.Contains("{article}") ? ResolveArticle(hour) : "";
-        var nextArticle = template.Contains("{nextArticle}") ? ResolveArticle(hour + 1) : "";
-        var dayPeriod = template.Contains("{dayPeriod}") ? GetDayPeriod(hour) : "";
+        var plan = GetTemplatePlan(template);
+        var hourWords = plan.UsesHour ? ResolveHourExpression(hour) : "";
+        var nextHourWords = plan.UsesNextHour ? ResolveHourExpression(hour + 1) : "";
+        var minuteWords = plan.UsesMinutes ? ResolveMinuteExpression(normalizedMinutes) : "";
+        var reverseMinuteWords = plan.UsesMinutesReverse && normalizedMinutes > 0 ? ResolveMinuteWords(60 - normalizedMinutes) : "";
+        var halfMinuteWords = plan.UsesMinutesFromHalf ? ResolveHalfMinuteWords(normalizedMinutes) : "";
+        var article = plan.UsesArticle ? ResolveArticle(hour) : "";
+        var nextArticle = plan.UsesNextArticle ? ResolveArticle(hour + 1) : "";
+        var dayPeriod = plan.UsesDayPeriod ? GetDayPeriod(hour) : "";
 
         // Single-pass expansion: scan the template once, resolve placeholders inline,
         // skip double spaces, and trim — producing only the final return string.
-        var maxLen = template.Length
+        var maxLen = plan.LiteralLength
             + hourWords.Length + nextHourWords.Length + minuteWords.Length
             + reverseMinuteWords.Length + halfMinuteWords.Length
             + article.Length + nextArticle.Length + minuteSuffix.Length + dayPeriod.Length;
 
         Span<char> buf = stackalloc char[maxLen];
         var pos = 0;
-        var i = 0;
-
-        while (i < template.Length)
+        foreach (var segment in plan.Segments)
         {
-            if (template[i] == '{')
+            if (segment.Literal is not null)
             {
-                var close = template.IndexOf('}', i);
-                if (close < 0)
-                {
-                    AppendChar(buf, ref pos, template[i++]);
-                    continue;
-                }
-
-                var name = template.AsSpan(i + 1, close - i - 1);
+                AppendString(buf, ref pos, segment.Literal);
+            }
+            else
+            {
                 var replacement = ResolveTemplatePlaceholder(
-                    name, template, close + 1,
+                    segment.Placeholder, template, segment.AfterIndex,
                     hourWords, nextHourWords, minuteWords, reverseMinuteWords, halfMinuteWords,
                     article, nextArticle, minuteSuffix, dayPeriod);
 
                 replacement.CopyTo(buf[pos..]);
                 pos += replacement.Length;
-                i = close + 1;
-            }
-            else
-            {
-                AppendChar(buf, ref pos, template[i++]);
             }
         }
 
@@ -471,55 +462,63 @@ class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOn
         buf[pos++] = c;
     }
 
+    static void AppendString(Span<char> buf, ref int pos, string value)
+    {
+        foreach (var c in value)
+        {
+            AppendChar(buf, ref pos, c);
+        }
+    }
+
     /// <summary>
     /// Resolves a template placeholder by name, applying the Eifeler rule for number placeholders.
     /// Returns the replacement value as a <see cref="ReadOnlySpan{T}"/> to avoid allocations.
     /// </summary>
     ReadOnlySpan<char> ResolveTemplatePlaceholder(
-        ReadOnlySpan<char> name, string template, int afterIndex,
+        TemplatePlaceholder placeholder, string template, int afterIndex,
         string hour, string nextHour, string minutes, string minutesReverse, string minutesFromHalf,
         string article, string nextArticle, string minuteSuffix, string dayPeriod)
     {
         // Non-number placeholders: return directly without Eifeler processing.
-        if (name.SequenceEqual("article"))
+        if (placeholder == TemplatePlaceholder.Article)
         {
             return article;
         }
 
-        if (name.SequenceEqual("nextArticle"))
+        if (placeholder == TemplatePlaceholder.NextArticle)
         {
             return nextArticle;
         }
 
-        if (name.SequenceEqual("minuteSuffix"))
+        if (placeholder == TemplatePlaceholder.MinuteSuffix)
         {
             return minuteSuffix;
         }
 
-        if (name.SequenceEqual("dayPeriod"))
+        if (placeholder == TemplatePlaceholder.DayPeriod)
         {
             return dayPeriod;
         }
 
         // Number placeholders: apply Eifeler rule when enabled.
         string value;
-        if (name.SequenceEqual("hour"))
+        if (placeholder == TemplatePlaceholder.Hour)
         {
             value = hour;
         }
-        else if (name.SequenceEqual("nextHour"))
+        else if (placeholder == TemplatePlaceholder.NextHour)
         {
             value = nextHour;
         }
-        else if (name.SequenceEqual("minutes"))
+        else if (placeholder == TemplatePlaceholder.Minutes)
         {
             value = minutes;
         }
-        else if (name.SequenceEqual("minutesReverse"))
+        else if (placeholder == TemplatePlaceholder.MinutesReverse)
         {
             value = minutesReverse;
         }
-        else if (name.SequenceEqual("minutesFromHalf"))
+        else if (placeholder == TemplatePlaceholder.MinutesFromHalf)
         {
             value = minutesFromHalf;
         }
@@ -662,13 +661,15 @@ class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOn
     /// </summary>
     string ApplyDayPeriodIfNeeded(string expandedPhrase, string rawTemplate, int hour, int normalizedMinutes)
     {
+        var plan = GetTemplatePlan(rawTemplate);
+
         // If the template already placed the day-period inline, don't append/prepend it again.
-        if (rawTemplate.Contains("{dayPeriod}"))
+        if (plan.UsesDayPeriod)
         {
             return expandedPhrase;
         }
 
-        var usesNextHour = rawTemplate.Contains("{nextHour}") || rawTemplate.Contains("{nextArticle}");
+        var usesNextHour = plan.UsesNextHour || plan.UsesNextArticle;
         return ApplyDayPeriod(expandedPhrase, hour, usesNextHour);
     }
 
@@ -716,6 +717,224 @@ class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOn
         }
 
         return profile.Night;
+    }
+
+    TemplatePlan GetTemplatePlan(string template) =>
+        templatePlans.TryGetValue(template, out var plan) ? plan : TemplatePlan.Create(template);
+
+    static Dictionary<string, TemplatePlan> BuildTemplatePlans(PhraseClockNotationProfile profile)
+    {
+        var plans = new Dictionary<string, TemplatePlan>(StringComparer.Ordinal);
+
+        AddTemplatePlan(plans, profile.Min0);
+        AddTemplatePlan(plans, profile.Min5);
+        AddTemplatePlan(plans, profile.Min10);
+        AddTemplatePlan(plans, profile.Min15);
+        AddTemplatePlan(plans, profile.Min20);
+        AddTemplatePlan(plans, profile.Min25);
+        AddTemplatePlan(plans, profile.Min30);
+        AddTemplatePlan(plans, profile.Min35);
+        AddTemplatePlan(plans, profile.Min40);
+        AddTemplatePlan(plans, profile.Min45);
+        AddTemplatePlan(plans, profile.Min50);
+        AddTemplatePlan(plans, profile.Min55);
+        AddTemplatePlan(plans, profile.PastHourTemplate);
+        AddTemplatePlan(plans, profile.BeforeHalfTemplate);
+        AddTemplatePlan(plans, profile.AfterHalfTemplate);
+        AddTemplatePlan(plans, profile.BeforeNextTemplate);
+        AddTemplatePlan(plans, profile.DefaultTemplate);
+
+        return plans;
+    }
+
+    static void AddTemplatePlan(Dictionary<string, TemplatePlan> plans, string template)
+    {
+        if (template.Length > 0 && !plans.ContainsKey(template))
+        {
+            plans.Add(template, TemplatePlan.Create(template));
+        }
+    }
+
+    enum TemplatePlaceholder
+    {
+        Empty,
+        Hour,
+        NextHour,
+        Minutes,
+        MinutesReverse,
+        MinutesFromHalf,
+        Article,
+        NextArticle,
+        MinuteSuffix,
+        DayPeriod
+    }
+
+    readonly struct TemplateSegment(string? literal, TemplatePlaceholder placeholder, int afterIndex)
+    {
+        public string? Literal { get; } = literal;
+        public TemplatePlaceholder Placeholder { get; } = placeholder;
+        public int AfterIndex { get; } = afterIndex;
+
+        public static TemplateSegment ForLiteral(string literal) =>
+            new(literal, TemplatePlaceholder.Empty, 0);
+
+        public static TemplateSegment ForPlaceholder(TemplatePlaceholder placeholder, int afterIndex) =>
+            new(null, placeholder, afterIndex);
+    }
+
+    readonly struct TemplatePlan
+    {
+        public bool UsesHour { get; init; }
+        public bool UsesNextHour { get; init; }
+        public bool UsesMinutes { get; init; }
+        public bool UsesMinutesReverse { get; init; }
+        public bool UsesMinutesFromHalf { get; init; }
+        public bool UsesArticle { get; init; }
+        public bool UsesNextArticle { get; init; }
+        public bool UsesDayPeriod { get; init; }
+        public int LiteralLength { get; init; }
+        public TemplateSegment[] Segments { get; init; }
+
+        public static TemplatePlan Create(string template)
+        {
+            var plan = new TemplatePlan { Segments = [] };
+            var segments = new List<TemplateSegment>();
+            var i = 0;
+            var literalStart = 0;
+            while (i < template.Length)
+            {
+                if (template[i] != '{')
+                {
+                    i++;
+                    continue;
+                }
+
+                var close = template.IndexOf('}', i);
+                if (close < 0)
+                {
+                    break;
+                }
+
+                if (i > literalStart)
+                {
+                    plan = plan.AddLiteral(segments, template[literalStart..i]);
+                }
+
+                var placeholder = ParsePlaceholder(template.AsSpan(i + 1, close - i - 1));
+                segments.Add(TemplateSegment.ForPlaceholder(placeholder, close + 1));
+                plan = plan.WithPlaceholder(placeholder);
+                i = close + 1;
+                literalStart = i;
+            }
+
+            if (literalStart < template.Length)
+            {
+                plan = plan.AddLiteral(segments, template[literalStart..]);
+            }
+
+            return plan with { Segments = [.. segments] };
+        }
+
+        TemplatePlan AddLiteral(List<TemplateSegment> segments, string literal)
+        {
+            segments.Add(TemplateSegment.ForLiteral(literal));
+            return this with { LiteralLength = LiteralLength + literal.Length };
+        }
+
+        TemplatePlan WithPlaceholder(TemplatePlaceholder placeholder)
+        {
+            if (placeholder == TemplatePlaceholder.Hour)
+            {
+                return this with { UsesHour = true };
+            }
+
+            if (placeholder == TemplatePlaceholder.NextHour)
+            {
+                return this with { UsesNextHour = true };
+            }
+
+            if (placeholder == TemplatePlaceholder.Minutes)
+            {
+                return this with { UsesMinutes = true };
+            }
+
+            if (placeholder == TemplatePlaceholder.MinutesReverse)
+            {
+                return this with { UsesMinutesReverse = true };
+            }
+
+            if (placeholder == TemplatePlaceholder.MinutesFromHalf)
+            {
+                return this with { UsesMinutesFromHalf = true };
+            }
+
+            if (placeholder == TemplatePlaceholder.Article)
+            {
+                return this with { UsesArticle = true };
+            }
+
+            if (placeholder == TemplatePlaceholder.NextArticle)
+            {
+                return this with { UsesNextArticle = true };
+            }
+
+            if (placeholder == TemplatePlaceholder.DayPeriod)
+            {
+                return this with { UsesDayPeriod = true };
+            }
+
+            return this;
+        }
+
+        static TemplatePlaceholder ParsePlaceholder(ReadOnlySpan<char> name)
+        {
+            if (name.SequenceEqual("hour"))
+            {
+                return TemplatePlaceholder.Hour;
+            }
+
+            if (name.SequenceEqual("nextHour"))
+            {
+                return TemplatePlaceholder.NextHour;
+            }
+
+            if (name.SequenceEqual("minutes"))
+            {
+                return TemplatePlaceholder.Minutes;
+            }
+
+            if (name.SequenceEqual("minutesReverse"))
+            {
+                return TemplatePlaceholder.MinutesReverse;
+            }
+
+            if (name.SequenceEqual("minutesFromHalf"))
+            {
+                return TemplatePlaceholder.MinutesFromHalf;
+            }
+
+            if (name.SequenceEqual("article"))
+            {
+                return TemplatePlaceholder.Article;
+            }
+
+            if (name.SequenceEqual("nextArticle"))
+            {
+                return TemplatePlaceholder.NextArticle;
+            }
+
+            if (name.SequenceEqual("minuteSuffix"))
+            {
+                return TemplatePlaceholder.MinuteSuffix;
+            }
+
+            if (name.SequenceEqual("dayPeriod"))
+            {
+                return TemplatePlaceholder.DayPeriod;
+            }
+
+            return TemplatePlaceholder.Empty;
+        }
     }
 }
 

--- a/src/Humanizer/Localisation/TimeToClockNotation/PhraseClockNotationConverter.cs
+++ b/src/Humanizer/Localisation/TimeToClockNotation/PhraseClockNotationConverter.cs
@@ -45,46 +45,12 @@ class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOn
             return profile.Midday;
         }
 
-        var hourWords = ResolveHourExpression(hour);
-        var nextHourWords = ResolveHourExpression(hour + 1);
-        var rawMinuteWords = ResolveMinuteWords(normalizedMinutes);
-
-        // When a zero-filler is configured and minutes are 1-9, prepend the filler word
-        // so templates like "{hour} {minutes}" produce "et nul fem" instead of "et fem".
-        // When compactMinuteWords is active (CJK locales), omit the space between filler and word.
-        var minuteWords = normalizedMinutes is > 0 and < 10 && profile.ZeroFiller.Length > 0
-            ? string.Concat(profile.ZeroFiller, profile.CompactMinuteWords ? "" : " ", rawMinuteWords)
-            : rawMinuteWords;
-
-        var reverseMinuteWords = normalizedMinutes > 0 ? ResolveMinuteWords(60 - normalizedMinutes) : "";
-
-        string halfMinuteWords;
-        if (normalizedMinutes < 30)
-        {
-            halfMinuteWords = ResolveMinuteWords(30 - normalizedMinutes);
-        }
-        else if (normalizedMinutes > 30)
-        {
-            halfMinuteWords = ResolveMinuteWords(normalizedMinutes - 30);
-        }
-        else
-        {
-            halfMinuteWords = "";
-        }
-
-        // Resolve the article for locales that have singular/plural articles (ca, es).
-        var article = ResolveArticle(hour);
-        var nextArticle = ResolveArticle(hour + 1);
-
-        // Pre-compute the day-period string for possible inline use via {dayPeriod} placeholder.
-        var dayPeriod = GetDayPeriod(hour);
-
         // Check minute-bucket template first (exact 5-minute intervals).
         var template = GetBucketTemplate(normalizedMinutes);
         if (template.Length > 0)
         {
             var minuteSuffix = ResolveMinuteSuffixDirect(normalizedMinutes);
-            var result = ExpandTemplate(template, hourWords, nextHourWords, minuteWords, reverseMinuteWords, halfMinuteWords, article, nextArticle, minuteSuffix, dayPeriod);
+            var result = ExpandTemplate(template, hour, normalizedMinutes, minuteSuffix);
             return ApplyDayPeriodIfNeeded(result, template, hour, normalizedMinutes);
         }
 
@@ -95,7 +61,7 @@ class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOn
         if (rangeTemplate.Length > 0)
         {
             var minuteSuffix = ResolveMinuteSuffixForRange(normalizedMinutes);
-            var result = ExpandTemplate(rangeTemplate, hourWords, nextHourWords, minuteWords, reverseMinuteWords, halfMinuteWords, article, nextArticle, minuteSuffix, dayPeriod);
+            var result = ExpandTemplate(rangeTemplate, hour, normalizedMinutes, minuteSuffix);
             return ApplyDayPeriodIfNeeded(result, rangeTemplate, hour, normalizedMinutes);
         }
 
@@ -103,11 +69,13 @@ class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOn
         if (profile.DefaultTemplate.Length > 0)
         {
             var minuteSuffix = ResolveMinuteSuffixDirect(normalizedMinutes);
-            var result = ExpandTemplate(profile.DefaultTemplate, hourWords, nextHourWords, minuteWords, reverseMinuteWords, halfMinuteWords, article, nextArticle, minuteSuffix, dayPeriod);
+            var result = ExpandTemplate(profile.DefaultTemplate, hour, normalizedMinutes, minuteSuffix);
             return ApplyDayPeriodIfNeeded(result, profile.DefaultTemplate, hour, normalizedMinutes);
         }
 
         // Absolute fallback: "{hour} {minutes}".
+        var hourWords = ResolveHourExpression(hour);
+        var minuteWords = ResolveMinuteExpression(normalizedMinutes);
         var fallback = minuteWords.Length > 0 ? hourWords + " " + minuteWords : hourWords;
         return ApplyDayPeriod(fallback, hour, usesNextHour: false);
     }
@@ -217,6 +185,18 @@ class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOn
         }
 
         return words;
+    }
+
+    string ResolveMinuteExpression(int normalizedMinutes)
+    {
+        var rawMinuteWords = ResolveMinuteWords(normalizedMinutes);
+
+        // When a zero-filler is configured and minutes are 1-9, prepend the filler word
+        // so templates like "{hour} {minutes}" produce "et nul fem" instead of "et fem".
+        // When compactMinuteWords is active (CJK locales), omit the space between filler and word.
+        return normalizedMinutes is > 0 and < 10 && profile.ZeroFiller.Length > 0
+            ? string.Concat(profile.ZeroFiller, profile.CompactMinuteWords ? "" : " ", rawMinuteWords)
+            : rawMinuteWords;
     }
 
     /// <summary>
@@ -410,16 +390,22 @@ class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOn
         };
     }
 
-    string ExpandTemplate(
-        string template, string hour, string nextHour,
-        string minutes, string minutesReverse, string minutesFromHalf,
-        string article, string nextArticle, string minuteSuffix, string dayPeriod)
+    string ExpandTemplate(string template, int hour, int normalizedMinutes, string minuteSuffix)
     {
+        var hourWords = template.Contains("{hour}") ? ResolveHourExpression(hour) : "";
+        var nextHourWords = template.Contains("{nextHour}") ? ResolveHourExpression(hour + 1) : "";
+        var minuteWords = template.Contains("{minutes}") ? ResolveMinuteExpression(normalizedMinutes) : "";
+        var reverseMinuteWords = template.Contains("{minutesReverse}") && normalizedMinutes > 0 ? ResolveMinuteWords(60 - normalizedMinutes) : "";
+        var halfMinuteWords = template.Contains("{minutesFromHalf}") ? ResolveHalfMinuteWords(normalizedMinutes) : "";
+        var article = template.Contains("{article}") ? ResolveArticle(hour) : "";
+        var nextArticle = template.Contains("{nextArticle}") ? ResolveArticle(hour + 1) : "";
+        var dayPeriod = template.Contains("{dayPeriod}") ? GetDayPeriod(hour) : "";
+
         // Single-pass expansion: scan the template once, resolve placeholders inline,
         // skip double spaces, and trim — producing only the final return string.
         var maxLen = template.Length
-            + hour.Length + nextHour.Length + minutes.Length
-            + minutesReverse.Length + minutesFromHalf.Length
+            + hourWords.Length + nextHourWords.Length + minuteWords.Length
+            + reverseMinuteWords.Length + halfMinuteWords.Length
             + article.Length + nextArticle.Length + minuteSuffix.Length + dayPeriod.Length;
 
         Span<char> buf = stackalloc char[maxLen];
@@ -440,7 +426,7 @@ class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOn
                 var name = template.AsSpan(i + 1, close - i - 1);
                 var replacement = ResolveTemplatePlaceholder(
                     name, template, close + 1,
-                    hour, nextHour, minutes, minutesReverse, minutesFromHalf,
+                    hourWords, nextHourWords, minuteWords, reverseMinuteWords, halfMinuteWords,
                     article, nextArticle, minuteSuffix, dayPeriod);
 
                 replacement.CopyTo(buf[pos..]);
@@ -457,6 +443,21 @@ class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOn
         var result = buf[..pos];
         result = result.Trim();
         return new string(result);
+    }
+
+    string ResolveHalfMinuteWords(int normalizedMinutes)
+    {
+        if (normalizedMinutes < 30)
+        {
+            return ResolveMinuteWords(30 - normalizedMinutes);
+        }
+
+        if (normalizedMinutes > 30)
+        {
+            return ResolveMinuteWords(normalizedMinutes - 30);
+        }
+
+        return "";
     }
 
     static void AppendChar(Span<char> buf, ref int pos, char c)

--- a/src/Humanizer/Localisation/WordsToNumber/TokenMapWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/TokenMapWordsToNumberConverter.cs
@@ -1041,6 +1041,8 @@ static class TokenMapWordsToNumberNormalizer
 
             if (i == 0 ||
                 i == source.Length - 1 ||
+                source[i - 1] == '-' ||
+                source[i + 1] == '-' ||
                 source[i - 1] == ' ' ||
                 source[i + 1] == ' ')
             {

--- a/src/Humanizer/Localisation/WordsToNumber/TokenMapWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/TokenMapWordsToNumberConverter.cs
@@ -971,6 +971,8 @@ static class TokenMapWordsToNumberNormalizer
         // This profile stays allocation-free when the input is already lowercase and only trimmed
         // whitespace needs to be preserved.
         var needsNormalization = false;
+        var sawHyphen = false;
+        var needsBuilderNormalization = false;
         var previousWasSpace = false;
 
         foreach (var current in source)
@@ -978,13 +980,16 @@ static class TokenMapWordsToNumberNormalizer
             if (current is ',' or '.')
             {
                 needsNormalization = true;
+                needsBuilderNormalization = true;
                 break;
             }
 
             if (current == '-')
             {
                 needsNormalization = true;
-                break;
+                sawHyphen = true;
+                previousWasSpace = false;
+                continue;
             }
 
             if (char.IsWhiteSpace(current))
@@ -992,6 +997,7 @@ static class TokenMapWordsToNumberNormalizer
                 if (current != ' ' || previousWasSpace)
                 {
                     needsNormalization = true;
+                    needsBuilderNormalization = true;
                     break;
                 }
 
@@ -1002,6 +1008,7 @@ static class TokenMapWordsToNumberNormalizer
             if (char.IsUpper(current))
             {
                 needsNormalization = true;
+                needsBuilderNormalization = true;
                 break;
             }
 
@@ -1013,7 +1020,35 @@ static class TokenMapWordsToNumberNormalizer
             return source.Length == words.Length ? words : source.ToString();
         }
 
+        if (sawHyphen && !needsBuilderNormalization && CanReplaceHyphensWithSpaces(source))
+        {
+            return source.Length == words.Length
+                ? words.Replace('-', ' ')
+                : source.ToString().Replace('-', ' ');
+        }
+
         return NormalizeWithBuilder(words, TokenMapNormalizationProfile.LowercaseRemovePeriods);
+    }
+
+    static bool CanReplaceHyphensWithSpaces(ReadOnlySpan<char> source)
+    {
+        for (var i = 0; i < source.Length; i++)
+        {
+            if (source[i] != '-')
+            {
+                continue;
+            }
+
+            if (i == 0 ||
+                i == source.Length - 1 ||
+                source[i - 1] == ' ' ||
+                source[i + 1] == ' ')
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -146,8 +146,43 @@ public static class MetricNumeralExtensions
     /// </code>
     /// </example>
     /// <returns>A valid Metric representation</returns>
-    public static string ToMetric(this int input, MetricNumeralFormats? formats = null, int? decimals = null) =>
-        ((double)input).ToMetric(formats, decimals);
+    public static string ToMetric(this int input, MetricNumeralFormats? formats = null, int? decimals = null)
+    {
+        if (!formats.HasValue && !decimals.HasValue)
+        {
+            return BuildDefaultRepresentation(input);
+        }
+
+        return ((double)input).ToMetric(formats, decimals);
+    }
+
+    static string BuildDefaultRepresentation(int input)
+    {
+        if (input == 0)
+        {
+            return input.ToString();
+        }
+
+        var absolute = Math.Abs((long)input);
+        var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
+
+        if (absolute < 1_000)
+        {
+            return input.ToString(nfi);
+        }
+
+        if (absolute < 1_000_000)
+        {
+            return (input / 1_000d).ToString("G15", nfi) + "k";
+        }
+
+        if (absolute < 1_000_000_000)
+        {
+            return (input / 1_000_000d).ToString("G15", nfi) + "M";
+        }
+
+        return (input / 1_000_000_000d).ToString("G15", nfi) + "G";
+    }
 
     /// <summary>
     /// Converts a number into a valid and Human-readable Metric representation.

--- a/src/Humanizer/OrdinalizeExtensions.cs
+++ b/src/Humanizer/OrdinalizeExtensions.cs
@@ -263,12 +263,13 @@ public static class OrdinalizeExtensions
 
         var formatting = GetOrdinalNumberFormatting(culture);
         if (formatting.NumberFormat.NegativeSign == NumberFormatInfo.InvariantInfo.NegativeSign &&
-            formatting.UsesInvariantDigits)
+            formatting.UsesInvariantDigits &&
+            formatting.NumberFormat.NumberNegativePattern == NumberFormatInfo.InvariantInfo.NumberNegativePattern)
         {
             return number.ToString(CultureInfo.InvariantCulture);
         }
 
-        return FormatNegativeOrdinalNumberString(number, formatting.NumberFormat.NegativeSign, formatting.NumberFormat);
+        return number.ToString(formatting.NumberFormat);
     }
 
     static OrdinalNumberFormatting GetDefaultOrdinalNumberFormatting(CultureInfo culture)
@@ -280,12 +281,6 @@ public static class OrdinalizeExtensions
 
         return OrdinalNumberFormattingCache.GetOrAdd(culture.Name, static cultureName =>
             CreateOrdinalNumberFormatting(CultureInfo.GetCultureInfo(cultureName)));
-    }
-
-    static string FormatNegativeOrdinalNumberString(int number, string negativeSign, NumberFormatInfo formattingNumberFormat)
-    {
-        var magnitude = number == int.MinValue ? (long)int.MaxValue + 1 : Math.Abs(number);
-        return negativeSign + magnitude.ToString(formattingNumberFormat);
     }
 
     static OrdinalNumberFormatting GetOrdinalNumberFormatting(CultureInfo culture)

--- a/src/Humanizer/OrdinalizeExtensions.cs
+++ b/src/Humanizer/OrdinalizeExtensions.cs
@@ -251,31 +251,45 @@ public static class OrdinalizeExtensions
 
     static string FormatOrdinalNumberString(int number, CultureInfo culture)
     {
+        var formattingNumberFormat = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(culture);
+        var usesInvariantDigits = UsesInvariantDigits(formattingNumberFormat);
+
         if (number >= 0)
         {
+            return usesInvariantDigits
+                ? number.ToString(CultureInfo.InvariantCulture)
+                : number.ToString(formattingNumberFormat);
+        }
+
+        if (formattingNumberFormat.NegativeSign == NumberFormatInfo.InvariantInfo.NegativeSign &&
+            usesInvariantDigits)
+        {
             return number.ToString(CultureInfo.InvariantCulture);
         }
 
-        if (LocaleNumberFormattingOverrides.TryGetNegativeSign(culture, out var negativeSign))
-        {
-            return FormatNegativeOrdinalNumberString(number, negativeSign!);
-        }
-
-        var cultureNegativeSign = culture.NumberFormat.NegativeSign;
-        return cultureNegativeSign == NumberFormatInfo.InvariantInfo.NegativeSign
-            ? number.ToString(CultureInfo.InvariantCulture)
-            : FormatNegativeOrdinalNumberString(number, cultureNegativeSign);
+        return FormatNegativeOrdinalNumberString(number, formattingNumberFormat.NegativeSign, formattingNumberFormat);
     }
 
-    static string FormatNegativeOrdinalNumberString(int number, string negativeSign)
+    static string FormatNegativeOrdinalNumberString(int number, string negativeSign, NumberFormatInfo formattingNumberFormat)
     {
-        if (negativeSign == NumberFormatInfo.InvariantInfo.NegativeSign)
-        {
-            return number.ToString(CultureInfo.InvariantCulture);
-        }
-
         var magnitude = number == int.MinValue ? (long)int.MaxValue + 1 : Math.Abs(number);
-        return negativeSign + magnitude.ToString(CultureInfo.InvariantCulture);
+        return negativeSign + magnitude.ToString(formattingNumberFormat);
+    }
+
+    static bool UsesInvariantDigits(NumberFormatInfo formattingNumberFormat)
+    {
+        var nativeDigits = formattingNumberFormat.NativeDigits;
+        return nativeDigits.Length == 10 &&
+               nativeDigits[0] == "0" &&
+               nativeDigits[1] == "1" &&
+               nativeDigits[2] == "2" &&
+               nativeDigits[3] == "3" &&
+               nativeDigits[4] == "4" &&
+               nativeDigits[5] == "5" &&
+               nativeDigits[6] == "6" &&
+               nativeDigits[7] == "7" &&
+               nativeDigits[8] == "8" &&
+               nativeDigits[9] == "9";
     }
 
     static int ParseOrdinalNumber(string numberString, CultureInfo culture) =>

--- a/src/Humanizer/OrdinalizeExtensions.cs
+++ b/src/Humanizer/OrdinalizeExtensions.cs
@@ -5,6 +5,8 @@ namespace Humanizer;
 /// </summary>
 public static class OrdinalizeExtensions
 {
+    static readonly ConcurrentDictionary<string, OrdinalNumberFormatting> OrdinalNumberFormattingCache = new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>
     /// Turns a number into an ordinal string used to denote the position in an ordered sequence such as 1st, 2nd, 3rd, 4th.
     /// </summary>
@@ -251,29 +253,62 @@ public static class OrdinalizeExtensions
 
     static string FormatOrdinalNumberString(int number, CultureInfo culture)
     {
-        var formattingNumberFormat = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(culture);
-        var usesInvariantDigits = UsesInvariantDigits(formattingNumberFormat);
-
         if (number >= 0)
         {
-            return usesInvariantDigits
+            var positiveFormatting = GetDefaultOrdinalNumberFormatting(culture);
+            return positiveFormatting.UsesInvariantDigits
                 ? number.ToString(CultureInfo.InvariantCulture)
-                : number.ToString(formattingNumberFormat);
+                : number.ToString(positiveFormatting.NumberFormat);
         }
 
-        if (formattingNumberFormat.NegativeSign == NumberFormatInfo.InvariantInfo.NegativeSign &&
-            usesInvariantDigits)
+        var formatting = GetOrdinalNumberFormatting(culture);
+        if (formatting.NumberFormat.NegativeSign == NumberFormatInfo.InvariantInfo.NegativeSign &&
+            formatting.UsesInvariantDigits)
         {
             return number.ToString(CultureInfo.InvariantCulture);
         }
 
-        return FormatNegativeOrdinalNumberString(number, formattingNumberFormat.NegativeSign, formattingNumberFormat);
+        return FormatNegativeOrdinalNumberString(number, formatting.NumberFormat.NegativeSign, formatting.NumberFormat);
+    }
+
+    static OrdinalNumberFormatting GetDefaultOrdinalNumberFormatting(CultureInfo culture)
+    {
+        if (string.IsNullOrEmpty(culture.Name))
+        {
+            return CreateOrdinalNumberFormatting(culture);
+        }
+
+        return OrdinalNumberFormattingCache.GetOrAdd(culture.Name, static cultureName =>
+            CreateOrdinalNumberFormatting(CultureInfo.GetCultureInfo(cultureName)));
     }
 
     static string FormatNegativeOrdinalNumberString(int number, string negativeSign, NumberFormatInfo formattingNumberFormat)
     {
         var magnitude = number == int.MinValue ? (long)int.MaxValue + 1 : Math.Abs(number);
         return negativeSign + magnitude.ToString(formattingNumberFormat);
+    }
+
+    static OrdinalNumberFormatting GetOrdinalNumberFormatting(CultureInfo culture)
+    {
+        if (string.IsNullOrEmpty(culture.Name))
+        {
+            return CreateOrdinalNumberFormatting(culture);
+        }
+
+        var formatting = GetDefaultOrdinalNumberFormatting(culture);
+        if (culture.NumberFormat.NegativeSign == formatting.CultureNegativeSign)
+        {
+            return formatting;
+        }
+
+        return CreateOrdinalNumberFormatting(culture);
+    }
+
+    static OrdinalNumberFormatting CreateOrdinalNumberFormatting(CultureInfo culture)
+    {
+        var cultureNegativeSign = culture.NumberFormat.NegativeSign;
+        var numberFormat = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(culture);
+        return new(numberFormat, cultureNegativeSign, UsesInvariantDigits(numberFormat));
     }
 
     static bool UsesInvariantDigits(NumberFormatInfo formattingNumberFormat)
@@ -291,6 +326,11 @@ public static class OrdinalizeExtensions
                nativeDigits[8] == "8" &&
                nativeDigits[9] == "9";
     }
+
+    readonly record struct OrdinalNumberFormatting(
+        NumberFormatInfo NumberFormat,
+        string CultureNegativeSign,
+        bool UsesInvariantDigits);
 
     static int ParseOrdinalNumber(string numberString, CultureInfo culture) =>
         int.Parse(numberString, culture);

--- a/src/Humanizer/OrdinalizeExtensions.cs
+++ b/src/Humanizer/OrdinalizeExtensions.cs
@@ -158,7 +158,7 @@ public static class OrdinalizeExtensions
     public static string Ordinalize(this int number, CultureInfo culture)
     {
         var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
-        return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(number.ToString(LocaleNumberFormattingOverrides.GetFormattingNumberFormat(resolvedCulture))));
+        return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)));
     }
 
     /// <summary>
@@ -178,7 +178,7 @@ public static class OrdinalizeExtensions
     public static string Ordinalize(this int number, CultureInfo culture, WordForm wordForm)
     {
         var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
-        return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(number.ToString(LocaleNumberFormattingOverrides.GetFormattingNumberFormat(resolvedCulture))), wordForm);
+        return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)), wordForm);
     }
 
     /// <summary>
@@ -223,7 +223,7 @@ public static class OrdinalizeExtensions
     public static string Ordinalize(this int number, GrammaticalGender gender, CultureInfo culture)
     {
         var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
-        return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(number.ToString(LocaleNumberFormattingOverrides.GetFormattingNumberFormat(resolvedCulture))), gender);
+        return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)), gender);
     }
 
     /// <summary>
@@ -246,7 +246,36 @@ public static class OrdinalizeExtensions
     public static string Ordinalize(this int number, GrammaticalGender gender, CultureInfo culture, WordForm wordForm)
     {
         var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
-        return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(number.ToString(LocaleNumberFormattingOverrides.GetFormattingNumberFormat(resolvedCulture))), gender, wordForm);
+        return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)), gender, wordForm);
+    }
+
+    static string FormatOrdinalNumberString(int number, CultureInfo culture)
+    {
+        if (number >= 0)
+        {
+            return number.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (LocaleNumberFormattingOverrides.TryGetNegativeSign(culture, out var negativeSign))
+        {
+            return FormatNegativeOrdinalNumberString(number, negativeSign!);
+        }
+
+        var cultureNegativeSign = culture.NumberFormat.NegativeSign;
+        return cultureNegativeSign == NumberFormatInfo.InvariantInfo.NegativeSign
+            ? number.ToString(CultureInfo.InvariantCulture)
+            : FormatNegativeOrdinalNumberString(number, cultureNegativeSign);
+    }
+
+    static string FormatNegativeOrdinalNumberString(int number, string negativeSign)
+    {
+        if (negativeSign == NumberFormatInfo.InvariantInfo.NegativeSign)
+        {
+            return number.ToString(CultureInfo.InvariantCulture);
+        }
+
+        var magnitude = number == int.MinValue ? (long)int.MaxValue + 1 : Math.Abs(number);
+        return negativeSign + magnitude.ToString(CultureInfo.InvariantCulture);
     }
 
     static int ParseOrdinalNumber(string numberString, CultureInfo culture) =>

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -265,9 +265,7 @@ public static partial class StringHumanizeExtensions
     {
         for (var i = 0; i < input.Length; i++)
         {
-            if ((input[i] == '-' || input[i] == '_') &&
-                ((i > 0 && char.IsWhiteSpace(input[i - 1])) ||
-                 (i + 1 < input.Length && char.IsWhiteSpace(input[i + 1]))))
+            if (IsSpacingSeparator(input[i]) && HasAdjacentWhitespace(input, i))
             {
                 return true;
             }
@@ -275,6 +273,13 @@ public static partial class StringHumanizeExtensions
 
         return false;
     }
+
+    static bool IsSpacingSeparator(char c) =>
+        c is '-' or '_';
+
+    static bool HasAdjacentWhitespace(string input, int index) =>
+        (index > 0 && char.IsWhiteSpace(input[index - 1])) ||
+        (index + 1 < input.Length && char.IsWhiteSpace(input[index + 1]));
 
     static bool IsAllUpper(string input, int index, int length)
     {

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -10,7 +10,6 @@ namespace Humanizer;
 public static partial class StringHumanizeExtensions
 {
     const string PascalCaseWordPartsPattern = @"(\p{Lu}?\p{Ll}+|[0-9]+\p{Ll}*|\p{Lu}+(?=\p{Lu}|[0-9]|\b)|\p{Lo}+)[,;]?";
-    const string FreestandingSpacingCharPattern = @"\s[-_]|[-_]\s";
 
 #if NET7_0_OR_GREATER
     [GeneratedRegex(PascalCaseWordPartsPattern, RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture)]
@@ -18,20 +17,12 @@ public static partial class StringHumanizeExtensions
 
     private static Regex PascalCaseWordPartsRegex() => PascalCaseWordPartsRegexGenerated();
 
-    [GeneratedRegex(FreestandingSpacingCharPattern)]
-    private static partial Regex FreestandingSpacingCharRegexGenerated();
-
-    private static Regex FreestandingSpacingCharRegex() => FreestandingSpacingCharRegexGenerated();
 #else
     private static readonly Regex PascalCaseWordPartsRegexField = new(
         PascalCaseWordPartsPattern,
         RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture | RegexOptions.Compiled);
 
     private static Regex PascalCaseWordPartsRegex() => PascalCaseWordPartsRegexField;
-
-    private static readonly Regex FreestandingSpacingCharRegexField = new(FreestandingSpacingCharPattern, RegexOptions.Compiled);
-
-    private static Regex FreestandingSpacingCharRegex() => FreestandingSpacingCharRegexField;
 #endif
 
     static string FromUnderscoreDashSeparatedWords(string input)
@@ -48,7 +39,7 @@ public static partial class StringHumanizeExtensions
 #endif
     }
 
-    static string FromPascalCase(string input)
+    static string FromPascalCaseRegex(string input)
     {
         var result = string.Join(" ", PascalCaseWordPartsRegex()
             .Matches(input)
@@ -71,6 +62,153 @@ public static partial class StringHumanizeExtensions
         return result.Length > 0
             ? Concat(char.ToUpper(result[0]), result.AsSpan(1, result.Length - 1))
             : result;
+    }
+
+    static string FromPascalCase(string input) =>
+        TryFromAsciiPascalCase(input, out var result)
+            ? result
+            : FromPascalCaseRegex(input);
+
+    static bool TryFromAsciiPascalCase(string input, [NotNullWhen(true)] out string? result)
+    {
+        result = null;
+        if (input.Length == 0)
+        {
+            result = "";
+            return true;
+        }
+
+        for (var i = 0; i < input.Length; i++)
+        {
+            if (input[i] > '\u007F' || (!IsAsciiLetterOrDigit(input[i]) && input[i] != ' '))
+            {
+                return false;
+            }
+        }
+
+        var textInfo = CultureInfo.CurrentCulture.TextInfo;
+        var buffer = new char[Math.Max(1, input.Length * 2)];
+        var pos = 0;
+        var wordCount = 0;
+        var containsSpace = false;
+        var allUpperOrSpace = true;
+
+        for (var i = 0; i < input.Length;)
+        {
+            if (input[i] == ' ')
+            {
+                i++;
+                continue;
+            }
+
+            var start = i;
+            var length = ReadAsciiWord(input, ref i);
+            if (length == 0)
+            {
+                return false;
+            }
+
+            if (wordCount > 0)
+            {
+                buffer[pos++] = ' ';
+                containsSpace = true;
+            }
+
+            var preserveUpper = IsAllUpper(input, start, length) &&
+                (length > 1 || (start > 0 && input[start - 1] == ' ') || input.AsSpan(start, length).SequenceEqual("I"));
+
+            for (var j = 0; j < length; j++)
+            {
+                var c = input[start + j];
+                var value = preserveUpper ? c : textInfo.ToLower(c);
+                buffer[pos++] = value;
+                if (value != ' ' && !char.IsUpper(value))
+                {
+                    allUpperOrSpace = false;
+                }
+            }
+
+            wordCount++;
+        }
+
+        if (pos == 0)
+        {
+            result = "";
+            return true;
+        }
+
+        if (allUpperOrSpace && containsSpace)
+        {
+            for (var i = 0; i < pos; i++)
+            {
+                buffer[i] = textInfo.ToLower(buffer[i]);
+            }
+        }
+
+        buffer[0] = textInfo.ToUpper(buffer[0]);
+        result = new(buffer, 0, pos);
+        return true;
+    }
+
+    static int ReadAsciiWord(string input, ref int index)
+    {
+        var start = index;
+        var c = input[index];
+        if (IsAsciiDigit(c))
+        {
+            index++;
+            while (index < input.Length && IsAsciiDigit(input[index]))
+            {
+                index++;
+            }
+
+            while (index < input.Length && IsAsciiLower(input[index]))
+            {
+                index++;
+            }
+
+            return index - start;
+        }
+
+        if (IsAsciiLower(c))
+        {
+            index++;
+            while (index < input.Length && IsAsciiLower(input[index]))
+            {
+                index++;
+            }
+
+            return index - start;
+        }
+
+        if (!IsAsciiUpper(c))
+        {
+            return 0;
+        }
+
+        var upperStart = index;
+        index++;
+        while (index < input.Length && IsAsciiUpper(input[index]))
+        {
+            index++;
+        }
+
+        if (index < input.Length && IsAsciiLower(input[index]))
+        {
+            if (index - upperStart > 1)
+            {
+                index--;
+                return index - start;
+            }
+
+            index++;
+            while (index < input.Length && IsAsciiLower(input[index]))
+            {
+                index++;
+            }
+        }
+
+        return index - start;
     }
 
     /// <summary>
@@ -103,14 +241,14 @@ public static partial class StringHumanizeExtensions
     public static string Humanize(this string input)
     {
         // if input is all capitals (e.g. an acronym) then return it without change
-        if (input.All(char.IsUpper))
+        if (IsAllUpper(input, 0, input.Length))
         {
             return input;
         }
 
         // if input contains a dash or underscore which precedes or follows a space (or both, e.g. freestanding)
         // remove the dash/underscore and run it through FromPascalCase
-        if (FreestandingSpacingCharRegex().IsMatch(input))
+        if (HasFreestandingSpacingChar(input))
         {
             return FromPascalCase(FromUnderscoreDashSeparatedWords(input));
         }
@@ -122,6 +260,47 @@ public static partial class StringHumanizeExtensions
 
         return FromPascalCase(input);
     }
+
+    static bool HasFreestandingSpacingChar(string input)
+    {
+        for (var i = 0; i < input.Length; i++)
+        {
+            if ((input[i] == '-' || input[i] == '_') &&
+                ((i > 0 && char.IsWhiteSpace(input[i - 1])) ||
+                 (i + 1 < input.Length && char.IsWhiteSpace(input[i + 1]))))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool IsAllUpper(string input, int index, int length)
+    {
+        var end = index + length;
+        for (var i = index; i < end; i++)
+        {
+            if (!char.IsUpper(input[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    static bool IsAsciiLetterOrDigit(char c) =>
+        IsAsciiUpper(c) || IsAsciiLower(c) || IsAsciiDigit(c);
+
+    static bool IsAsciiUpper(char c) =>
+        c is >= 'A' and <= 'Z';
+
+    static bool IsAsciiLower(char c) =>
+        c is >= 'a' and <= 'z';
+
+    static bool IsAsciiDigit(char c) =>
+        c is >= '0' and <= '9';
 
     /// <summary>
     /// Transforms a string into a human-readable format and applies the specified letter casing.

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -35,6 +35,11 @@ public static class TimeSpanHumanizeExtensions
     /// <param name="toWords">Uses words instead of numbers if true. E.g. one day.</param>
     public static string Humanize(this TimeSpan timeSpan, int precision, bool countEmptyUnits, CultureInfo? culture = null, TimeUnit maxUnit = TimeUnit.Week, TimeUnit minUnit = TimeUnit.Millisecond, string? collectionSeparator = ", ", bool toWords = false)
     {
+        if (precision == 1 && !countEmptyUnits)
+        {
+            return HumanizeSinglePart(timeSpan, culture, maxUnit, minUnit, toWords);
+        }
+
         var timeParts = CreateTheTimePartsWithUpperAndLowerLimits(timeSpan, culture, maxUnit, minUnit, toWords);
         timeParts = SetPrecisionOfTimeSpan(timeParts, precision, countEmptyUnits);
 
@@ -185,6 +190,23 @@ public static class TimeSpanHumanizeExtensions
         amountOfTimeUnits != 0
             ? cultureFormatter.TimeSpanHumanize(timeUnitType, Math.Abs(amountOfTimeUnits), toWords)
             : null;
+
+    static string HumanizeSinglePart(TimeSpan timeSpan, CultureInfo? culture, TimeUnit maxUnit, TimeUnit minUnit, bool toWords)
+    {
+        var cultureFormatter = Configurator.GetFormatter(culture);
+        foreach (var timeUnit in TimeUnits)
+        {
+            var timePart = GetTimeUnitPart(timeUnit, timeSpan, maxUnit, minUnit, cultureFormatter, toWords);
+            if (timePart is not null)
+            {
+                return timePart;
+            }
+        }
+
+        return toWords
+            ? cultureFormatter.TimeSpanHumanize_Zero()
+            : cultureFormatter.TimeSpanHumanize(minUnit, 0);
+    }
 
     static List<string?> CreateTimePartsWithNoTimeValue(string noTimeValue) =>
         [noTimeValue];

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -40,8 +40,7 @@ public static class TimeSpanHumanizeExtensions
             return HumanizeSinglePart(timeSpan, culture, maxUnit, minUnit, toWords);
         }
 
-        var timeParts = CreateTheTimePartsWithUpperAndLowerLimits(timeSpan, culture, maxUnit, minUnit, toWords);
-        timeParts = SetPrecisionOfTimeSpan(timeParts, precision, countEmptyUnits);
+        var timeParts = CreatePrecisionLimitedTimeParts(timeSpan, culture, maxUnit, minUnit, precision, countEmptyUnits, toWords);
 
         return ConcatenateTimeSpanParts(timeParts, culture, collectionSeparator);
     }
@@ -79,29 +78,64 @@ public static class TimeSpanHumanizeExtensions
         return string.Format(ageFormat, value);
     }
 
-    static List<string?> CreateTheTimePartsWithUpperAndLowerLimits(TimeSpan timespan, CultureInfo? culture, TimeUnit maxUnit, TimeUnit minUnit, bool toWords = false)
+    static List<string> CreatePrecisionLimitedTimeParts(
+        TimeSpan timespan,
+        CultureInfo? culture,
+        TimeUnit maxUnit,
+        TimeUnit minUnit,
+        int precision,
+        bool countEmptyUnits,
+        bool toWords = false)
     {
+        if (precision <= 0)
+        {
+            return [];
+        }
+
         var cultureFormatter = Configurator.GetFormatter(culture);
         var firstValueFound = false;
-        var timeParts = new List<string?>();
+        var countedUnits = 0;
+        var timeParts = new List<string>(Math.Min(precision, TimeUnits.Length));
 
         foreach (var timeUnit in TimeUnits)
         {
             var timePart = GetTimeUnitPart(timeUnit, timespan, maxUnit, minUnit, cultureFormatter, toWords);
 
-            if (timePart != null || firstValueFound)
+            if (timePart == null && !firstValueFound)
             {
-                firstValueFound = true;
+                continue;
+            }
+
+            firstValueFound = true;
+            if (countEmptyUnits)
+            {
+                countedUnits++;
+                if (timePart != null)
+                {
+                    timeParts.Add(timePart);
+                }
+
+                if (countedUnits >= precision)
+                {
+                    return timeParts;
+                }
+            }
+            else if (timePart != null)
+            {
                 timeParts.Add(timePart);
+                if (timeParts.Count >= precision)
+                {
+                    return timeParts;
+                }
             }
         }
 
-        if (IsContainingOnlyNullValue(timeParts))
+        if (timeParts.Count == 0)
         {
             var noTimeValueCultureFormatted = toWords
                 ? cultureFormatter.TimeSpanHumanize_Zero()
                 : cultureFormatter.TimeSpanHumanize(minUnit, 0);
-            timeParts = CreateTimePartsWithNoTimeValue(noTimeValueCultureFormatted);
+            timeParts.Add(noTimeValueCultureFormatted);
         }
 
         return timeParts;
@@ -208,29 +242,7 @@ public static class TimeSpanHumanizeExtensions
             : cultureFormatter.TimeSpanHumanize(minUnit, 0);
     }
 
-    static List<string?> CreateTimePartsWithNoTimeValue(string noTimeValue) =>
-        [noTimeValue];
-
-    static bool IsContainingOnlyNullValue(IEnumerable<string?> timeParts) =>
-        !timeParts.Any(x => x != null);
-
-    static List<string?> SetPrecisionOfTimeSpan(IEnumerable<string?> timeParts, int precision, bool countEmptyUnits)
-    {
-        if (!countEmptyUnits)
-        {
-            timeParts = timeParts.Where(x => x != null);
-        }
-
-        timeParts = timeParts.Take(precision);
-        if (countEmptyUnits)
-        {
-            timeParts = timeParts.Where(x => x != null);
-        }
-
-        return [.. timeParts];
-    }
-
-    static string ConcatenateTimeSpanParts(IEnumerable<string?> timeSpanParts, CultureInfo? culture, string? collectionSeparator)
+    static string ConcatenateTimeSpanParts(List<string> timeSpanParts, CultureInfo? culture, string? collectionSeparator)
     {
         if (collectionSeparator == null)
         {

--- a/src/Humanizer/Transformer/To.cs
+++ b/src/Humanizer/Transformer/To.cs
@@ -6,22 +6,10 @@ namespace Humanizer;
 public static class To
 {
     /// <summary>
-    /// Transforms a string using the provided transformer.
-    /// </summary>
-    public static string Transform(this string input, IStringTransformer transformer) =>
-        transformer.Transform(input);
-
-    /// <summary>
     /// Transforms a string using the provided transformers. Transformations are applied in the provided order.
     /// </summary>
     public static string Transform(this string input, params IStringTransformer[] transformers) =>
         transformers.Aggregate(input, (current, stringTransformer) => stringTransformer.Transform(current));
-
-    /// <summary>
-    /// Transforms a string using the provided transformer and culture.
-    /// </summary>
-    public static string Transform(this string input, CultureInfo culture, ICulturedStringTransformer transformer) =>
-        transformer.Transform(input, culture);
 
     /// <summary>
     /// Transforms a string using the provided transformers. Transformations are applied in the provided order.

--- a/src/Humanizer/Transformer/To.cs
+++ b/src/Humanizer/Transformer/To.cs
@@ -6,10 +6,22 @@ namespace Humanizer;
 public static class To
 {
     /// <summary>
+    /// Transforms a string using the provided transformer.
+    /// </summary>
+    public static string Transform(this string input, IStringTransformer transformer) =>
+        transformer.Transform(input);
+
+    /// <summary>
     /// Transforms a string using the provided transformers. Transformations are applied in the provided order.
     /// </summary>
     public static string Transform(this string input, params IStringTransformer[] transformers) =>
         transformers.Aggregate(input, (current, stringTransformer) => stringTransformer.Transform(current));
+
+    /// <summary>
+    /// Transforms a string using the provided transformer and culture.
+    /// </summary>
+    public static string Transform(this string input, CultureInfo culture, ICulturedStringTransformer transformer) =>
+        transformer.Transform(input, culture);
 
     /// <summary>
     /// Transforms a string using the provided transformers. Transformations are applied in the provided order.

--- a/src/Humanizer/Transformer/ToTitleCase.cs
+++ b/src/Humanizer/Transformer/ToTitleCase.cs
@@ -41,11 +41,39 @@ partial class ToTitleCase : ICulturedStringTransformer
 
     static void OverwriteLowercase(StringBuilder builder, string input, int index, int length, TextInfo textInfo)
     {
+        if (ContainsNonAscii(input, index, length))
+        {
+            Overwrite(builder, index, textInfo.ToLower(input.Substring(index, length)));
+            return;
+        }
+
         var end = index + length;
         for (var i = index; i < end; i++)
         {
             builder[i] = textInfo.ToLower(input[i]);
         }
+    }
+
+    static void Overwrite(StringBuilder builder, int index, string replacement)
+    {
+        for (var i = 0; i < replacement.Length; i++)
+        {
+            builder[index + i] = replacement[i];
+        }
+    }
+
+    static bool ContainsNonAscii(string input, int index, int length)
+    {
+        var end = index + length;
+        for (var i = index; i < end; i++)
+        {
+            if (input[i] > '\u007F')
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     static bool AllCapitals(string input, int index, int length)

--- a/src/Humanizer/Transformer/ToTitleCase.cs
+++ b/src/Humanizer/Transformer/ToTitleCase.cs
@@ -6,13 +6,6 @@ partial class ToTitleCase : ICulturedStringTransformer
         Transform(input, CultureInfo.CurrentCulture);
 
     private const string WordPattern = @"(\w|[^\u0000-\u007F])+'?\w*";
-    static readonly FrozenSet<string> MinorWords =
-        new[]
-        {
-            "a", "an", "the",
-            "and", "as", "but", "if", "nor", "or", "so", "yet",
-            "at", "by", "for", "in", "of", "off", "on", "to", "up", "via"
-        }.ToFrozenSet(StringComparer.Ordinal);
 
 #if NET7_0_OR_GREATER
     [GeneratedRegex(WordPattern)]
@@ -33,33 +26,34 @@ partial class ToTitleCase : ICulturedStringTransformer
         for (var i = 0; i < matches.Count; i++)
         {
             var word = matches[i];
-            var value = word.Value;
-            if (AllCapitals(value) || (i > 0 && IsArticleOrConjunctionOrPreposition(value)))
+            if (AllCapitals(input, word.Index, word.Length) ||
+                (i > 0 && IsArticleOrConjunctionOrPreposition(input.AsSpan(word.Index, word.Length))))
             {
                 continue;
             }
 
-            builder[word.Index] = textInfo.ToUpper(value[0]);
-            Overwrite(builder, word.Index + 1, textInfo.ToLower(value[1..]));
+            builder[word.Index] = textInfo.ToUpper(input[word.Index]);
+            OverwriteLowercase(builder, input, word.Index + 1, word.Length - 1, textInfo);
         }
 
         return builder.ToString();
     }
 
-    static void Overwrite(StringBuilder builder, int index, string replacement)
+    static void OverwriteLowercase(StringBuilder builder, string input, int index, int length, TextInfo textInfo)
     {
-        // Directly overwrite characters instead of Remove + Insert
-        for (var i = 0; i < replacement.Length; i++)
+        var end = index + length;
+        for (var i = index; i < end; i++)
         {
-            builder[index + i] = replacement[i];
+            builder[i] = textInfo.ToLower(input[i]);
         }
     }
 
-    static bool AllCapitals(string input)
+    static bool AllCapitals(string input, int index, int length)
     {
-        foreach (var ch in input)
+        var end = index + length;
+        for (var i = index; i < end; i++)
         {
-            if (!char.IsUpper(ch))
+            if (!char.IsUpper(input[i]))
             {
                 return false;
             }
@@ -68,6 +62,11 @@ partial class ToTitleCase : ICulturedStringTransformer
         return true;
     }
 
-    private static bool IsArticleOrConjunctionOrPreposition(string word) =>
-        MinorWords.Contains(word);
+    private static bool IsArticleOrConjunctionOrPreposition(ReadOnlySpan<char> word) =>
+        word switch
+        {
+            "a" or "an" or "as" or "at" or "by" or "if" or "in" or "of" or "on" or "or" or "so" or "to" or "up" => true,
+            "and" or "but" or "for" or "nor" or "off" or "the" or "via" or "yet" => true,
+            _ => false
+        };
 }

--- a/src/Humanizer/Transformer/ToTitleCase.cs
+++ b/src/Humanizer/Transformer/ToTitleCase.cs
@@ -20,6 +20,89 @@ partial class ToTitleCase : ICulturedStringTransformer
 
     public string Transform(string input, CultureInfo culture)
     {
+        if (TryTransformAscii(input, culture, out var transformed))
+        {
+            return transformed;
+        }
+
+        return TransformWithRegex(input, culture);
+    }
+
+    static bool TryTransformAscii(string input, CultureInfo culture, [NotNullWhen(true)] out string? result)
+    {
+        result = null;
+        if (ContainsNonAscii(input, 0, input.Length))
+        {
+            return false;
+        }
+
+        char[]? buffer = null;
+        var textInfo = culture.TextInfo;
+        var wordIndex = 0;
+        for (var i = 0; i < input.Length;)
+        {
+            if (!IsAsciiWord(input[i]))
+            {
+                i++;
+                continue;
+            }
+
+            var wordStart = i;
+            i++;
+            while (i < input.Length && IsAsciiWord(input[i]))
+            {
+                i++;
+            }
+
+            if (i < input.Length && input[i] == '\'')
+            {
+                i++;
+                while (i < input.Length && IsAsciiWord(input[i]))
+                {
+                    i++;
+                }
+            }
+
+            var wordLength = i - wordStart;
+            if (AllCapitals(input, wordStart, wordLength) ||
+                (wordIndex > 0 && IsArticleOrConjunctionOrPreposition(input.AsSpan(wordStart, wordLength))))
+            {
+                wordIndex++;
+                continue;
+            }
+
+            SetCharIfChanged(input, ref buffer, wordStart, textInfo.ToUpper(input[wordStart]));
+            for (var j = wordStart + 1; j < wordStart + wordLength; j++)
+            {
+                SetCharIfChanged(input, ref buffer, j, textInfo.ToLower(input[j]));
+            }
+
+            wordIndex++;
+        }
+
+        result = buffer is null ? input : new(buffer);
+        return true;
+    }
+
+    static void SetCharIfChanged(string input, ref char[]? buffer, int index, char value)
+    {
+        if (input[index] == value)
+        {
+            return;
+        }
+
+        buffer ??= input.ToCharArray();
+        buffer[index] = value;
+    }
+
+    static bool IsAsciiWord(char c) =>
+        c is >= 'a' and <= 'z' ||
+        c is >= 'A' and <= 'Z' ||
+        c is >= '0' and <= '9' ||
+        c == '_';
+
+    static string TransformWithRegex(string input, CultureInfo culture)
+    {
         var matches = WordRegex().Matches(input);
         var builder = new StringBuilder(input);
         var textInfo = culture.TextInfo;

--- a/src/Humanizer/Transformer/ToTitleCase.cs
+++ b/src/Humanizer/Transformer/ToTitleCase.cs
@@ -31,17 +31,19 @@ partial class ToTitleCase : ICulturedStringTransformer
     static bool TryTransformAscii(string input, CultureInfo culture, [NotNullWhen(true)] out string? result)
     {
         result = null;
-        if (ContainsNonAscii(input, 0, input.Length))
-        {
-            return false;
-        }
-
         char[]? buffer = null;
         var textInfo = culture.TextInfo;
+        var useCultureSensitiveCasing = UsesCultureSensitiveAsciiCasing(culture);
         var wordIndex = 0;
         for (var i = 0; i < input.Length;)
         {
-            if (!IsAsciiWord(input[i]))
+            var current = input[i];
+            if (current > '\u007F')
+            {
+                return false;
+            }
+
+            if (!IsAsciiWord(current))
             {
                 i++;
                 continue;
@@ -49,32 +51,54 @@ partial class ToTitleCase : ICulturedStringTransformer
 
             var wordStart = i;
             i++;
-            while (i < input.Length && IsAsciiWord(input[i]))
+            while (i < input.Length)
             {
+                current = input[i];
+                if (current > '\u007F')
+                {
+                    return false;
+                }
+
+                if (!IsAsciiWord(current))
+                {
+                    break;
+                }
+
                 i++;
             }
 
             if (i < input.Length && input[i] == '\'')
             {
                 i++;
-                while (i < input.Length && IsAsciiWord(input[i]))
+                while (i < input.Length)
                 {
+                    current = input[i];
+                    if (current > '\u007F')
+                    {
+                        return false;
+                    }
+
+                    if (!IsAsciiWord(current))
+                    {
+                        break;
+                    }
+
                     i++;
                 }
             }
 
             var wordLength = i - wordStart;
-            if (AllCapitals(input, wordStart, wordLength) ||
+            if (AllAsciiCapitals(input, wordStart, wordLength) ||
                 (wordIndex > 0 && IsArticleOrConjunctionOrPreposition(input.AsSpan(wordStart, wordLength))))
             {
                 wordIndex++;
                 continue;
             }
 
-            SetCharIfChanged(input, ref buffer, wordStart, textInfo.ToUpper(input[wordStart]));
+            SetCharIfChanged(input, ref buffer, wordStart, ToUpperAscii(input[wordStart], textInfo, useCultureSensitiveCasing));
             for (var j = wordStart + 1; j < wordStart + wordLength; j++)
             {
-                SetCharIfChanged(input, ref buffer, j, textInfo.ToLower(input[j]));
+                SetCharIfChanged(input, ref buffer, j, ToLowerAscii(input[j], textInfo, useCultureSensitiveCasing));
             }
 
             wordIndex++;
@@ -100,6 +124,24 @@ partial class ToTitleCase : ICulturedStringTransformer
         c is >= 'A' and <= 'Z' ||
         c is >= '0' and <= '9' ||
         c == '_';
+
+    static char ToUpperAscii(char c, TextInfo textInfo, bool useCultureSensitiveCasing) =>
+        useCultureSensitiveCasing
+            ? textInfo.ToUpper(c)
+            : c is >= 'a' and <= 'z'
+                ? (char)(c - ('a' - 'A'))
+                : c;
+
+    static char ToLowerAscii(char c, TextInfo textInfo, bool useCultureSensitiveCasing) =>
+        useCultureSensitiveCasing
+            ? textInfo.ToLower(c)
+            : c is >= 'A' and <= 'Z'
+                ? (char)(c + ('a' - 'A'))
+                : c;
+
+    static bool UsesCultureSensitiveAsciiCasing(CultureInfo culture) =>
+        culture.Name.StartsWith("tr", StringComparison.OrdinalIgnoreCase) ||
+        culture.Name.StartsWith("az", StringComparison.OrdinalIgnoreCase);
 
     static string TransformWithRegex(string input, CultureInfo culture)
     {
@@ -165,6 +207,20 @@ partial class ToTitleCase : ICulturedStringTransformer
         for (var i = index; i < end; i++)
         {
             if (!char.IsUpper(input[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    static bool AllAsciiCapitals(string input, int index, int length)
+    {
+        var end = index + length;
+        for (var i = index; i < end; i++)
+        {
+            if (input[i] is not (>= 'A' and <= 'Z'))
             {
                 return false;
             }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -1890,7 +1890,9 @@ namespace Humanizer
         public static Humanizer.ICulturedStringTransformer SentenceCase { get; }
         public static Humanizer.ICulturedStringTransformer TitleCase { get; }
         public static Humanizer.ICulturedStringTransformer UpperCase { get; }
+        public static string Transform(this string input, Humanizer.IStringTransformer transformer) { }
         public static string Transform(this string input, params Humanizer.IStringTransformer[] transformers) { }
+        public static string Transform(this string input, System.Globalization.CultureInfo culture, Humanizer.ICulturedStringTransformer transformer) { }
         public static string Transform(this string input, System.Globalization.CultureInfo culture, params Humanizer.ICulturedStringTransformer[] transformers) { }
     }
     public static class ToQuantityExtensions

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -1890,9 +1890,7 @@ namespace Humanizer
         public static Humanizer.ICulturedStringTransformer SentenceCase { get; }
         public static Humanizer.ICulturedStringTransformer TitleCase { get; }
         public static Humanizer.ICulturedStringTransformer UpperCase { get; }
-        public static string Transform(this string input, Humanizer.IStringTransformer transformer) { }
         public static string Transform(this string input, params Humanizer.IStringTransformer[] transformers) { }
-        public static string Transform(this string input, System.Globalization.CultureInfo culture, Humanizer.ICulturedStringTransformer transformer) { }
         public static string Transform(this string input, System.Globalization.CultureInfo culture, params Humanizer.ICulturedStringTransformer[] transformers) { }
     }
     public static class ToQuantityExtensions

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -1890,7 +1890,9 @@ namespace Humanizer
         public static Humanizer.ICulturedStringTransformer SentenceCase { get; }
         public static Humanizer.ICulturedStringTransformer TitleCase { get; }
         public static Humanizer.ICulturedStringTransformer UpperCase { get; }
+        public static string Transform(this string input, Humanizer.IStringTransformer transformer) { }
         public static string Transform(this string input, params Humanizer.IStringTransformer[] transformers) { }
+        public static string Transform(this string input, System.Globalization.CultureInfo culture, Humanizer.ICulturedStringTransformer transformer) { }
         public static string Transform(this string input, System.Globalization.CultureInfo culture, params Humanizer.ICulturedStringTransformer[] transformers) { }
     }
     public static class ToQuantityExtensions

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -1890,9 +1890,7 @@ namespace Humanizer
         public static Humanizer.ICulturedStringTransformer SentenceCase { get; }
         public static Humanizer.ICulturedStringTransformer TitleCase { get; }
         public static Humanizer.ICulturedStringTransformer UpperCase { get; }
-        public static string Transform(this string input, Humanizer.IStringTransformer transformer) { }
         public static string Transform(this string input, params Humanizer.IStringTransformer[] transformers) { }
-        public static string Transform(this string input, System.Globalization.CultureInfo culture, Humanizer.ICulturedStringTransformer transformer) { }
         public static string Transform(this string input, System.Globalization.CultureInfo culture, params Humanizer.ICulturedStringTransformer[] transformers) { }
     }
     public static class ToQuantityExtensions

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -1889,7 +1889,9 @@ namespace Humanizer
         public static Humanizer.ICulturedStringTransformer SentenceCase { get; }
         public static Humanizer.ICulturedStringTransformer TitleCase { get; }
         public static Humanizer.ICulturedStringTransformer UpperCase { get; }
+        public static string Transform(this string input, Humanizer.IStringTransformer transformer) { }
         public static string Transform(this string input, params Humanizer.IStringTransformer[] transformers) { }
+        public static string Transform(this string input, System.Globalization.CultureInfo culture, Humanizer.ICulturedStringTransformer transformer) { }
         public static string Transform(this string input, System.Globalization.CultureInfo culture, params Humanizer.ICulturedStringTransformer[] transformers) { }
     }
     public static class ToQuantityExtensions

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -1889,9 +1889,7 @@ namespace Humanizer
         public static Humanizer.ICulturedStringTransformer SentenceCase { get; }
         public static Humanizer.ICulturedStringTransformer TitleCase { get; }
         public static Humanizer.ICulturedStringTransformer UpperCase { get; }
-        public static string Transform(this string input, Humanizer.IStringTransformer transformer) { }
         public static string Transform(this string input, params Humanizer.IStringTransformer[] transformers) { }
-        public static string Transform(this string input, System.Globalization.CultureInfo culture, Humanizer.ICulturedStringTransformer transformer) { }
         public static string Transform(this string input, System.Globalization.CultureInfo culture, params Humanizer.ICulturedStringTransformer[] transformers) { }
     }
     public static class ToQuantityExtensions

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -1225,7 +1225,9 @@ namespace Humanizer
         public static Humanizer.ICulturedStringTransformer SentenceCase { get; }
         public static Humanizer.ICulturedStringTransformer TitleCase { get; }
         public static Humanizer.ICulturedStringTransformer UpperCase { get; }
+        public static string Transform(this string input, Humanizer.IStringTransformer transformer) { }
         public static string Transform(this string input, params Humanizer.IStringTransformer[] transformers) { }
+        public static string Transform(this string input, System.Globalization.CultureInfo culture, Humanizer.ICulturedStringTransformer transformer) { }
         public static string Transform(this string input, System.Globalization.CultureInfo culture, params Humanizer.ICulturedStringTransformer[] transformers) { }
     }
     public static class ToQuantityExtensions

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -1225,9 +1225,7 @@ namespace Humanizer
         public static Humanizer.ICulturedStringTransformer SentenceCase { get; }
         public static Humanizer.ICulturedStringTransformer TitleCase { get; }
         public static Humanizer.ICulturedStringTransformer UpperCase { get; }
-        public static string Transform(this string input, Humanizer.IStringTransformer transformer) { }
         public static string Transform(this string input, params Humanizer.IStringTransformer[] transformers) { }
-        public static string Transform(this string input, System.Globalization.CultureInfo culture, Humanizer.ICulturedStringTransformer transformer) { }
         public static string Transform(this string input, System.Globalization.CultureInfo culture, params Humanizer.ICulturedStringTransformer[] transformers) { }
     }
     public static class ToQuantityExtensions

--- a/tests/Humanizer.Tests/ArticlePrefixSortTests.cs
+++ b/tests/Humanizer.Tests/ArticlePrefixSortTests.cs
@@ -14,6 +14,7 @@ public class ArticlePrefixSortTests
     [InlineData("An Æon", "Æon An")]
     [InlineData("The _underscore", "_underscore The")]
     [InlineData("The 7th Seal", "7th Seal The")]
+    [InlineData("The Ⅻ Monkeys", "The Ⅻ Monkeys")]
     [InlineData("The Theater!", "Theater! The")]
     [InlineData("A  Theater", "A  Theater")]
     [InlineData("The\tTheater", "The\tTheater")]

--- a/tests/Humanizer.Tests/ArticlePrefixSortTests.cs
+++ b/tests/Humanizer.Tests/ArticlePrefixSortTests.cs
@@ -9,6 +9,19 @@ public class ArticlePrefixSortTests
     public void SortStringArrayIgnoringArticlePrefixes(string[] input, string[] expectedOutput) =>
         Assert.Equal(expectedOutput, EnglishArticle.PrependArticleSuffix(EnglishArticle.AppendArticlePrefix(input)));
 
+    [Theory]
+    [InlineData("The Éclair", "Éclair The")]
+    [InlineData("An Æon", "Æon An")]
+    [InlineData("The _underscore", "_underscore The")]
+    [InlineData("The 7th Seal", "7th Seal The")]
+    [InlineData("The Theater!", "Theater! The")]
+    [InlineData("A  Theater", "A  Theater")]
+    [InlineData("The\tTheater", "The\tTheater")]
+    [InlineData("Theory", "Theory")]
+    [InlineData("An!", "An!")]
+    public void AppendArticlePrefixPreservesRegexEquivalentEdges(string input, string expected) =>
+        Assert.Equal([expected], EnglishArticle.AppendArticlePrefix([input]));
+
     [Fact]
     public void An_Empty_String_Array_Throws_ArgumentOutOfRangeException()
     {

--- a/tests/Humanizer.Tests/ArticlePrefixSortTests.cs
+++ b/tests/Humanizer.Tests/ArticlePrefixSortTests.cs
@@ -15,6 +15,8 @@ public class ArticlePrefixSortTests
     [InlineData("The _underscore", "_underscore The")]
     [InlineData("The 7th Seal", "7th Seal The")]
     [InlineData("The Ⅻ Monkeys", "The Ⅻ Monkeys")]
+    [InlineData("The \u200Cjoiner", "\u200Cjoiner The")]
+    [InlineData("The \u200Djoiner", "\u200Djoiner The")]
     [InlineData("The Theater!", "Theater! The")]
     [InlineData("A  Theater", "A  Theater")]
     [InlineData("The\tTheater", "The\tTheater")]

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -760,6 +760,7 @@ public class CoverageGapTests
         Assert.Equal("one", TokenMapWordsToNumberNormalizer.Normalize(" one ", TokenMapNormalizationProfile.LowercaseRemovePeriods));
         Assert.Equal("one two", TokenMapWordsToNumberNormalizer.Normalize("One,\tTwo.", TokenMapNormalizationProfile.LowercaseRemovePeriods));
         Assert.Equal("thirty four", TokenMapWordsToNumberNormalizer.Normalize("thirty-four", TokenMapNormalizationProfile.LowercaseRemovePeriods));
+        Assert.Equal("one two", TokenMapWordsToNumberNormalizer.Normalize("one--two", TokenMapNormalizationProfile.LowercaseRemovePeriods));
         Assert.Equal("one two", TokenMapWordsToNumberNormalizer.Normalize("one- two", TokenMapNormalizationProfile.LowercaseRemovePeriods));
         Assert.Equal("onetwo", TokenMapWordsToNumberNormalizer.Normalize("one,two", TokenMapNormalizationProfile.LowercaseRemovePeriods));
         Assert.Equal("one two", TokenMapWordsToNumberNormalizer.Normalize("one  two", TokenMapNormalizationProfile.LowercaseRemovePeriods));
@@ -768,6 +769,7 @@ public class CoverageGapTests
         Assert.Equal(string.Empty, TokenMapWordsToNumberNormalizer.Normalize("", TokenMapNormalizationProfile.LowercaseReplacePeriodsWithSpaces));
         Assert.Equal("one", TokenMapWordsToNumberNormalizer.Normalize(" one ", TokenMapNormalizationProfile.LowercaseReplacePeriodsWithSpaces));
         Assert.Equal("one two", TokenMapWordsToNumberNormalizer.Normalize("One,.\tTwo-", TokenMapNormalizationProfile.LowercaseReplacePeriodsWithSpaces));
+        Assert.Equal("one two", TokenMapWordsToNumberNormalizer.Normalize("one--two", TokenMapNormalizationProfile.LowercaseReplacePeriodsWithSpaces));
         Assert.Equal("onetwo", TokenMapWordsToNumberNormalizer.Normalize("one,two", TokenMapNormalizationProfile.LowercaseReplacePeriodsWithSpaces));
         Assert.Equal("one two", TokenMapWordsToNumberNormalizer.Normalize("one  two", TokenMapNormalizationProfile.LowercaseReplacePeriodsWithSpaces));
         Assert.Equal("one two", TokenMapWordsToNumberNormalizer.Normalize("one\ttwo", TokenMapNormalizationProfile.LowercaseReplacePeriodsWithSpaces));

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -759,6 +759,8 @@ public class CoverageGapTests
         Assert.Equal(string.Empty, TokenMapWordsToNumberNormalizer.Normalize(" ", TokenMapNormalizationProfile.LowercaseRemovePeriods));
         Assert.Equal("one", TokenMapWordsToNumberNormalizer.Normalize(" one ", TokenMapNormalizationProfile.LowercaseRemovePeriods));
         Assert.Equal("one two", TokenMapWordsToNumberNormalizer.Normalize("One,\tTwo.", TokenMapNormalizationProfile.LowercaseRemovePeriods));
+        Assert.Equal("thirty four", TokenMapWordsToNumberNormalizer.Normalize("thirty-four", TokenMapNormalizationProfile.LowercaseRemovePeriods));
+        Assert.Equal("one two", TokenMapWordsToNumberNormalizer.Normalize("one- two", TokenMapNormalizationProfile.LowercaseRemovePeriods));
         Assert.Equal("onetwo", TokenMapWordsToNumberNormalizer.Normalize("one,two", TokenMapNormalizationProfile.LowercaseRemovePeriods));
         Assert.Equal("one two", TokenMapWordsToNumberNormalizer.Normalize("one  two", TokenMapNormalizationProfile.LowercaseRemovePeriods));
         Assert.Equal("one two", TokenMapWordsToNumberNormalizer.Normalize("one\ttwo", TokenMapNormalizationProfile.LowercaseRemovePeriods));

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -124,6 +124,11 @@ public class InflectorTests
     public void Pascalize(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Pascalize());
 
+    [Theory, UseCulture("tr-TR")]
+    [InlineData("istanbul_input", "İstanbulİnput")]
+    public void PascalizeUsesTurkishCasing(string input, string expectedOutput) =>
+        Assert.Equal(expectedOutput, input.Pascalize());
+
     // Same as pascalize, except first char is lowercase
     [Theory]
     [InlineData("customer", "customer")]
@@ -140,6 +145,11 @@ public class InflectorTests
     public void Camelize(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Camelize());
 
+    [Theory, UseCulture("tr-TR")]
+    [InlineData("Istanbul_input", "ıstanbulİnput")]
+    public void CamelizeUsesTurkishCasing(string input, string expectedOutput) =>
+        Assert.Equal(expectedOutput, input.Camelize());
+
     //Makes an underscored lowercase string
     [Theory]
     [InlineData("SomeTitle", "some_title")]
@@ -152,6 +162,11 @@ public class InflectorTests
     public void Underscore(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Underscore());
 
+    [Theory, UseCulture("tr-TR")]
+    [InlineData("IstanbulInput", "ıstanbul_ınput")]
+    public void UnderscoreUsesTurkishCasing(string input, string expectedOutput) =>
+        Assert.Equal(expectedOutput, input.Underscore());
+
     // transform words into lowercase and separate with a -
     [Theory]
     [InlineData("SomeWords", "some-words")]
@@ -160,6 +175,11 @@ public class InflectorTests
     [InlineData("SomeForeignWords ÆgÑuÄgypten", "some-foreign-words-æg-ñu-ägypten")]
     [InlineData("A VeryShortSENTENCE", "a-very-short-sentence")]
     public void Kebaberize(string input, string expectedOutput) =>
+        Assert.Equal(expectedOutput, input.Kebaberize());
+
+    [Theory, UseCulture("tr-TR")]
+    [InlineData("IstanbulInput", "ıstanbul-ınput")]
+    public void KebaberizeUsesTurkishCasing(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Kebaberize());
 }
 

--- a/tests/Humanizer.Tests/MetricNumeralTests.cs
+++ b/tests/Humanizer.Tests/MetricNumeralTests.cs
@@ -76,6 +76,16 @@ public class MetricNumeralTests
     }
 
     [Theory]
+    [InlineData("999", 999)]
+    [InlineData("1k", 1000)]
+    [InlineData("999.5k", 999500)]
+    [InlineData("1M", 1000000)]
+    [InlineData("2.147483647G", int.MaxValue)]
+    [InlineData("-2.147483648G", int.MinValue)]
+    public void ToMetricUsesDefaultIntFormatting(string expected, int subject) =>
+        Assert.Equal(expected, subject.ToMetric());
+
+    [Theory]
     [InlineData(0, 0, "0")]
     [InlineData(0, 1, "0.0")]
     [InlineData(0, 3, "0.000")]

--- a/tests/Humanizer.Tests/OrdinalizeTests.cs
+++ b/tests/Humanizer.Tests/OrdinalizeTests.cs
@@ -114,6 +114,15 @@ public class OrdinalizeTests
         Assert.Equal("!1st", (-1).Ordinalize(culture));
     }
 
+    [Fact]
+    public void OrdinalizeNegativeNumberWithCustomCultureNegativePatternMatchesStringOverload()
+    {
+        var culture = (CultureInfo)CultureInfo.GetCultureInfo("en-US").Clone();
+        culture.NumberFormat.NumberNegativePattern = 3;
+
+        Assert.Equal((-1).ToString(culture).Ordinalize(culture), (-1).Ordinalize(culture));
+    }
+
     [Theory]
     [InlineData("ar-SA", 42)]
     [InlineData("ar-SA", -42)]

--- a/tests/Humanizer.Tests/OrdinalizeTests.cs
+++ b/tests/Humanizer.Tests/OrdinalizeTests.cs
@@ -105,6 +105,15 @@ public class OrdinalizeTests
         Assert.Equal(number.Ordinalize(culture), ordinalized);
     }
 
+    [Fact]
+    public void OrdinalizeNegativeNumberWithCustomCultureNegativeSign()
+    {
+        var culture = (CultureInfo)CultureInfo.GetCultureInfo("en-US").Clone();
+        culture.NumberFormat.NegativeSign = "!";
+
+        Assert.Equal("!1st", (-1).Ordinalize(culture));
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(1)]

--- a/tests/Humanizer.Tests/OrdinalizeTests.cs
+++ b/tests/Humanizer.Tests/OrdinalizeTests.cs
@@ -115,6 +115,16 @@ public class OrdinalizeTests
     }
 
     [Theory]
+    [InlineData("ar-SA", 42)]
+    [InlineData("ar-SA", -42)]
+    public void OrdinalizeNumberWithSpecifiedCultureMatchesStringOverload(string cultureName, int number)
+    {
+        var culture = new CultureInfo(cultureName);
+
+        Assert.Equal(number.ToString(culture).Ordinalize(culture), number.Ordinalize(culture));
+    }
+
+    [Theory]
     [InlineData(0)]
     [InlineData(1)]
     [InlineData(8)]

--- a/tests/Humanizer.Tests/StringHumanizeTests.cs
+++ b/tests/Humanizer.Tests/StringHumanizeTests.cs
@@ -24,6 +24,11 @@ public class StringHumanizeTests
     public void CanHumanizeStringInPascalCaseInTurkish(string input, string expectedResult) =>
         Assert.Equal(expectedResult, input.Humanize());
 
+    [Theory, UseCulture("tr-TR")]
+    [InlineData("istanbulInputString", "İstanbul Input String")]
+    public void CanHumanizeStringIntoTitleCaseInTurkish(string input, string expectedResult) =>
+        Assert.Equal(expectedResult, input.Humanize(LetterCasing.Title));
+
     [Theory, UseCulture("ar")]
     [InlineData("جمهورية ألمانيا الاتحادية", "جمهورية ألمانيا الاتحادية")]
     public void CanHumanizeOtherUnicodeLetter(string input, string expectedResult) =>

--- a/tests/Humanizer.Tests/TransformersTests.cs
+++ b/tests/Humanizer.Tests/TransformersTests.cs
@@ -18,6 +18,16 @@ public class TransformersTests
     public void TransformToTitleCase(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Transform(To.TitleCase));
 
+    [Fact]
+    public void TransformToTitleCaseUsesCultureSensitiveLowercase()
+    {
+        var culture = new CultureInfo("el-GR");
+        const string input = "οΣΟΣ";
+        var expected = culture.TextInfo.ToUpper(input[0]) + culture.TextInfo.ToLower(input[1..]);
+
+        Assert.Equal(expected, input.Transform(culture, To.TitleCase));
+    }
+
     [Theory]
     [InlineData("lower case statement", "lower case statement")]
     [InlineData("Sentence casing", "sentence casing")]

--- a/tests/Humanizer.Tests/TransformersTests.cs
+++ b/tests/Humanizer.Tests/TransformersTests.cs
@@ -18,6 +18,12 @@ public class TransformersTests
     public void TransformToTitleCase(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Transform(To.TitleCase));
 
+    [Theory, UseCulture("tr-TR")]
+    [InlineData("istanbul is in turkey", "İstanbul İs in Turkey")]
+    [InlineData("TITLE WITH I", "TITLE WITH I")]
+    public void TransformToTitleCaseUsesTurkishCasing(string input, string expectedOutput) =>
+        Assert.Equal(expectedOutput, input.Transform(To.TitleCase));
+
     [Fact]
     public void TransformToTitleCaseUsesCultureSensitiveLowercase()
     {

--- a/tests/Humanizer.Tests/TransformersTests.cs
+++ b/tests/Humanizer.Tests/TransformersTests.cs
@@ -15,6 +15,7 @@ public class TransformersTests
     [InlineData("NASA and the fbi", "NASA and the Fbi")]
     [InlineData("the lord of the rings", "The Lord of the Rings")]
     [InlineData("rock-and-roll by night", "Rock-and-Roll by Night")]
+    [InlineData("hello – world", "Hello – World")]
     public void TransformToTitleCase(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Transform(To.TitleCase));
 


### PR DESCRIPTION
## Summary
- avoid eager allocation/formatting in ordinal, clock-notation, transformer, metric, phrase-join, and single-part TimeSpan hot paths
- preserve existing public API behavior with focused tests around optimized branches, culture-sensitive formatting, and boundary cases
- address Copilot review feedback for culture-specific ordinal formatting, adjacent-hyphen normalization, and context-sensitive title casing
- cache default ordinal number formatting by culture name to remove the large `int.Ordinalize(culture)` positive-number regression found in the benchmark artifacts
- repair benchmark comparison reporting so ResultsComparer restores with an isolated NuGet config and no longer uploads a hidden build-failure fragment as a successful report
- expand BenchmarkDotNet coverage for optimized paths and control paths:
  - metric default int small/kilo/mega plus boundary, giga, formatted fallback, and double milli cases
  - formatter first-touch/date/data-unit cases plus single-part, multi-part, zero, and words TimeSpan humanization

## Benchmark Evidence
Local net10 short BenchmarkDotNet runs on Apple M2 Max after `b959f088`:
- `MetricNumeralBenchmarks`: small `59.05 ns / 56 B`, kilo `117.68 ns / 112 B`, mega `113.29 ns / 112 B`, boundary `149.74 ns / 128 B`, giga `158.14 ns / 152 B`, formatted fallback `205.21 ns / 128 B`, milli `125.57 ns / 136 B`
- `FormatterBenchmarks`: Russian single-part TimeSpan `95.84 ns / 64 B`, multi-part control `423.60 ns / 600 B`, zero `161.50 ns / 80 B`, words `131.71 ns / 224 B`, Romanian Date `140.24 ns / 136 B`, Arabic DataUnit `39.56 ns / 80 B`

Short local review-fix spot checks after `58084558`:
- `OrdinalBenchmarks`: English ordinalize `29.93 ns / 64 B`; custom-culture paths unchanged in shape for Dutch/Turkish/Greek/Finnish control cases
- `TransformersBenchmarks`: title case 10 chars `201.24 ns / 696 B`, 100 chars `2.424 us / 7264 B`, 1000 chars `24.483 us / 73200 B`

Short local ordinal regression check after `3221a0ad`:
- `OrdinalBenchmarks`: English `27.63 ns / 64 B`, Dutch `44.51 ns / 176 B`, Turkish `45.18 ns / 176 B`, Greek `46.37 ns / 176 B`, Finnish `44.53 ns / 176 B`
- The prior GitHub artifact for `58084558` showed Dutch/Turkish/Greek around `110-111 us`; the cache change removes that regression locally.

GitHub benchmark workflow:
- `b959f088` completed successfully: https://github.com/Humanizr/Humanizer/actions/runs/24616985676
- `58084558` completed successfully, but its comparison artifact exposed the ResultsComparer restore/reporting bug: https://github.com/Humanizr/Humanizer/actions/runs/24617740031
- latest head `3221a0ad` is running from the push and PR events:
  - https://github.com/Humanizr/Humanizer/actions/runs/24618892125
  - https://github.com/Humanizr/Humanizer/actions/runs/24618892631

## Tests
- `dotnet build src/Benchmarks/Benchmarks.csproj -c Release -f net10.0`
- `dotnet run --project src/Benchmarks/Benchmarks.csproj -c Release -f net10.0 -- --filter '*MetricNumeralBenchmarks*' --job short --warmupCount 1 --iterationCount 3`
- `dotnet run --project src/Benchmarks/Benchmarks.csproj -c Release -f net10.0 -- --filter '*FormatterBenchmarks*' --job short --warmupCount 1 --iterationCount 3`
- `dotnet run --project src/Benchmarks/Benchmarks.csproj -c Release -f net10.0 -- --filter '*OrdinalBenchmarks*' --job short --warmupCount 1 --iterationCount 3`
- `dotnet run --project src/Benchmarks/Benchmarks.csproj -c Release -f net10.0 -- --filter '*TransformersBenchmarks*' --job short --warmupCount 1 --iterationCount 3`
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0 --no-restore -- --filter-class '*OrdinalizeTests' --filter-class '*TransformersTests' --filter-class '*CoverageGapTests'`
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0 --no-restore -- --filter-class '*OrdinalizeTests' --filter-class '*DutchGenderedOrdinalTests'`
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0 --no-restore -- --filter-class '*OrdinalizeTests' --filter-class '*DutchGenderedOrdinalTests'`
- `dotnet run --project src/Benchmarks/Benchmarks.csproj -c Release -f net10.0 -- --filter '*OrdinalBenchmarks*' --job short --warmupCount 1 --iterationCount 1`
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic --no-restore`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/benchmarks-baseline-vs-current.yml"); puts "yaml ok"'`
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o artifacts/packages/ordinal-benchmark-fix`
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0 --no-restore`
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0 --no-restore`
- `git diff --check`

Note: `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0 --no-restore` could not run locally because this machine does not have the .NET 8 runtime installed; CI should cover it.
