### PR TITLE
feat(locale): add Amharic locale parity data

### DIFF
--- a/src/Humanizer/Locales/am.yml
+++ b/src/Humanizer/Locales/am.yml
@@ -1,0 +1,483 @@
+locale: 'am'
+
+surfaces:
+  list:
+    engine: 'conjunction'
+    value: 'እና'
+
+  formatter:
+    engine: 'profiled'
+    pluralRule: 'singular-plural'
+    dataUnitPluralRule: 'singular-plural'
+
+  phrases:
+    relativeDate:
+      now: 'አሁን'
+      never: 'በጭራሽ'
+      past:
+        millisecond:
+          single: 'ከ1 ሚሊሰከንድ በፊት'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በፊት'
+            forms:
+              default: 'ሚሊሰከንዶች'
+        second:
+          single: 'ከ1 ሰከንድ በፊት'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በፊት'
+            forms:
+              default: 'ሰከንዶች'
+        minute:
+          single: 'ከ1 ደቂቃ በፊት'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በፊት'
+            forms:
+              default: 'ደቂቃዎች'
+        hour:
+          single: 'ከ1 ሰዓት በፊት'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በፊት'
+            forms:
+              default: 'ሰዓታት'
+        day:
+          single: 'ትናንት'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በፊት'
+            forms:
+              default: 'ቀናት'
+        week:
+          single: 'ከ1 ሳምንት በፊት'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በፊት'
+            forms:
+              default: 'ሳምንታት'
+        month:
+          single: 'ከ1 ወር በፊት'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በፊት'
+            forms:
+              default: 'ወራት'
+        year:
+          single: 'ከ1 ዓመት በፊት'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በፊት'
+            forms:
+              default: 'ዓመታት'
+      future:
+        millisecond:
+          single: 'ከ1 ሚሊሰከንድ በኋላ'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በኋላ'
+            forms:
+              default: 'ሚሊሰከንዶች'
+        second:
+          single: 'ከ1 ሰከንድ በኋላ'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በኋላ'
+            forms:
+              default: 'ሰከንዶች'
+        minute:
+          single: 'ከ1 ደቂቃ በኋላ'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በኋላ'
+            forms:
+              default: 'ደቂቃዎች'
+        hour:
+          single: 'ከ1 ሰዓት በኋላ'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በኋላ'
+            forms:
+              default: 'ሰዓታት'
+        day:
+          single: 'ነገ'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በኋላ'
+            forms:
+              default: 'ቀናት'
+        week:
+          single: 'ከ1 ሳምንት በኋላ'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በኋላ'
+            forms:
+              default: 'ሳምንታት'
+        month:
+          single: 'ከ1 ወር በኋላ'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በኋላ'
+            forms:
+              default: 'ወራት'
+        year:
+          single: 'ከ1 ዓመት በኋላ'
+          multiple:
+            beforeCount: 'ከ'
+            afterCount: 'በኋላ'
+            forms:
+              default: 'ዓመታት'
+    duration:
+      zero: 'ጊዜ የለም'
+      age:
+        template: '{value} ዕድሜ'
+      millisecond:
+        single:
+          numeric: '1 ሚሊሰከንድ'
+          words: 'አንድ ሚሊሰከንድ'
+        multiple:
+          forms:
+            singular: 'ሚሊሰከንድ'
+            default: 'ሚሊሰከንዶች'
+      second:
+        single:
+          numeric: '1 ሰከንድ'
+          words: 'አንድ ሰከንድ'
+        multiple:
+          forms:
+            singular: 'ሰከንድ'
+            default: 'ሰከንዶች'
+      minute:
+        single:
+          numeric: '1 ደቂቃ'
+          words: 'አንድ ደቂቃ'
+        multiple:
+          forms:
+            singular: 'ደቂቃ'
+            default: 'ደቂቃዎች'
+      hour:
+        single:
+          numeric: '1 ሰዓት'
+          words: 'አንድ ሰዓት'
+        multiple:
+          forms:
+            singular: 'ሰዓት'
+            default: 'ሰዓታት'
+      day:
+        single:
+          numeric: '1 ቀን'
+          words: 'አንድ ቀን'
+        multiple:
+          forms:
+            singular: 'ቀን'
+            default: 'ቀናት'
+      week:
+        single:
+          numeric: '1 ሳምንት'
+          words: 'አንድ ሳምንት'
+        multiple:
+          forms:
+            singular: 'ሳምንት'
+            default: 'ሳምንታት'
+      month:
+        single:
+          numeric: '1 ወር'
+          words: 'አንድ ወር'
+        multiple:
+          forms:
+            singular: 'ወር'
+            default: 'ወራት'
+      year:
+        single:
+          numeric: '1 ዓመት'
+          words: 'አንድ ዓመት'
+        multiple:
+          forms:
+            singular: 'ዓመት'
+            default: 'ዓመታት'
+    dataUnits:
+      bit:
+        forms:
+          singular: 'ቢት'
+          default: 'ቢቶች'
+        symbol: 'b'
+      byte:
+        forms:
+          singular: 'ባይት'
+          default: 'ባይቶች'
+        symbol: 'B'
+      kilobyte:
+        forms:
+          singular: 'ኪሎባይት'
+          default: 'ኪሎባይቶች'
+        symbol: 'KB'
+      megabyte:
+        forms:
+          singular: 'ሜጋባይት'
+          default: 'ሜጋባይቶች'
+        symbol: 'MB'
+      gigabyte:
+        forms:
+          singular: 'ጊጋባይት'
+          default: 'ጊጋባይቶች'
+        symbol: 'GB'
+      terabyte:
+        forms:
+          singular: 'ቴራባይት'
+          default: 'ቴራባይቶች'
+        symbol: 'TB'
+    timeUnits:
+      millisecond:
+        symbol: 'ሚሊሰከንድ'
+      second:
+        symbol: 'ሰከንድ'
+      minute:
+        symbol: 'ደቂቃ'
+      hour:
+        symbol: 'ሰዓት'
+      day:
+        symbol: 'ቀን'
+      week:
+        symbol: 'ሳምንት'
+      month:
+        symbol: 'ወር'
+      year:
+        symbol: 'ዓመት'
+
+  number:
+    words:
+      engine: 'conjunctional-scale'
+      minusWord: 'አሉታዊ'
+      andWord: 'እና'
+      hundredWord: 'መቶ'
+      hundredOrdinalWord: 'መቶኛ'
+      tensUnitsSeparator: ' '
+      defaultAddAnd: false
+      addAndMode: 'always-default'
+      andStrategy: 'never'
+      tupleSuffix: '-ቱፕል'
+      ordinalLeadingOneStrategy: 'keep-leading-one'
+      ordinalMode: 'english'
+      unitsMap:
+        0: 'ዜሮ'
+        1: 'አንድ'
+        2: 'ሁለት'
+        3: 'ሶስት'
+        4: 'አራት'
+        5: 'አምስት'
+        6: 'ስድስት'
+        7: 'ሰባት'
+        8: 'ስምንት'
+        9: 'ዘጠኝ'
+        10: 'አስር'
+        11: 'አስራ አንድ'
+        12: 'አስራ ሁለት'
+        13: 'አስራ ሶስት'
+        14: 'አስራ አራት'
+        15: 'አስራ አምስት'
+        16: 'አስራ ስድስት'
+        17: 'አስራ ሰባት'
+        18: 'አስራ ስምንት'
+        19: 'አስራ ዘጠኝ'
+      ordinalUnitsMap:
+        0: 'ዜሮኛ'
+        1: 'አንደኛ'
+        2: 'ሁለተኛ'
+        3: 'ሶስተኛ'
+        4: 'አራተኛ'
+        5: 'አምስተኛ'
+        6: 'ስድስተኛ'
+        7: 'ሰባተኛ'
+        8: 'ስምንተኛ'
+        9: 'ዘጠነኛ'
+        10: 'አስረኛ'
+        11: 'አስራ አንደኛ'
+        12: 'አስራ ሁለተኛ'
+        13: 'አስራ ሶስተኛ'
+        14: 'አስራ አራተኛ'
+        15: 'አስራ አምስተኛ'
+        16: 'አስራ ስድስተኛ'
+        17: 'አስራ ሰባተኛ'
+        18: 'አስራ ስምንተኛ'
+        19: 'አስራ ዘጠነኛ'
+      tensMap:
+        2: 'ሃያ'
+        3: 'ሰላሳ'
+        4: 'አርባ'
+        5: 'ሃምሳ'
+        6: 'ስልሳ'
+        7: 'ሰባ'
+        8: 'ሰማንያ'
+        9: 'ዘጠና'
+      ordinalTensMap:
+        2: 'ሃያኛ'
+        3: 'ሰላሳኛ'
+        4: 'አርባኛ'
+        5: 'ሃምሳኛ'
+        6: 'ስልሳኛ'
+        7: 'ሰባኛ'
+        8: 'ሰማንያኛ'
+        9: 'ዘጠናኛ'
+      scales:
+        -
+          value: 1000000000000000000
+          name: 'ኩዊንቲሊዮን'
+          ordinalName: 'ኩዊንቲሊዮንኛ'
+        -
+          value: 1000000000000000
+          name: 'ኳድሪሊዮን'
+          ordinalName: 'ኳድሪሊዮንኛ'
+        -
+          value: 1000000000000
+          name: 'ትሪሊዮን'
+          ordinalName: 'ትሪሊዮንኛ'
+        -
+          value: 1000000000
+          name: 'ቢሊዮን'
+          ordinalName: 'ቢሊዮንኛ'
+        -
+          value: 1000000
+          name: 'ሚሊዮን'
+          ordinalName: 'ሚሊዮንኛ'
+        -
+          value: 1000
+          name: 'ሺህ'
+          ordinalName: 'ሺኛ'
+      namedTuples:
+        1: 'ነጠላ'
+        2: 'ጥንድ'
+        3: 'ሶስትዮሽ'
+    parse:
+      engine: 'token-map'
+      normalizationProfile: 'LowercaseRemovePeriods'
+      cardinalMap:
+        'ዜሮ': 0
+        'አንድ': 1
+        'ሁለት': 2
+        'ሶስት': 3
+        'አራት': 4
+        'አምስት': 5
+        'ስድስት': 6
+        'ሰባት': 7
+        'ስምንት': 8
+        'ዘጠኝ': 9
+        'አስር': 10
+        'አስራ': 10
+        'ሃያ': 20
+        'ሰላሳ': 30
+        'አርባ': 40
+        'ሃምሳ': 50
+        'ስልሳ': 60
+        'ሰባ': 70
+        'ሰማንያ': 80
+        'ዘጠና': 90
+        'መቶ': 100
+        'ሺህ': 1000
+        'ሚሊዮን': 1000000
+        'ቢሊዮን': 1000000000
+        'ትሪሊዮን': 1000000000000
+        'ኳድሪሊዮን': 1000000000000000
+        'ኩዊንቲሊዮን': 1000000000000000000
+      ordinalMap:
+        'ዜሮኛ': 0
+        'አንደኛ': 1
+        'ሁለተኛ': 2
+        'ሶስተኛ': 3
+        'አራተኛ': 4
+        'አምስተኛ': 5
+        'ስድስተኛ': 6
+        'ሰባተኛ': 7
+        'ስምንተኛ': 8
+        'ዘጠነኛ': 9
+        'አስረኛ': 10
+        'ሃያኛ': 20
+        'ሰላሳኛ': 30
+        'አርባኛ': 40
+        'ሃምሳኛ': 50
+        'ስልሳኛ': 60
+        'ሰባኛ': 70
+        'ሰማንያኛ': 80
+        'ዘጠናኛ': 90
+        'መቶኛ': 100
+        'ሺኛ': 1000
+        'ሚሊዮንኛ': 1000000
+        'ቢሊዮንኛ': 1000000000
+        'ትሪሊዮንኛ': 1000000000000
+      ordinalScaleMap:
+        'ሺኛ': 1000
+        'ሚሊዮንኛ': 1000000
+        'ቢሊዮንኛ': 1000000000
+        'ትሪሊዮንኛ': 1000000000000
+      negativePrefixes:
+        - 'አሉታዊ'
+      allowTerminalOrdinalToken: true
+      useHundredMultiplier: true
+      allowInvariantIntegerInput: true
+
+  ordinal:
+    numeric:
+      engine: 'suffix'
+      masculineSuffix: 'ኛ'
+      feminineSuffix: 'ኛ'
+      neuterSuffix: 'ኛ'
+    date:
+      pattern: '{day} MMMM yyyy'
+      dayMode: 'Numeric'
+    dateOnly:
+      pattern: '{day} MMMM yyyy'
+      dayMode: 'Numeric'
+
+  clock:
+    engine: 'phrase-clock'
+    hourMode: 'h12'
+    dayPeriodPosition: 'prefix'
+    hourSuffixSingular: 'ሰዓት'
+    hourSuffixPlural: 'ሰዓት'
+    minuteSuffixSingular: 'ደቂቃ'
+    minuteSuffixPlural: 'ደቂቃ'
+    min0: '{hour}'
+    defaultTemplate: '{hour} {minutes} {minuteSuffix}'
+    earlyMorning: 'ከሌሊቱ'
+    morning: 'ጠዋት'
+    afternoon: 'ከሰዓት በኋላ'
+    evening: 'ማታ'
+    night: 'ማታ'
+    eveningStartHour: 18
+    nightStartHour: 21
+
+  compass:
+    full:
+      - 'ሰሜን'
+      - 'ሰሜን-ሰሜን ምስራቅ'
+      - 'ሰሜን ምስራቅ'
+      - 'ምስራቅ-ሰሜን ምስራቅ'
+      - 'ምስራቅ'
+      - 'ምስራቅ-ደቡብ ምስራቅ'
+      - 'ደቡብ ምስራቅ'
+      - 'ደቡብ-ደቡብ ምስራቅ'
+      - 'ደቡብ'
+      - 'ደቡብ-ደቡብ ምዕራብ'
+      - 'ደቡብ ምዕራብ'
+      - 'ምዕራብ-ደቡብ ምዕራብ'
+      - 'ምዕራብ'
+      - 'ምዕራብ-ሰሜን ምዕራብ'
+      - 'ሰሜን ምዕራብ'
+      - 'ሰሜን-ሰሜን ምዕራብ'
+    short:
+      - 'ሰ'
+      - 'ሰሰም'
+      - 'ሰም'
+      - 'ምሰም'
+      - 'ም'
+      - 'ምደም'
+      - 'ደም'
+      - 'ደደም'
+      - 'ደ'
+      - 'ደደምዕ'
+      - 'ደምዕ'
+      - 'ምዕደምዕ'
+      - 'ምዕ'
+      - 'ምዕሰምዕ'
+      - 'ሰምዕ'
+      - 'ሰሰምዕ'

--- a/tests/Humanizer.Tests/Localisation/LocaleCoverageData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleCoverageData.cs
@@ -13,6 +13,7 @@ static class LocaleCoverageData
     // Representative non-first-of-month date sample.
     public static TheoryData<string, DateExpectationRow> DateToOrdinalWords2022January25ExpectationTheoryData { get; } = new()
     {
+        { "am", new(2022, 1, 25, "25 ጃንዋሪ 2022") },
         { "hi", new(2022, 1, 25, "25 जनवरी 2022") },
 
         { "af", new(2022, 1, 25, "25 Januarie 2022") },
@@ -85,6 +86,7 @@ static class LocaleCoverageData
     // First-of-month sample where many locales change the day form.
     public static TheoryData<string, DateExpectationRow> DateToOrdinalWords2015January1ExpectationTheoryData { get; } = new()
     {
+        { "am", new(2015, 1, 1, "1 ጃንዋሪ 2015") },
         { "hi", new(2015, 1, 1, "1 जनवरी 2015") },
 
         { "af", new(2015, 1, 1, "1 Januarie 2015") },
@@ -157,6 +159,7 @@ static class LocaleCoverageData
     // Early-month sample used to catch plain numeric-day formatting.
     public static TheoryData<string, DateExpectationRow> DateToOrdinalWords2015February3ExpectationTheoryData { get; } = new()
     {
+        { "am", new(2015, 2, 3, "3 ፌብሩዋሪ 2015") },
         { "hi", new(2015, 2, 3, "3 फ़रवरी 2015") },
 
         { "af", new(2015, 2, 3, "3 Februarie 2015") },
@@ -228,6 +231,7 @@ static class LocaleCoverageData
 
     public static TheoryData<string, DateExpectationRow> DateToOrdinalWords2020February29ExpectationTheoryData { get; } = new()
     {
+        { "am", new(2020, 2, 29, "29 ፌብሩዋሪ 2020") },
         { "hi", new(2020, 2, 29, "29 फ़रवरी 2020") },
 
         { "ca", new(2020, 2, 29, "29 de febrer de 2020") },
@@ -236,6 +240,7 @@ static class LocaleCoverageData
 
     public static TheoryData<string, DateExpectationRow> DateToOrdinalWords2015September4ExpectationTheoryData { get; } = new()
     {
+        { "am", new(2015, 9, 4, "4 ሴፕቴምበር 2015") },
         { "hi", new(2015, 9, 4, "4 सितंबर 2015") },
 
         { "ca", new(2015, 9, 4, "4 de setembre de 2015") },
@@ -244,6 +249,7 @@ static class LocaleCoverageData
 
     public static TheoryData<string, DateExpectationRow> DateToOrdinalWords1979November7ExpectationTheoryData { get; } = new()
     {
+        { "am", new(1979, 11, 7, "7 ኖቬምበር 1979") },
         { "hi", new(1979, 11, 7, "7 नवंबर 1979") },
 
         { "ca", new(1979, 11, 7, "7 de novembre de 1979") },
@@ -252,6 +258,7 @@ static class LocaleCoverageData
 
     public static TheoryData<string, DateExpectationRow> DateToOrdinalWords2020March2ExpectationTheoryData { get; } = new()
     {
+        { "am", new(2020, 3, 2, "2 ማርች 2020") },
         { "hi", new(2020, 3, 2, "2 मार्च 2020") },
 
         { "fr", new(2020, 3, 2, "2 mars 2020") },
@@ -259,6 +266,7 @@ static class LocaleCoverageData
 
     public static TheoryData<string, DateExpectationRow> DateToOrdinalWords2021October31ExpectationTheoryData { get; } = new()
     {
+        { "am", new(2021, 10, 31, "31 ኦክቶበር 2021") },
         { "hi", new(2021, 10, 31, "31 अक्टूबर 2021") },
 
         { "fr", new(2021, 10, 31, "31 octobre 2021") },
@@ -266,6 +274,7 @@ static class LocaleCoverageData
 
     public static TheoryData<string, DateExpectationRow> DateToOrdinalWords2024December31ExpectationTheoryData { get; } = new()
     {
+        { "am", new(2024, 12, 31, "31 ዲሴምበር 2024") },
         { "hi", new(2024, 12, 31, "31 दिसंबर 2024") },
 
         { "ar", new(2024, 12, 31, "31 ديسمبر 2024") },
@@ -278,6 +287,7 @@ static class LocaleCoverageData
     // Unrounded afternoon clock sample.
     public static TheoryData<string, ClockExpectationRow> TimeOnlyToClockNotation1323ExpectationTheoryData { get; } = new()
     {
+        { "am", new(13, 23, "ከሰዓት በኋላ አንድ ሰዓት ሃያ ሶስት ደቂቃ") },
         { "hi", new(13, 23, "दोपहर एक बजकर तेईस मिनट") },
 
         { "af", new(13, 23, "een uur drie en twintig") },
@@ -350,6 +360,7 @@ static class LocaleCoverageData
     // Same afternoon clock sample rounded to the nearest five minutes.
     public static TheoryData<string, ClockExpectationRow> TimeOnlyToClockNotation1323RoundedExpectationTheoryData { get; } = new()
     {
+        { "am", new(13, 23, "ከሰዓት በኋላ አንድ ሰዓት ሃያ አምስት ደቂቃ") },
         { "hi", new(13, 23, "दोपहर एक बजकर पच्चीस मिनट") },
 
         { "af", new(13, 23, "een uur vyf en twintig") },
@@ -422,6 +433,7 @@ static class LocaleCoverageData
     // Early-morning sample that catches one-o'clock phrasing and culture short-time output.
     public static TheoryData<string, ClockExpectationRow> TimeOnlyToClockNotation0105ExpectationTheoryData { get; } = new()
     {
+        { "am", new(1, 5, "ከሌሊቱ አንድ ሰዓት አምስት ደቂቃ") },
         { "hi", new(1, 5, "सुबह एक बजकर पाँच मिनट") },
 
         { "af", new(1, 5, "een uur vyf") },
@@ -812,6 +824,7 @@ static class LocaleCoverageData
     public static TheoryData<string, string, string> FormatterExpectationTheoryData =>
         new()
         {
+            { "am", "ትናንት", "2 ቀናት" },
             { "af", "gister", "2 dae" },
             { "ar", "أمس", "يومين" },
             { "az", "dünən", "2 gün" },
@@ -883,6 +896,7 @@ static class LocaleCoverageData
     public static TheoryData<string, string, string> CollectionFormatterExpectationTheoryData =>
         new()
         {
+            { "am", "1 እና 2", "1, 2 እና 3" },
             { "af", "1 en 2", "1, 2 en 3" },
             { "ar", "1 و2", "1, 2 و3" },
             { "az", "1 və 2", "1, 2 və 3" },
@@ -954,6 +968,7 @@ static class LocaleCoverageData
     public static TheoryData<string, int, string> NumberToWordsOrdinalExpectationTheoryData =>
         new()
         {
+            { "am", 1, "አንደኛ" },
             { "af", 1, "eerste" },
             { "ar", 1, "الأولى" },
             { "az", 1, "birinci" },
@@ -1025,6 +1040,7 @@ static class LocaleCoverageData
     public static TheoryData<string, long, string> NumberToWordsCardinalExpectationTheoryData =>
         new()
         {
+            { "am", 1, "አንድ" },
             { "af", 1, "een" },
             { "ar", 1, "واحد" },
             { "az", 1, "bir" },
@@ -1132,6 +1148,7 @@ static class LocaleCoverageData
     public static TheoryData<string, long, string> WordsToNumberExpectationTheoryData =>
         new()
         {
+            { "am", 21, "ሃያ አንድ" },
             { "af", 21, "een en twintig" },
             { "ar", 21, "واحد و عشرون" },
             { "az", 21, "iyirmi bir" },

--- a/tests/Humanizer.Tests/Localisation/LocaleFormatterExactTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleFormatterExactTheoryData.cs
@@ -182,6 +182,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, DateDayPluralExpectationRow> DateDayPluralCases => new()
     {
+        { "am", new("ከ 2 ቀናት በፊት", "ከ 3 ቀናት በፊት", "ከ 4 ቀናት በፊት", "ከ 5 ቀናት በፊት", "ከ 11 ቀናት በፊት", "ከ 21 ቀናት በፊት", "ከ 2 ቀናት በኋላ", "ከ 3 ቀናት በኋላ", "ከ 4 ቀናት በኋላ", "ከ 5 ቀናት በኋላ", "ከ 11 ቀናት በኋላ", "ከ 21 ቀናት በኋላ") },
         { "af", new("2 dae gelede", "3 dae gelede", "4 dae gelede", "5 dae gelede", "11 dae gelede", "21 dae gelede", "oor 2 dae", "oor 3 dae", "oor 4 dae", "oor 5 dae", "oor 11 dae", "oor 21 dae") },
         { "ar", new("منذ يومين", "منذ 3 أيام", "منذ 4 أيام", "منذ 5 أيام", "منذ 11 يوم", "منذ 21 يوم", "في غضون يومين من الآن", "في غضون 3 أيام من الآن", "في غضون 4 أيام من الآن", "في غضون 5 أيام من الآن", "في غضون 11 يوم من الآن", "في غضون 21 يوم من الآن") },
         { "az", new("2 gün əvvəl", "3 gün əvvəl", "4 gün əvvəl", "5 gün əvvəl", "11 gün əvvəl", "21 gün əvvəl", "2 gün sonra", "3 gün sonra", "4 gün sonra", "5 gün sonra", "11 gün sonra", "21 gün sonra") },
@@ -253,6 +254,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, MultiPartTimeSpanExpectationRow> MultiPartTimeSpanCases => new()
     {
+        { "am", new("2 ሳምንታት, 1 ቀን እና 1 ሰዓት", "1 ቀን, 3 ደቂቃዎች እና 4 ሰከንዶች", "1 ቀን እና 3 ደቂቃዎች") },
         { "af", new("2 weke, 1 dag en 1 uur", "1 dag, 3 minute en 4 sekondes", "1 dag en 3 minute") },
         { "ar", new("أسبوعين, يوم واحد وساعة واحدة", "يوم واحد, 3 دقائق و4 ثوان", "يوم واحد و3 دقائق") },
         { "az", new("2 həftə, 1 gün və 1 saat", "1 gün, 3 dəqiqə və 4 saniyə", "1 gün və 3 dəqiqə") },
@@ -324,6 +326,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, TimeUnitSymbolExpectationRow> TimeUnitSymbolCases => new()
     {
+        { "am", new("ሚሊሰከንድ", "ሰከንድ", "ደቂቃ", "ሰዓት", "ቀን", "ሳምንት", "ወር", "ዓመት") },
         { "af", new("ms", "sek.", "min.", "uur", "dag", "week", "maand", "jaar") },
         { "ar", new("مللي ثانية", "ثانية", "دقيقة", "ساعة", "يوم", "أسبوع", "شهر", "سنة") },
         { "az", new("ms", "saniyə", "dəqiqə", "saat", "gün", "həftə", "ay", "il") },
@@ -416,6 +419,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, ByteSizeSymbolExpectationRow> ByteSizeSymbolCases => new()
     {
+        { "am", new("1 b", "2 B", "1.95 KB", "2048 KB") },
         { "af", new("1 b", "2 B", "1,95 KB", "2048 KB") },
         { "ar", new("1 b", "2 B", ArabicKilobytes, "2048 KB") },
         { "az", new("1 b", "2 B", "1,95 KB", "2048 KB") },
@@ -487,6 +491,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, ByteSizeFullWordExpectationRow> ByteSizeFullWordCases => new()
     {
+        { "am", new("1 ቢት", "1 ባይት", "2 ባይቶች", "2 ኪሎባይቶች", "2 ሜጋባይቶች") },
         { "af", new("1 bit", "1 byte", "2 bytes", "2 kilobytes", "2 megabytes") },
         { "ar", new("1 بت", "1 بايت", "2 بايت", "2 كيلوبايت", "2 ميجابايت") },
         { "az", new("1 bit", "1 bayt", "2 bayt", "2 kilobayt", "2 meqabayt") },
@@ -558,6 +563,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, CollectionHumanizeExpectationRow> CollectionHumanizeCases => new()
     {
+        { "am", new("1 እና 2", "1, 2 እና 3", "1, 2, 3 እና 4") },
         { "af", new("1 en 2", "1, 2 en 3", "1, 2, 3 en 4") },
         { "ar", new("1 و2", "1, 2 و3", "1, 2, 3 و4") },
         { "az", new("1 və 2", "1, 2 və 3", "1, 2, 3 və 4") },
@@ -629,6 +635,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, HeadingExpectationRow> HeadingCases => new()
     {
+        { "am", new("ሰ", "ሰሰም", "ሰም", "ምሰም", "ም", "ምደም", "ደም", "ደደም", "ደ", "ደደምዕ", "ደምዕ", "ምዕደምዕ", "ምዕ", "ምዕሰምዕ", "ሰምዕ", "ሰሰምዕ", "ሰሜን", "ሰሜን-ሰሜን ምስራቅ", "ሰሜን ምስራቅ", "ምስራቅ-ሰሜን ምስራቅ", "ምስራቅ", "ምስራቅ-ደቡብ ምስራቅ", "ደቡብ ምስራቅ", "ደቡብ-ደቡብ ምስራቅ", "ደቡብ", "ደቡብ-ደቡብ ምዕራብ", "ደቡብ ምዕራብ", "ምዕራብ-ደቡብ ምዕራብ", "ምዕራብ", "ምዕራብ-ሰሜን ምዕራብ", "ሰሜን ምዕራብ", "ሰሜን-ሰሜን ምዕራብ") },
         { "af", new("N", "NNO", "NO", "ONO", "O", "OSO", "SO", "SSO", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW", "noord", "noordnoordoos", "noordoos", "oosnoordoos", "oos", "oossuidoos", "suidoos", "suidsuidoos", "suid", "suidsuidwes", "suidwes", "wessuidwes", "wes", "wesnoordwes", "noordwes", "noordnoordwes") },
         { "ar", new("ش", "ش.ش.ق", "ش.ق", "ق.ش.ق", "ق", "ق.ج.ق", "ج.ق", "ج.ج.ق", "ج", "ج.ج.غ", "ج.غ", "غ.ج.غ", "غ", "غ.ش.غ", "ش.غ", "ش.ش.غ", "شمال", "شمال-شمال-شرق", "شمال-شرق", "شرق-شمال-شرق", "شرق", "شرق-جنوب-شرق", "جنوب-شرق", "جنوب-جنوب-شرق", "جنوب", "جنوب-جنوب-غرب", "جنوب-غرب", "غرب-جنوب-غرب", "غرب", "غرب-شمال-غرب", "شمال-غرب", "شمال-شمال-غرب") },
         { "az", new("Ş", "ŞŞŞ", "ŞŞ", "Ş-ŞŞ", "Şər", "Ş-CŞ", "CŞ", "CCŞ", "C", "CCQ", "CQ", "Q-CQ", "Q", "Q-ŞQ", "ŞQ", "ŞŞQ", "şimal", "şimal-şimal-şərq", "şimal-şərq", "şərq-şimal-şərq", "şərq", "şərq-cənub-şərq", "cənub-şərq", "cənub-cənub-şərq", "cənub", "cənub-cənub-qərb", "cənub-qərb", "qərb-cənub-qərb", "qərb", "qərb-şimal-qərb", "şimal-qərb", "şimal-şimal-qərb") },
@@ -700,6 +707,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, CardinalHeadingExpectationRow> HeadingAbbreviatedCardinalCases => new()
     {
+        { "am", new("ሰ", "ም", "ደ", "ምዕ") },
         { "af", new("N", "O", "S", "W") },
         { "ar", new("ش", "ق", "ج", "غ") },
         { "az", new("Ş", "Şər", "C", "Q") },

--- a/tests/Humanizer.Tests/Localisation/LocaleNumberMagnitudeTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleNumberMagnitudeTheoryData.cs
@@ -4,6 +4,8 @@ public static class LocaleNumberMagnitudeTheoryData
 {
     public static TheoryData<string, long, string> MagnitudeCardinalCases => new()
     {
+        { "am", 1001, "አንድ ሺህ አንድ" },
+        { "am", 1000001, "አንድ ሚሊዮን አንድ" },
         { "af", 1001L, "een duisend en een" },
         { "af", 1000001L, "een miljoen en een" },
         { "ar", 1001L, "ألف و واحد" },
@@ -146,6 +148,8 @@ public static class LocaleNumberMagnitudeTheoryData
 
     public static TheoryData<string, long, string> ExtendedMagnitudeCardinalCases => new()
     {
+        { "am", 1001000001, "አንድ ቢሊዮን አንድ ሚሊዮን አንድ" },
+        { "am", 4325010007018, "አራት ትሪሊዮን ሶስት መቶ ሃያ አምስት ቢሊዮን አስር ሚሊዮን ሰባት ሺህ አስራ ስምንት" },
         { "af", 1001000001L, "een miljard een miljoen en een" },
         { "af", 4325010007018L, "vier biljoene drie honderd vyf en twintig miljard tien miljoen sewe duisend en agtien" },
         { "ar", 1001000001L, "مليار و   مليون و واحد" },

--- a/tests/Humanizer.Tests/Localisation/LocaleNumberOverloadTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleNumberOverloadTheoryData.cs
@@ -4,6 +4,8 @@ public static class LocaleNumberOverloadTheoryData
 {
     public static TheoryData<string, long, string> AddAndCases => new()
     {
+        { "am", 1001001, "አንድ ሚሊዮን አንድ ሺህ አንድ" },
+        { "am", 1234567890, "አንድ ቢሊዮን ሁለት መቶ ሰላሳ አራት ሚሊዮን አምስት መቶ ስልሳ ሰባት ሺህ ስምንት መቶ ዘጠና" },
         { "af", 1001001L, "een miljoen een duisend en een" },
         { "af", 1001000001L, "een miljard een miljoen en een" },
         { "af", 4325010007018L, "vier biljoene drie honderd vyf en twintig miljard tien miljoen sewe duisend en agtien" },
@@ -205,6 +207,8 @@ public static class LocaleNumberOverloadTheoryData
 
     public static TheoryData<string, long, string> WordFormCases => new()
     {
+        { "am", 1001001L, "አንድ ሚሊዮን አንድ ሺህ አንድ" },
+        { "am", 1234567890L, "አንድ ቢሊዮን ሁለት መቶ ሰላሳ አራት ሚሊዮን አምስት መቶ ስልሳ ሰባት ሺህ ስምንት መቶ ዘጠና" },
         { "af", 1001001L, "een miljoen een duisend en een" },
         { "af", 1001000001L, "een miljard een miljoen en een" },
         { "af", 4325010007018L, "vier biljoene drie honderd vyf en twintig miljard tien miljoen sewe duisend en agtien" },
@@ -406,6 +410,8 @@ public static class LocaleNumberOverloadTheoryData
 
     public static TheoryData<string, long, string> GenderCases => new()
     {
+        { "am", 1001001L, "አንድ ሚሊዮን አንድ ሺህ አንድ" },
+        { "am", 1234567890L, "አንድ ቢሊዮን ሁለት መቶ ሰላሳ አራት ሚሊዮን አምስት መቶ ስልሳ ሰባት ሺህ ስምንት መቶ ዘጠና" },
         { "af", 1001001L, "een miljoen een duisend en een" },
         { "af", 1001000001L, "een miljard een miljoen en een" },
         { "af", 4325010007018L, "vier biljoene drie honderd vyf en twintig miljard tien miljoen sewe duisend en agtien" },
@@ -607,6 +613,8 @@ public static class LocaleNumberOverloadTheoryData
 
     public static TheoryData<string, long, string> WordFormGenderCases => new()
     {
+        { "am", 1001001L, "አንድ ሚሊዮን አንድ ሺህ አንድ" },
+        { "am", 1234567890L, "አንድ ቢሊዮን ሁለት መቶ ሰላሳ አራት ሚሊዮን አምስት መቶ ስልሳ ሰባት ሺህ ስምንት መቶ ዘጠና" },
         { "af", 1001001L, "een miljoen een duisend en een" },
         { "af", 1001000001L, "een miljard een miljoen en een" },
         { "af", 4325010007018L, "vier biljoene drie honderd vyf en twintig miljard tien miljoen sewe duisend en agtien" },

--- a/tests/Humanizer.Tests/Localisation/LocaleNumberTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleNumberTheoryData.cs
@@ -4,6 +4,57 @@ static class LocaleNumberTheoryData
 {
     public static TheoryData<string, int, string> CardinalCases => new()
     {
+        { "am", 0, "ዜሮ" },
+        { "am", 1, "አንድ" },
+        { "am", 2, "ሁለት" },
+        { "am", 3, "ሶስት" },
+        { "am", 4, "አራት" },
+        { "am", 5, "አምስት" },
+        { "am", 10, "አስር" },
+        { "am", 11, "አስራ አንድ" },
+        { "am", 12, "አስራ ሁለት" },
+        { "am", 19, "አስራ ዘጠኝ" },
+        { "am", 20, "ሃያ" },
+        { "am", 21, "ሃያ አንድ" },
+        { "am", 22, "ሃያ ሁለት" },
+        { "am", 30, "ሰላሳ" },
+        { "am", 40, "አርባ" },
+        { "am", 50, "ሃምሳ" },
+        { "am", 60, "ስልሳ" },
+        { "am", 70, "ሰባ" },
+        { "am", 80, "ሰማንያ" },
+        { "am", 90, "ዘጠና" },
+        { "am", 99, "ዘጠና ዘጠኝ" },
+        { "am", 100, "አንድ መቶ" },
+        { "am", 101, "አንድ መቶ አንድ" },
+        { "am", 110, "አንድ መቶ አስር" },
+        { "am", 111, "አንድ መቶ አስራ አንድ" },
+        { "am", 115, "አንድ መቶ አስራ አምስት" },
+        { "am", 121, "አንድ መቶ ሃያ አንድ" },
+        { "am", 122, "አንድ መቶ ሃያ ሁለት" },
+        { "am", 123, "አንድ መቶ ሃያ ሶስት" },
+        { "am", 200, "ሁለት መቶ" },
+        { "am", 999, "ዘጠኝ መቶ ዘጠና ዘጠኝ" },
+        { "am", 1000, "አንድ ሺህ" },
+        { "am", 1001, "አንድ ሺህ አንድ" },
+        { "am", 1111, "አንድ ሺህ አንድ መቶ አስራ አንድ" },
+        { "am", 1234, "አንድ ሺህ ሁለት መቶ ሰላሳ አራት" },
+        { "am", 3501, "ሶስት ሺህ አምስት መቶ አንድ" },
+        { "am", 12345, "አስራ ሁለት ሺህ ሶስት መቶ አርባ አምስት" },
+        { "am", 100000, "አንድ መቶ ሺህ" },
+        { "am", 111111, "አንድ መቶ አስራ አንድ ሺህ አንድ መቶ አስራ አንድ" },
+        { "am", 123456, "አንድ መቶ ሃያ ሶስት ሺህ አራት መቶ ሃምሳ ስድስት" },
+        { "am", 1000000, "አንድ ሚሊዮን" },
+        { "am", 1000001, "አንድ ሚሊዮን አንድ" },
+        { "am", 1111111, "አንድ ሚሊዮን አንድ መቶ አስራ አንድ ሺህ አንድ መቶ አስራ አንድ" },
+        { "am", 1234567, "አንድ ሚሊዮን ሁለት መቶ ሰላሳ አራት ሺህ አምስት መቶ ስልሳ ሰባት" },
+        { "am", 10000000, "አስር ሚሊዮን" },
+        { "am", 11111111, "አስራ አንድ ሚሊዮን አንድ መቶ አስራ አንድ ሺህ አንድ መቶ አስራ አንድ" },
+        { "am", 12345678, "አስራ ሁለት ሚሊዮን ሶስት መቶ አርባ አምስት ሺህ ስድስት መቶ ሰባ ስምንት" },
+        { "am", 100000000, "አንድ መቶ ሚሊዮን" },
+        { "am", 111111111, "አንድ መቶ አስራ አንድ ሚሊዮን አንድ መቶ አስራ አንድ ሺህ አንድ መቶ አስራ አንድ" },
+        { "am", 123456789, "አንድ መቶ ሃያ ሶስት ሚሊዮን አራት መቶ ሃምሳ ስድስት ሺህ ሰባት መቶ ሰማንያ ዘጠኝ" },
+        { "am", 1000000000, "አንድ ቢሊዮን" },
         { "af", 0, "nul" },
         { "af", 1, "een" },
         { "af", 2, "twee" },
@@ -2676,6 +2727,12 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, bool, string> CardinalAddAndCases => new()
     {
+        { "am", 101, true, "አንድ መቶ አንድ" },
+        { "am", 101, false, "አንድ መቶ አንድ" },
+        { "am", 105, true, "አንድ መቶ አምስት" },
+        { "am", 105, false, "አንድ መቶ አምስት" },
+        { "am", 1001, true, "አንድ ሺህ አንድ" },
+        { "am", 1001, false, "አንድ ሺህ አንድ" },
         { "af", 101, true, "een honderd en een" },
         { "af", 101, false, "een honderd en een" },
         { "af", 105, true, "een honderd en vyf" },
@@ -3441,6 +3498,7 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, WordForm, string> CardinalWordFormCases => new()
     {
+        { "am", 21, WordForm.Normal, "ሃያ አንድ" },
         { "af", 1, WordForm.Abbreviation, "een" },
         { "af", 21, WordForm.Abbreviation, "een en twintig" },
         { "af", 31, WordForm.Abbreviation, "een en dertig" },
@@ -3831,6 +3889,9 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, GrammaticalGender, string> CardinalGenderCases => new()
     {
+        { "am", 21, GrammaticalGender.Masculine, "ሃያ አንድ" },
+        { "am", 21, GrammaticalGender.Feminine, "ሃያ አንድ" },
+        { "am", 21, GrammaticalGender.Neuter, "ሃያ አንድ" },
         { "af", 1, GrammaticalGender.Feminine, "een" },
         { "af", 1, GrammaticalGender.Masculine, "een" },
         { "af", 1, GrammaticalGender.Neuter, "een" },
@@ -4239,6 +4300,9 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, WordForm, GrammaticalGender, string> CardinalWordFormGenderCases => new()
     {
+        { "am", 21, WordForm.Normal, GrammaticalGender.Masculine, "ሃያ አንድ" },
+        { "am", 21, WordForm.Normal, GrammaticalGender.Feminine, "ሃያ አንድ" },
+        { "am", 21, WordForm.Normal, GrammaticalGender.Neuter, "ሃያ አንድ" },
         { "af", 21, WordForm.Abbreviation, GrammaticalGender.Feminine, "een en twintig" },
         { "af", 21, WordForm.Abbreviation, GrammaticalGender.Masculine, "een en twintig" },
         { "af", 21, WordForm.Abbreviation, GrammaticalGender.Neuter, "een en twintig" },
@@ -4442,6 +4506,19 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, string> OrdinalCases => new()
     {
+        { "am", 0, "ዜሮኛ" },
+        { "am", 1, "አንደኛ" },
+        { "am", 2, "ሁለተኛ" },
+        { "am", 3, "ሶስተኛ" },
+        { "am", 4, "አራተኛ" },
+        { "am", 5, "አምስተኛ" },
+        { "am", 10, "አስረኛ" },
+        { "am", 11, "አስራ አንደኛ" },
+        { "am", 20, "ሃያኛ" },
+        { "am", 21, "ሃያ አንደኛ" },
+        { "am", 100, "አንድ መቶኛ" },
+        { "am", 101, "አንድ መቶ አንደኛ" },
+        { "am", 1000, "አንድ ሺኛ" },
         { "af", 0, "nulste" },
         { "af", 1, "eerste" },
         { "af", 2, "tweede" },
@@ -5775,6 +5852,7 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, WordForm, string> OrdinalWordFormCases => new()
     {
+        { "am", 21, WordForm.Normal, "ሃያ አንደኛ" },
         { "af", 1, WordForm.Abbreviation, "eerste" },
         { "af", 2, WordForm.Abbreviation, "tweede" },
         { "af", 3, WordForm.Abbreviation, "derde" },
@@ -6115,6 +6193,9 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, GrammaticalGender, string> OrdinalGenderCases => new()
     {
+        { "am", 21, GrammaticalGender.Masculine, "ሃያ አንደኛ" },
+        { "am", 21, GrammaticalGender.Feminine, "ሃያ አንደኛ" },
+        { "am", 21, GrammaticalGender.Neuter, "ሃያ አንደኛ" },
         { "af", 1, GrammaticalGender.Feminine, "eerste" },
         { "af", 1, GrammaticalGender.Masculine, "eerste" },
         { "af", 1, GrammaticalGender.Neuter, "eerste" },
@@ -6942,6 +7023,9 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, GrammaticalGender, WordForm, string> OrdinalWordFormGenderCases => new()
     {
+        { "am", 21, GrammaticalGender.Masculine, WordForm.Normal, "ሃያ አንደኛ" },
+        { "am", 21, GrammaticalGender.Feminine, WordForm.Normal, "ሃያ አንደኛ" },
+        { "am", 21, GrammaticalGender.Neuter, WordForm.Normal, "ሃያ አንደኛ" },
         { "af", 3, GrammaticalGender.Feminine, WordForm.Abbreviation, "derde" },
         { "af", 3, GrammaticalGender.Masculine, WordForm.Abbreviation, "derde" },
         { "af", 3, GrammaticalGender.Neuter, WordForm.Abbreviation, "derde" },
@@ -7144,6 +7228,10 @@ static class LocaleNumberTheoryData
 };
     public static TheoryData<string, int, string> TupleCases => new()
     {
+        { "am", 1, "ነጠላ" },
+        { "am", 2, "ጥንድ" },
+        { "am", 3, "ሶስትዮሽ" },
+        { "am", 4, "4-ቱፕል" },
         { "af", 2, "twee" },
         { "ar", 2, "اثنان" },
         { "az", 2, "iki" },
@@ -7216,6 +7304,10 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, string, long> WordsToNumberCases => new()
     {
+        { "am", "ሃያ አንድ", 21 },
+        { "am", "አንድ መቶ አምስት", 105 },
+        { "am", "አንድ ሺህ አንድ", 1001 },
+        { "am", "ሃያ አንደኛ", 21 },
         { "af", "een en twintig", 21L },
         { "ar", "واحد و عشرون", 21L },
         { "az", "iyirmi bir", 21L },

--- a/tests/Humanizer.Tests/Localisation/LocaleOrdinalizerMatrixData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleOrdinalizerMatrixData.cs
@@ -5,6 +5,15 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, int, string> OrdinalizerExpectationTheoryData =>
         new()
         {
+        { "am", 0, "0ኛ" },
+        { "am", 1, "1ኛ" },
+        { "am", 2, "2ኛ" },
+        { "am", 3, "3ኛ" },
+        { "am", 10, "10ኛ" },
+        { "am", 23, "23ኛ" },
+        { "am", 100, "100ኛ" },
+        { "am", 101, "101ኛ" },
+        { "am", 1001, "1001ኛ" },
             { "af", 0, "0de" },
             { "af", 1, "1ste" },
             { "af", 2, "2de" },
@@ -598,6 +607,9 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, int, GrammaticalGender, string> OrdinalizerGenderExpectationTheoryData =>
         new()
         {
+        { "am", 1, GrammaticalGender.Masculine, "1ኛ" },
+        { "am", 1, GrammaticalGender.Feminine, "1ኛ" },
+        { "am", 1, GrammaticalGender.Neuter, "1ኛ" },
             { "af", 0, GrammaticalGender.Masculine, "0de" },
             { "af", 1, GrammaticalGender.Masculine, "1ste" },
             { "af", 2, GrammaticalGender.Masculine, "2de" },
@@ -3337,6 +3349,8 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, string, string> OrdinalizerDefaultExpectationTheoryData =>
         new()
         {
+        { "am", "1", "1ኛ" },
+        { "am", "21", "21ኛ" },
             { "af", "0", "0de" },
             { "af", "1", "1ste" },
             { "af", "2", "2de" },
@@ -3929,6 +3943,7 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, int, string> OrdinalizerNegativeExpectationTheoryData =>
         new()
         {
+        { "am", -1, "-1ኛ" },
             { "af", -1, "-1ste" },
             { "af", -2, "-2de" },
             { "af", -10, "-10de" },
@@ -4261,6 +4276,7 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, int, WordForm, string> OrdinalizerWordFormExpectationTheoryData =>
         new()
         {
+        { "am", 1, WordForm.Normal, "1ኛ" },
             { "af", 1, WordForm.Abbreviation, "1ste" },
             { "af", 1, WordForm.Normal, "1ste" },
             { "af", 2, WordForm.Abbreviation, "2de" },
@@ -4788,6 +4804,9 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, int, GrammaticalGender, WordForm, string> OrdinalizerWordFormGenderExpectationTheoryData =>
         new()
         {
+        { "am", 1, GrammaticalGender.Masculine, WordForm.Normal, "1ኛ" },
+        { "am", 1, GrammaticalGender.Feminine, WordForm.Normal, "1ኛ" },
+        { "am", 1, GrammaticalGender.Neuter, WordForm.Normal, "1ኛ" },
             { "af", 1, GrammaticalGender.Masculine, WordForm.Abbreviation, "1ste" },
             { "af", 1, GrammaticalGender.Masculine, WordForm.Normal, "1ste" },
             { "af", 1, GrammaticalGender.Feminine, WordForm.Abbreviation, "1ste" },
@@ -6339,6 +6358,9 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, string, GrammaticalGender, string> OrdinalizerStringExactExpectationTheoryData =>
         new()
         {
+        { "am", "1", GrammaticalGender.Masculine, "1ኛ" },
+        { "am", "1", GrammaticalGender.Feminine, "1ኛ" },
+        { "am", "1", GrammaticalGender.Neuter, "1ኛ" },
             { "af", "0", GrammaticalGender.Masculine, "0de" },
             { "af", "1", GrammaticalGender.Masculine, "1ste" },
             { "af", "2", GrammaticalGender.Masculine, "2de" },
@@ -8892,6 +8914,9 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, int, GrammaticalGender, string> OrdinalizerNumberExactExpectationTheoryData =>
         new()
         {
+            { "am", 1, GrammaticalGender.Masculine, "1ኛ" },
+            { "am", 1, GrammaticalGender.Feminine, "1ኛ" },
+            { "am", 1, GrammaticalGender.Neuter, "1ኛ" },
             { "af", 0, GrammaticalGender.Masculine, "0de" },
             { "af", 1, GrammaticalGender.Masculine, "1ste" },
             { "af", 2, GrammaticalGender.Masculine, "2de" },

--- a/tests/Humanizer.Tests/Localisation/LocalePhraseTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocalePhraseTheoryData.cs
@@ -4,6 +4,21 @@ static class LocalePhraseTheoryData
 {
     public static TheoryData<string, int, TimeUnit, Tense, string> DateHumanizeCases => new()
     {
+        { "am", 1, TimeUnit.Second, Tense.Past, "ከ1 ሰከንድ በፊት" },
+        { "am", 2, TimeUnit.Second, Tense.Future, "ከ 2 ሰከንዶች በኋላ" },
+        { "am", 1, TimeUnit.Minute, Tense.Past, "ከ1 ደቂቃ በፊት" },
+        { "am", 2, TimeUnit.Minute, Tense.Future, "ከ 2 ደቂቃዎች በኋላ" },
+        { "am", 1, TimeUnit.Hour, Tense.Past, "ከ1 ሰዓት በፊት" },
+        { "am", 2, TimeUnit.Hour, Tense.Future, "ከ 2 ሰዓታት በኋላ" },
+        { "am", 1, TimeUnit.Day, Tense.Past, "ትናንት" },
+        { "am", 1, TimeUnit.Day, Tense.Future, "ነገ" },
+        { "am", 2, TimeUnit.Day, Tense.Past, "ከ 2 ቀናት በፊት" },
+        { "am", 2, TimeUnit.Day, Tense.Future, "ከ 2 ቀናት በኋላ" },
+        { "am", 1, TimeUnit.Month, Tense.Past, "ከ1 ወር በፊት" },
+        { "am", 2, TimeUnit.Month, Tense.Future, "ከ 2 ወራት በኋላ" },
+        { "am", 1, TimeUnit.Year, Tense.Past, "ከ1 ዓመት በፊት" },
+        { "am", 2, TimeUnit.Year, Tense.Future, "ከ 2 ዓመታት በኋላ" },
+        { "am", 0, TimeUnit.Second, Tense.Future, "አሁን" },
         { "af", 1, TimeUnit.Second, Tense.Past, "1 sekonde terug" },
         { "af", 2, TimeUnit.Second, Tense.Future, "oor 2 sekondes" },
         { "af", 1, TimeUnit.Minute, Tense.Past, "1 minuut terug" },
@@ -1441,6 +1456,7 @@ static class LocalePhraseTheoryData
 
     public static TheoryData<string, string> NullDateHumanizeCases => new()
     {
+        { "am", "በጭራሽ" },
         { "af", "nooit" },
         { "ar", "أبدًا" },
         { "az", "heç vaxt" },
@@ -1548,6 +1564,16 @@ static class LocalePhraseTheoryData
 
     public static TheoryData<string, int, TimeUnit, bool, string> TimeSpanHumanizeCases => new()
     {
+        { "am", 1, TimeUnit.Second, false, "1 ሰከንድ" },
+        { "am", 2, TimeUnit.Second, false, "2 ሰከንዶች" },
+        { "am", 1, TimeUnit.Minute, false, "1 ደቂቃ" },
+        { "am", 2, TimeUnit.Minute, false, "2 ደቂቃዎች" },
+        { "am", 1, TimeUnit.Hour, false, "1 ሰዓት" },
+        { "am", 2, TimeUnit.Hour, false, "2 ሰዓታት" },
+        { "am", 1, TimeUnit.Day, false, "1 ቀን" },
+        { "am", 2, TimeUnit.Day, false, "2 ቀናት" },
+        { "am", 0, TimeUnit.Millisecond, false, "0 ሚሊሰከንዶች" },
+        { "am", 0, TimeUnit.Millisecond, true, "ጊዜ የለም" },
         { "af", 1, TimeUnit.Second, false, "1 sekonde" },
         { "af", 2, TimeUnit.Second, false, "2 sekondes" },
         { "af", 1, TimeUnit.Minute, false, "1 minuut" },

--- a/tests/Humanizer.Tests/Localisation/am/AmharicLocaleParityTests.cs
+++ b/tests/Humanizer.Tests/Localisation/am/AmharicLocaleParityTests.cs
@@ -1,0 +1,173 @@
+namespace Humanizer.Tests.Localisation.am;
+
+[UseCulture("am")]
+public class AmharicLocaleParityTests
+{
+    static readonly CultureInfo Am = new("am");
+    static readonly int[] Pair = [1, 2];
+    static readonly int[] Triple = [1, 2, 3];
+
+    [Fact]
+    public void ListHumanize_UsesAmharicConjunction()
+    {
+        Assert.Equal("1 እና 2", Pair.Humanize());
+        Assert.Equal("1, 2 እና 3", Triple.Humanize());
+    }
+
+    [Theory]
+    [InlineData(1, TimeUnit.Day, Tense.Past, "ትናንት")]
+    [InlineData(1, TimeUnit.Day, Tense.Future, "ነገ")]
+    [InlineData(2, TimeUnit.Day, Tense.Past, "ከ 2 ቀናት በፊት")]
+    [InlineData(2, TimeUnit.Day, Tense.Future, "ከ 2 ቀናት በኋላ")]
+    [InlineData(1, TimeUnit.Hour, Tense.Past, "ከ1 ሰዓት በፊት")]
+    [InlineData(2, TimeUnit.Hour, Tense.Future, "ከ 2 ሰዓታት በኋላ")]
+    [InlineData(0, TimeUnit.Second, Tense.Future, "አሁን")]
+    public void DateHumanize_UsesAmharicPhrases(int count, TimeUnit unit, Tense tense, string expected)
+    {
+        var formatter = Configurator.Formatters.ResolveForCulture(Am);
+        Assert.Equal(expected, formatter.DateHumanize(unit, tense, count));
+    }
+
+    [Fact]
+    public void NullableDateHumanize_NullDateUsesAmharicNeverPhrase()
+    {
+        DateTime? date = null;
+        Assert.Equal("በጭራሽ", date.Humanize(culture: Am));
+    }
+
+    [Theory]
+    [InlineData(1, "1 ሰዓት")]
+    [InlineData(2, "2 ሰዓታት")]
+    public void Duration_UsesAmharicUnitForms(int hours, string expected)
+    {
+        Assert.Equal(expected, TimeSpan.FromHours(hours).Humanize(culture: Am));
+    }
+
+    [Fact]
+    public void Duration_ToWordsUsesAmharicNumberWords()
+    {
+        Assert.Equal("አንድ ቀን", TimeSpan.FromDays(1).Humanize(toWords: true, culture: Am));
+    }
+
+    [Theory]
+    [InlineData(DataUnit.Bit, 1, "ቢት")]
+    [InlineData(DataUnit.Byte, 1, "ባይት")]
+    [InlineData(DataUnit.Byte, 2, "ባይቶች")]
+    [InlineData(DataUnit.Kilobyte, 2, "ኪሎባይቶች")]
+    [InlineData(DataUnit.Megabyte, 2, "ሜጋባይቶች")]
+    public void DataUnit_FullWordForms(DataUnit unit, int count, string expected)
+    {
+        var formatter = Configurator.Formatters.ResolveForCulture(Am);
+        Assert.Equal(expected, formatter.DataUnitHumanize(unit, count, toSymbol: false));
+    }
+
+    [Theory]
+    [InlineData(TimeUnit.Millisecond, "ሚሊሰከንድ")]
+    [InlineData(TimeUnit.Second, "ሰከንድ")]
+    [InlineData(TimeUnit.Minute, "ደቂቃ")]
+    [InlineData(TimeUnit.Hour, "ሰዓት")]
+    [InlineData(TimeUnit.Day, "ቀን")]
+    [InlineData(TimeUnit.Week, "ሳምንት")]
+    [InlineData(TimeUnit.Month, "ወር")]
+    [InlineData(TimeUnit.Year, "ዓመት")]
+    public void TimeUnitSymbols(TimeUnit unit, string expected)
+    {
+        var formatter = Configurator.Formatters.ResolveForCulture(Am);
+        Assert.Equal(expected, formatter.TimeUnitHumanize(unit));
+    }
+
+    [Theory]
+    [InlineData(0, "ዜሮ")]
+    [InlineData(21, "ሃያ አንድ")]
+    [InlineData(1234567, "አንድ ሚሊዮን ሁለት መቶ ሰላሳ አራት ሺህ አምስት መቶ ስልሳ ሰባት")]
+    [InlineData(1234567890, "አንድ ቢሊዮን ሁለት መቶ ሰላሳ አራት ሚሊዮን አምስት መቶ ስልሳ ሰባት ሺህ ስምንት መቶ ዘጠና")]
+    public void NumberToWords_ProducesAmharicCardinals(long number, string expected)
+    {
+        Assert.Equal(expected, number.ToWords(Am));
+    }
+
+    [Theory]
+    [InlineData(1, "አንደኛ")]
+    [InlineData(21, "ሃያ አንደኛ")]
+    [InlineData(1000, "አንድ ሺኛ")]
+    public void ToOrdinalWords_ProducesAmharicOrdinals(int number, string expected)
+    {
+        Assert.Equal(expected, number.ToOrdinalWords(Am));
+    }
+
+    [Theory]
+    [InlineData("ሃያ አንድ", 21)]
+    [InlineData("አንድ መቶ አምስት", 105)]
+    [InlineData("አንድ ሺህ አንድ", 1001)]
+    [InlineData("ሃያ አንደኛ", 21)]
+    public void WordsToNumber_ParsesAmharicCardinalsAndOrdinals(string words, long expected)
+    {
+        Assert.Equal(expected, words.ToNumber(Am));
+    }
+
+    [Theory]
+    [InlineData(1, "1ኛ")]
+    [InlineData(23, "23ኛ")]
+    [InlineData(-1, "-1ኛ")]
+    public void Ordinalize_UsesAmharicNumericSuffix(int number, string expected)
+    {
+        Assert.Equal(expected, number.Ordinalize(Am));
+    }
+
+    [Theory]
+    [InlineData(2022, 1, 25, "25 ጃንዋሪ 2022")]
+    [InlineData(2015, 2, 3, "3 ፌብሩዋሪ 2015")]
+    [InlineData(2024, 12, 31, "31 ዲሴምበር 2024")]
+    public void DateTime_ToOrdinalWords_ExactOutput(int year, int month, int day, string expected)
+    {
+        Assert.Equal(expected, new DateTime(year, month, day).ToOrdinalWords());
+    }
+
+#if NET6_0_OR_GREATER
+    [Theory]
+    [InlineData(2022, 1, 25, "25 ጃንዋሪ 2022")]
+    [InlineData(2015, 2, 3, "3 ፌብሩዋሪ 2015")]
+    public void DateOnly_ToOrdinalWords_ExactOutput(int year, int month, int day, string expected)
+    {
+        Assert.Equal(expected, new DateOnly(year, month, day).ToOrdinalWords());
+    }
+
+    [Theory]
+    [InlineData(1, 5, "ከሌሊቱ አንድ ሰዓት አምስት ደቂቃ")]
+    [InlineData(13, 0, "ከሰዓት በኋላ አንድ ሰዓት")]
+    [InlineData(13, 23, "ከሰዓት በኋላ አንድ ሰዓት ሃያ ሶስት ደቂቃ")]
+    [InlineData(18, 0, "ማታ ስድስት ሰዓት")]
+    public void ToClockNotation_ExactOutput(int hours, int minutes, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(hours, minutes).ToClockNotation());
+    }
+
+    [Fact]
+    public void ToClockNotation_Rounded_ExactOutput()
+    {
+        Assert.Equal("ከሰዓት በኋላ አንድ ሰዓት ሃያ አምስት ደቂቃ", new TimeOnly(13, 23).ToClockNotation(ClockNotationRounding.NearestFiveMinutes));
+    }
+#endif
+
+    [Theory]
+    [InlineData(0.0, "ሰሜን")]
+    [InlineData(45.0, "ሰሜን ምስራቅ")]
+    [InlineData(90.0, "ምስራቅ")]
+    [InlineData(180.0, "ደቡብ")]
+    [InlineData(270.0, "ምዕራብ")]
+    public void Compass_FullDirections(double angle, string expected)
+    {
+        Assert.Equal(expected, angle.ToHeading(HeadingStyle.Full));
+    }
+
+    [Theory]
+    [InlineData(0.0, "ሰ")]
+    [InlineData(45.0, "ሰም")]
+    [InlineData(90.0, "ም")]
+    [InlineData(180.0, "ደ")]
+    [InlineData(270.0, "ምዕ")]
+    public void Compass_AbbreviatedDirections(double angle, string expected)
+    {
+        Assert.Equal(expected, angle.ToHeading(HeadingStyle.Abbreviated));
+    }
+}


### PR DESCRIPTION
## Summary
- Add locale-owned Amharic (`am`) YAML surfaces for list formatting, formatter phrases, number words/parser data, ordinal/date/clock/compass behavior.
- Add Amharic exact-output coverage plus locale theory matrix rows for formatter, phrase, number, ordinalizer, magnitude, overload, date, and clock surfaces.
- No shared generator/runtime/schema/number contract changes; this does not compete with the shared number-contract work owned by `feat/locale-sw`.

## Validation
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0 --no-restore` — passed, 41746 total, 0 failed.
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0 --no-restore` — passed, 41746 total, 0 failed.
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0 --no-restore` — passed, 41746 total, 0 failed.
- `dotnet test tests/Humanizer.SourceGenerators.Tests/Humanizer.SourceGenerators.Tests.csproj --framework net11.0 --no-restore` — passed, 104 total, 0 failed.
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o artifacts/locale-parity-validation` — passed.
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — passed.

## Known unresolved gate
- Native/near-native Amharic review remains required before claiming final locale parity. The automated proposer/reviewer pass supported the terms but explicitly could not claim native/near-native Amharic naturalness judgment.
- `tests/Humanizer.SourceGenerators.Tests` currently targets `net11.0` only; attempting `--framework net10.0` fails before test execution with a target-framework/assets mismatch.
