### PR TITLE
Add Swahili locale parity

### DIFF
--- a/src/Humanizer.SourceGenerators/Common/EngineContractCatalog.cs
+++ b/src/Humanizer.SourceGenerators/Common/EngineContractCatalog.cs
@@ -531,9 +531,10 @@ public sealed partial class HumanizerSourceGenerator
                         ),
                 Member("culture", null, null, null, null, null, null, null)
             ),
-                // Shared scale-leading compound engine for languages that say scale nouns before their count token,
-                // e.g. "hundred two" or "thousand two", with data-driven tens conjunction and parser
-                // support for the same scale-token order.
+                // Shared scale-leading compound engine for languages that say scale nouns before their
+                // count token, e.g. "hundred one and two" or "thousand two". The conjunction is
+                // data-driven for tens+units and terminal sub-hundred remainders; higher-scale
+                // remainders are space-joined. The parser supports the same scale-token order.
                 ["scale-leading-compound"] = Schema("scale-leading-compound", null,
                 Member("profile-object", null, null, null, null, null, null, null,
                             Member("string", "zeroWord", null, null, null, null, null, null),

--- a/src/Humanizer.SourceGenerators/Common/EngineContractCatalog.cs
+++ b/src/Humanizer.SourceGenerators/Common/EngineContractCatalog.cs
@@ -531,7 +531,22 @@ public sealed partial class HumanizerSourceGenerator
                         ),
                 Member("culture", null, null, null, null, null, null, null)
             ),
-                // Shared Scandinavian-style engine where the runtime decomposition is stable but the cardinal and ordinal scale strategies diverge by profile data. Strategy enums name the structural choice, not the locale.
+                // Shared scale-leading compound engine for languages that say scale nouns before their count token,
+                // e.g. "hundred two" or "thousand two", with data-driven tens conjunction and parser
+                // support for the same scale-token order.
+                ["scale-leading-compound"] = Schema("scale-leading-compound", null,
+                Member("profile-object", null, null, null, null, null, null, null,
+                            Member("string", "zeroWord", null, null, null, null, null, null),
+                            Member("string", "minusWord", null, null, null, null, null, null),
+                            Member("string", "conjunctionWord", null, null, null, null, null, null),
+                            Member("string", "ordinalPrefix", null, null, null, "", null, null),
+                            Member("string", "ordinalSuffix", null, null, null, "", null, null),
+                            Member("string-array", "unitsMap", null, null, null, null, null, null),
+                            Member("string-array", "tensMap", null, null, null, null, null, null),
+                            Member("builder", "scales", null, null, "scale-leading-compound-scale-array", null, null, null),
+                            Member("nullable-int-string-dictionary", "ordinalMap", null, null, null, null, null, "empty")
+                        )
+            ),
                 ["scale-strategy"] = Schema("scale-strategy", null,
                 Member("profile-object", null, null, null, null, null, null, null,
                             Member("enum", "cardinalStrategy", null, "ScaleStrategyCardinalMode", null, null, null, null),

--- a/src/Humanizer.SourceGenerators/Common/GenerationHelpers.cs
+++ b/src/Humanizer.SourceGenerators/Common/GenerationHelpers.cs
@@ -922,6 +922,14 @@ public sealed partial class HumanizerSourceGenerator
             BooleanValue("displayOneUnit"),
             OptionalEnumValue("gender", "GrammaticalGender", "masculine"));
 
+
+    static string CreateScaleLeadingCompoundScaleArrayExpression(JsonElement arrayElement)
+        => CreateTypedConstructorArrayExpression(
+            "ScaleLeadingCompoundScale",
+            arrayElement,
+            RequiredInt64Value("value"),
+            RequiredStringValue("name"));
+
     static string CreateUnitLeadingCompoundScaleArrayExpression(JsonElement arrayElement)
         => CreateTypedConstructorArrayExpression(
             "UnitLeadingCompoundScale",

--- a/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/NumberToWordsEngineContractFactory.cs
+++ b/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/NumberToWordsEngineContractFactory.cs
@@ -170,6 +170,7 @@ public sealed partial class HumanizerSourceGenerator
                 "ordinal-prefix-scale-array" => CreateOrdinalPrefixScaleArrayExpression(builderRoot),
                 "inverted-tens-scale-array" => CreateInvertedTensScaleArrayExpression(builderRoot),
                 "south-slavic-scale-array" => CreateSouthSlavicScaleArrayExpression(builderRoot),
+                "scale-leading-compound-scale-array" => CreateScaleLeadingCompoundScaleArrayExpression(builderRoot),
                 "scandinavian-scale-array" => CreateScaleStrategyScaleArrayExpression(builderRoot),
                 "unit-leading-compound-scale-array" => CreateUnitLeadingCompoundScaleArrayExpression(builderRoot),
                 "conjoined-gendered-scale-array" => CreateConjoinedGenderedScaleArrayExpression(builderRoot),

--- a/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/WordsToNumberEngineContractFactory.cs
+++ b/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/WordsToNumberEngineContractFactory.cs
@@ -27,6 +27,7 @@ public sealed partial class HumanizerSourceGenerator
                 "greedy-compound" => CreateGreedyCompoundExpression(profile),
                 "inverted-tens" => CreateInvertedTensExpression(profile.Root),
                 "linking-affix" => CreateLinkingAffixExpression(profile.Root),
+                "scale-leading-compound" => CreateScaleLeadingCompoundExpression(profile.Root),
                 "prefixed-tens-scale" => CreatePrefixedTensScaleExpression(profile.Root),
                 "suffix-scale" => CreateSuffixScaleExpression(profile.Root),
                 "token-map" => "new TokenMapWordsToNumberConverter(" + CreateTokenMapRulesExpression(profile.Root) + ")",
@@ -111,6 +112,18 @@ public sealed partial class HumanizerSourceGenerator
             CreateStringArrayExpression(EngineContractUtilities.GetRequiredElement(root, "linkedSuffixes")) + ", " +
             CreateOptionalStringArrayExpression(root, "ignoredTokens") + ", " +
             CreateOptionalStringArrayExpression(root, "negativePrefixes") +
+            "))";
+
+        static string CreateScaleLeadingCompoundExpression(JsonElement root) =>
+            "new ScaleLeadingCompoundWordsToNumberConverter(new ScaleLeadingCompoundWordsToNumberProfile(" +
+            CreateStringLongFrozenDictionaryExpression(EngineContractUtilities.GetRequiredElement(root, "unitsMap")) + ", " +
+            CreateStringLongFrozenDictionaryExpression(EngineContractUtilities.GetRequiredElement(root, "tensMap")) + ", " +
+            CreateScaleLeadingCompoundScaleArrayExpression(EngineContractUtilities.GetRequiredElement(root, "scales")) + ", " +
+            QuoteLiteral(GetRequiredString(root, "conjunctionWord")) + ", " +
+            QuoteLiteral(GetRequiredString(root, "minusWord")) + ", " +
+            QuoteLiteral(GetOptionalString(root, "ordinalPrefix") ?? string.Empty) + ", " +
+            QuoteLiteral(GetOptionalString(root, "ordinalSuffix") ?? string.Empty) + ", " +
+            CreateOptionalStringLongFrozenDictionaryExpression(root, "ordinalMap") +
             "))";
 
         static string CreatePrefixedTensScaleExpression(JsonElement root) =>

--- a/src/Humanizer/Locales/sw.yml
+++ b/src/Humanizer/Locales/sw.yml
@@ -209,25 +209,25 @@ surfaces:
       millisecond:
         symbol: 'ms'
       second:
-        symbol: 'sekunde'
+        symbol: 'sek'
       minute:
-        symbol: 'dakika'
+        symbol: 'dak'
       hour:
         symbol: 'saa'
       day:
-        symbol: 'siku'
+        symbol: 'sk'
       week:
-        symbol: 'wiki'
+        symbol: 'wk'
       month:
-        symbol: 'mwezi'
+        symbol: 'mwez'
       year:
-        symbol: 'mwaka'
+        symbol: 'mwk'
 
   number:
     words:
       engine: 'scale-leading-compound'
       zeroWord: 'sifuri'
-      minusWord: 'minus'
+      minusWord: 'hasi'
       conjunctionWord: 'na'
       ordinalPrefix: 'ya '
       unitsMap:
@@ -299,7 +299,7 @@ surfaces:
     parse:
       engine: 'scale-leading-compound'
       conjunctionWord: 'na'
-      minusWord: 'minus'
+      minusWord: 'hasi'
       ordinalPrefix: 'ya '
       unitsMap:
         sifuri: 0
@@ -373,21 +373,22 @@ surfaces:
 
   clock:
     engine: 'phrase-clock'
+    # Traditional Swahili time names hours from the 6:00/18:00 boundary: 1 PM is saa saba.
     hourMode: 'h12'
     hourWordsMap:
       - ''
-      - 'moja'
-      - 'mbili'
-      - 'tatu'
-      - 'nne'
-      - 'tano'
-      - 'sita'
       - 'saba'
       - 'nane'
       - 'tisa'
       - 'kumi'
       - 'kumi na moja'
       - 'kumi na mbili'
+      - 'moja'
+      - 'mbili'
+      - 'tatu'
+      - 'nne'
+      - 'tano'
+      - 'sita'
     min0: 'saa {hour} {dayPeriod}'
     defaultTemplate: 'saa {hour} na dakika {minutes} {dayPeriod}'
     earlyMorning: 'asubuhi'

--- a/src/Humanizer/Locales/sw.yml
+++ b/src/Humanizer/Locales/sw.yml
@@ -1,0 +1,435 @@
+locale: 'sw'
+
+surfaces:
+  list:
+    engine: 'conjunction'
+    value: 'na'
+
+  formatter:
+    engine: 'profiled'
+    pluralRule: 'singular-plural'
+    dataUnitPluralRule: 'singular-plural'
+
+  phrases:
+    relativeDate:
+      now: 'sasa'
+      never: 'kamwe'
+      past:
+        millisecond:
+          single: 'milisekunde 1 iliyopita'
+          multiple:
+            forms:
+              default: 'milisekunde'
+            template: '{count} milisekunde zilizopita'
+        second:
+          single: 'sekunde 1 iliyopita'
+          multiple:
+            forms:
+              default: 'sekunde'
+            template: '{count} sekunde zilizopita'
+        minute:
+          single: 'dakika 1 iliyopita'
+          multiple:
+            forms:
+              default: 'dakika'
+            template: '{count} dakika zilizopita'
+        hour:
+          single: 'saa 1 iliyopita'
+          multiple:
+            forms:
+              default: 'saa'
+            template: '{count} saa zilizopita'
+        day:
+          single: 'jana'
+          multiple:
+            forms:
+              default: 'siku'
+            template: '{count} siku zilizopita'
+        week:
+          single: 'wiki 1 iliyopita'
+          multiple:
+            forms:
+              default: 'wiki'
+            template: '{count} wiki zilizopita'
+        month:
+          single: 'mwezi 1 uliopita'
+          multiple:
+            forms:
+              default: 'miezi'
+            template: '{count} miezi iliyopita'
+        year:
+          single: 'mwaka 1 uliopita'
+          multiple:
+            forms:
+              default: 'miaka'
+            template: '{count} miaka iliyopita'
+      future:
+        millisecond:
+          single: 'baada ya milisekunde 1'
+          multiple:
+            forms:
+              default: 'milisekunde'
+            template: 'baada ya milisekunde {count}'
+        second:
+          single: 'baada ya sekunde 1'
+          multiple:
+            forms:
+              default: 'sekunde'
+            template: 'baada ya sekunde {count}'
+        minute:
+          single: 'baada ya dakika 1'
+          multiple:
+            forms:
+              default: 'dakika'
+            template: 'baada ya dakika {count}'
+        hour:
+          single: 'baada ya saa 1'
+          multiple:
+            forms:
+              default: 'saa'
+            template: 'baada ya saa {count}'
+        day:
+          single: 'kesho'
+          multiple:
+            forms:
+              default: 'siku'
+            template: 'baada ya siku {count}'
+        week:
+          single: 'baada ya wiki 1'
+          multiple:
+            forms:
+              default: 'wiki'
+            template: 'baada ya wiki {count}'
+        month:
+          single: 'baada ya mwezi 1'
+          multiple:
+            forms:
+              default: 'miezi'
+            template: 'baada ya miezi {count}'
+        year:
+          single: 'baada ya mwaka 1'
+          multiple:
+            forms:
+              default: 'miaka'
+            template: 'baada ya miaka {count}'
+    duration:
+      zero: 'hakuna muda'
+      age:
+        template: 'umri wa {value}'
+      millisecond:
+        single:
+          numeric: 'milisekunde 1'
+          words: 'milisekunde moja'
+        multiple:
+          countPlacement: 'after-form'
+          forms:
+            default: 'milisekunde'
+      second:
+        single:
+          numeric: 'sekunde 1'
+          words: 'sekunde moja'
+        multiple:
+          countPlacement: 'after-form'
+          forms:
+            default: 'sekunde'
+      minute:
+        single:
+          numeric: 'dakika 1'
+          words: 'dakika moja'
+        multiple:
+          countPlacement: 'after-form'
+          forms:
+            default: 'dakika'
+      hour:
+        single:
+          numeric: 'saa 1'
+          words: 'saa moja'
+        multiple:
+          countPlacement: 'after-form'
+          forms:
+            default: 'saa'
+      day:
+        single:
+          numeric: 'siku 1'
+          words: 'siku moja'
+        multiple:
+          countPlacement: 'after-form'
+          forms:
+            default: 'siku'
+      week:
+        single:
+          numeric: 'wiki 1'
+          words: 'wiki moja'
+        multiple:
+          countPlacement: 'after-form'
+          forms:
+            default: 'wiki'
+      month:
+        single:
+          numeric: 'mwezi 1'
+          words: 'mwezi mmoja'
+        multiple:
+          countPlacement: 'after-form'
+          forms:
+            default: 'miezi'
+      year:
+        single:
+          numeric: 'mwaka 1'
+          words: 'mwaka mmoja'
+        multiple:
+          countPlacement: 'after-form'
+          forms:
+            default: 'miaka'
+    dataUnits:
+      bit:
+        forms:
+          default: 'biti'
+        symbol: 'b'
+      byte:
+        forms:
+          default: 'baiti'
+        symbol: 'B'
+      kilobyte:
+        forms:
+          default: 'kilobaiti'
+        symbol: 'KB'
+      megabyte:
+        forms:
+          default: 'megabaiti'
+        symbol: 'MB'
+      gigabyte:
+        forms:
+          default: 'gigabaiti'
+        symbol: 'GB'
+      terabyte:
+        forms:
+          default: 'terabaiti'
+        symbol: 'TB'
+    timeUnits:
+      millisecond:
+        symbol: 'ms'
+      second:
+        symbol: 'sekunde'
+      minute:
+        symbol: 'dakika'
+      hour:
+        symbol: 'saa'
+      day:
+        symbol: 'siku'
+      week:
+        symbol: 'wiki'
+      month:
+        symbol: 'mwezi'
+      year:
+        symbol: 'mwaka'
+
+  number:
+    words:
+      engine: 'scale-leading-compound'
+      zeroWord: 'sifuri'
+      minusWord: 'minus'
+      conjunctionWord: 'na'
+      ordinalPrefix: 'ya '
+      unitsMap:
+        - 'sifuri'
+        - 'moja'
+        - 'mbili'
+        - 'tatu'
+        - 'nne'
+        - 'tano'
+        - 'sita'
+        - 'saba'
+        - 'nane'
+        - 'tisa'
+        - 'kumi'
+        - 'kumi na moja'
+        - 'kumi na mbili'
+        - 'kumi na tatu'
+        - 'kumi na nne'
+        - 'kumi na tano'
+        - 'kumi na sita'
+        - 'kumi na saba'
+        - 'kumi na nane'
+        - 'kumi na tisa'
+      tensMap:
+        2: 'ishirini'
+        3: 'thelathini'
+        4: 'arobaini'
+        5: 'hamsini'
+        6: 'sitini'
+        7: 'sabini'
+        8: 'themanini'
+        9: 'tisini'
+      scales:
+        -
+          value: 1000000000000000000
+          name: 'kwintilioni'
+        -
+          value: 1000000000000000
+          name: 'kwadrilioni'
+        -
+          value: 1000000000000
+          name: 'trilioni'
+        -
+          value: 1000000000
+          name: 'bilioni'
+        -
+          value: 1000000
+          name: 'milioni'
+        -
+          value: 100000
+          name: 'laki'
+        -
+          value: 1000
+          name: 'elfu'
+        -
+          value: 100
+          name: 'mia'
+      ordinalMap:
+        1: 'kwanza'
+        2: 'pili'
+        3: 'tatu'
+        4: 'nne'
+        5: 'tano'
+        6: 'sita'
+        7: 'saba'
+        8: 'nane'
+        9: 'tisa'
+        10: 'kumi'
+    parse:
+      engine: 'scale-leading-compound'
+      conjunctionWord: 'na'
+      minusWord: 'minus'
+      ordinalPrefix: 'ya '
+      unitsMap:
+        sifuri: 0
+        moja: 1
+        mbili: 2
+        tatu: 3
+        nne: 4
+        tano: 5
+        sita: 6
+        saba: 7
+        nane: 8
+        tisa: 9
+      tensMap:
+        kumi: 10
+        ishirini: 20
+        thelathini: 30
+        arobaini: 40
+        hamsini: 50
+        sitini: 60
+        sabini: 70
+        themanini: 80
+        tisini: 90
+      scales:
+        -
+          value: 1000000000000000000
+          name: 'kwintilioni'
+        -
+          value: 1000000000000000
+          name: 'kwadrilioni'
+        -
+          value: 1000000000000
+          name: 'trilioni'
+        -
+          value: 1000000000
+          name: 'bilioni'
+        -
+          value: 1000000
+          name: 'milioni'
+        -
+          value: 100000
+          name: 'laki'
+        -
+          value: 1000
+          name: 'elfu'
+        -
+          value: 100
+          name: 'mia'
+      ordinalMap:
+        kwanza: 1
+        pili: 2
+        tatu: 3
+        nne: 4
+        tano: 5
+        sita: 6
+        saba: 7
+        nane: 8
+        tisa: 9
+        kumi: 10
+
+  ordinal:
+    numeric:
+      engine: 'template'
+      masculine:
+        defaultSuffix: ''
+    date:
+      pattern: '{day} MMMM yyyy'
+      dayMode: 'Numeric'
+    dateOnly:
+      pattern: '{day} MMMM yyyy'
+      dayMode: 'Numeric'
+
+  clock:
+    engine: 'phrase-clock'
+    hourMode: 'h12'
+    hourWordsMap:
+      - ''
+      - 'moja'
+      - 'mbili'
+      - 'tatu'
+      - 'nne'
+      - 'tano'
+      - 'sita'
+      - 'saba'
+      - 'nane'
+      - 'tisa'
+      - 'kumi'
+      - 'kumi na moja'
+      - 'kumi na mbili'
+    min0: 'saa {hour} {dayPeriod}'
+    defaultTemplate: 'saa {hour} na dakika {minutes} {dayPeriod}'
+    earlyMorning: 'asubuhi'
+    morning: 'asubuhi'
+    afternoon: 'mchana'
+    evening: 'jioni'
+    night: 'usiku'
+    eveningStartHour: 18
+    nightStartHour: 21
+
+  compass:
+    full:
+      - 'kaskazini'
+      - 'kaskazini-kaskazini mashariki'
+      - 'kaskazini mashariki'
+      - 'mashariki-kaskazini mashariki'
+      - 'mashariki'
+      - 'mashariki-kusini mashariki'
+      - 'kusini mashariki'
+      - 'kusini-kusini mashariki'
+      - 'kusini'
+      - 'kusini-kusini magharibi'
+      - 'kusini magharibi'
+      - 'magharibi-kusini magharibi'
+      - 'magharibi'
+      - 'magharibi-kaskazini magharibi'
+      - 'kaskazini magharibi'
+      - 'kaskazini-kaskazini magharibi'
+    short:
+      - 'K'
+      - 'KKM'
+      - 'KM'
+      - 'MKM'
+      - 'M'
+      - 'MKS'
+      - 'KS'
+      - 'KKS'
+      - 'S'
+      - 'KKG'
+      - 'KG'
+      - 'MKG'
+      - 'G'
+      - 'MKGz'
+      - 'KGz'
+      - 'KKGz'

--- a/src/Humanizer/Localisation/NumberToWords/ScaleLeadingCompoundNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/ScaleLeadingCompoundNumberToWordsConverter.cs
@@ -69,6 +69,7 @@ class ScaleLeadingCompoundNumberToWordsConverter(ScaleLeadingCompoundNumberToWor
 
         var parts = new List<string>();
         var remainder = number;
+        var consumedScale = false;
         foreach (var scale in profile.Scales)
         {
             var scaleValue = (ulong)scale.Value;
@@ -80,6 +81,12 @@ class ScaleLeadingCompoundNumberToWordsConverter(ScaleLeadingCompoundNumberToWor
 
             parts.Add(scale.Name + " " + ConvertPositive(count));
             remainder %= scaleValue;
+            consumedScale = true;
+        }
+
+        if (!consumedScale)
+        {
+            throw new InvalidOperationException("Scale-leading compound number profiles require a scale value no greater than 100.");
         }
 
         if (remainder > 0)
@@ -165,6 +172,11 @@ sealed class ScaleLeadingCompoundNumberToWordsProfile(
 
     static ScaleLeadingCompoundScale[] ValidateScales(ScaleLeadingCompoundScale[] value)
     {
+        if (value.Length == 0 || value[^1].Value > 100)
+        {
+            throw new InvalidOperationException("Scale-leading compound number profiles require a scale value no greater than 100.");
+        }
+
         for (var i = 0; i < value.Length; i++)
         {
             if (value[i].Value <= 0)

--- a/src/Humanizer/Localisation/NumberToWords/ScaleLeadingCompoundNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/ScaleLeadingCompoundNumberToWordsConverter.cs
@@ -19,10 +19,13 @@ class ScaleLeadingCompoundNumberToWordsConverter(ScaleLeadingCompoundNumberToWor
 
         if (number < 0)
         {
-            return profile.MinusWord + " " + Convert(-number);
+            var magnitude = number == long.MinValue
+                ? (ulong)long.MaxValue + 1UL
+                : (ulong)-number;
+            return profile.MinusWord + " " + ConvertPositive(magnitude);
         }
 
-        return ConvertPositive(number);
+        return ConvertPositive((ulong)number);
     }
 
     /// <inheritdoc />
@@ -36,11 +39,11 @@ class ScaleLeadingCompoundNumberToWordsConverter(ScaleLeadingCompoundNumberToWor
         return profile.OrdinalPrefix + Convert(number) + profile.OrdinalSuffix;
     }
 
-    string ConvertPositive(long number)
+    string ConvertPositive(ulong number)
     {
-        if (number < profile.UnitsMap.Length)
+        if (number < (ulong)profile.UnitsMap.Length)
         {
-            return profile.UnitsMap[number];
+            return profile.UnitsMap[(int)number];
         }
 
         if (number < 100)
@@ -52,14 +55,15 @@ class ScaleLeadingCompoundNumberToWordsConverter(ScaleLeadingCompoundNumberToWor
         var remainder = number;
         foreach (var scale in profile.Scales)
         {
-            var count = remainder / scale.Value;
+            var scaleValue = (ulong)scale.Value;
+            var count = remainder / scaleValue;
             if (count == 0)
             {
                 continue;
             }
 
             parts.Add(scale.Name + " " + ConvertPositive(count));
-            remainder %= scale.Value;
+            remainder %= scaleValue;
         }
 
         if (remainder > 0)
@@ -75,14 +79,14 @@ class ScaleLeadingCompoundNumberToWordsConverter(ScaleLeadingCompoundNumberToWor
         return string.Join(" ", parts);
     }
 
-    string ConvertUnderOneHundred(long number)
+    string ConvertUnderOneHundred(ulong number)
     {
         var tens = number / 10;
         var units = number % 10;
-        var tensWord = profile.TensMap[tens];
+        var tensWord = profile.TensMap[(int)tens];
         return units == 0
             ? tensWord
-            : tensWord + " " + profile.ConjunctionWord + " " + profile.UnitsMap[units];
+            : tensWord + " " + profile.ConjunctionWord + " " + profile.UnitsMap[(int)units];
     }
 }
 

--- a/src/Humanizer/Localisation/NumberToWords/ScaleLeadingCompoundNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/ScaleLeadingCompoundNumberToWordsConverter.cs
@@ -1,0 +1,128 @@
+namespace Humanizer;
+
+/// <summary>
+/// Renders decimal numbering systems where scale nouns lead their counts, for example
+/// "hundred two" or "thousand one", while sub-hundred compounds keep a tens-plus-unit
+/// conjunction.
+/// </summary>
+class ScaleLeadingCompoundNumberToWordsConverter(ScaleLeadingCompoundNumberToWordsProfile profile) : GenderlessNumberToWordsConverter
+{
+    readonly ScaleLeadingCompoundNumberToWordsProfile profile = profile;
+
+    /// <inheritdoc />
+    public override string Convert(long number)
+    {
+        if (number == 0)
+        {
+            return profile.ZeroWord;
+        }
+
+        if (number < 0)
+        {
+            return profile.MinusWord + " " + Convert(-number);
+        }
+
+        return ConvertPositive(number);
+    }
+
+    /// <inheritdoc />
+    public override string ConvertToOrdinal(int number)
+    {
+        if (profile.OrdinalMap.TryGetValue(number, out var ordinal))
+        {
+            return ordinal;
+        }
+
+        return profile.OrdinalPrefix + Convert(number) + profile.OrdinalSuffix;
+    }
+
+    string ConvertPositive(long number)
+    {
+        if (number < profile.UnitsMap.Length)
+        {
+            return profile.UnitsMap[number];
+        }
+
+        if (number < 100)
+        {
+            return ConvertUnderOneHundred(number);
+        }
+
+        var parts = new List<string>();
+        var remainder = number;
+        foreach (var scale in profile.Scales)
+        {
+            var count = remainder / scale.Value;
+            if (count == 0)
+            {
+                continue;
+            }
+
+            parts.Add(scale.Name + " " + ConvertPositive(count));
+            remainder %= scale.Value;
+        }
+
+        if (remainder > 0)
+        {
+            if (remainder < 100)
+            {
+                parts.Add(profile.ConjunctionWord);
+            }
+
+            parts.Add(ConvertPositive(remainder));
+        }
+
+        return string.Join(" ", parts);
+    }
+
+    string ConvertUnderOneHundred(long number)
+    {
+        var tens = number / 10;
+        var units = number % 10;
+        var tensWord = profile.TensMap[tens];
+        return units == 0
+            ? tensWord
+            : tensWord + " " + profile.ConjunctionWord + " " + profile.UnitsMap[units];
+    }
+}
+
+/// <summary>
+/// Immutable generated profile for <see cref="ScaleLeadingCompoundNumberToWordsConverter"/>.
+/// </summary>
+sealed class ScaleLeadingCompoundNumberToWordsProfile(
+    string zeroWord,
+    string minusWord,
+    string conjunctionWord,
+    string ordinalPrefix,
+    string ordinalSuffix,
+    string[] unitsMap,
+    string[] tensMap,
+    ScaleLeadingCompoundScale[] scales,
+    FrozenDictionary<int, string>? ordinalMap = null)
+{
+    /// <summary>Gets the word used for zero.</summary>
+    public string ZeroWord { get; } = zeroWord;
+    /// <summary>Gets the word used to prefix negative numbers.</summary>
+    public string MinusWord { get; } = minusWord;
+    /// <summary>Gets the conjunction inserted before sub-hundred remainders and between tens and units.</summary>
+    public string ConjunctionWord { get; } = conjunctionWord;
+    /// <summary>Gets the ordinal prefix used when no exact ordinal exists.</summary>
+    public string OrdinalPrefix { get; } = ordinalPrefix;
+    /// <summary>Gets the ordinal suffix used when no exact ordinal exists.</summary>
+    public string OrdinalSuffix { get; } = ordinalSuffix;
+    /// <summary>Gets cardinal words for zero through nineteen.</summary>
+    public string[] UnitsMap { get; } = unitsMap;
+    /// <summary>Gets decade words keyed by their tens digit.</summary>
+    public string[] TensMap { get; } = tensMap;
+    /// <summary>Gets descending scale rows.</summary>
+    public ScaleLeadingCompoundScale[] Scales { get; } = scales;
+    /// <summary>Gets exact ordinal words keyed by numeric value.</summary>
+    public FrozenDictionary<int, string> OrdinalMap { get; } = ordinalMap ?? FrozenDictionary<int, string>.Empty;
+}
+
+/// <summary>
+/// One descending scale row for scale-leading compound renderers.
+/// </summary>
+/// <param name="Value">The numeric scale value.</param>
+/// <param name="Name">The localized scale noun.</param>
+readonly record struct ScaleLeadingCompoundScale(long Value, string Name);

--- a/src/Humanizer/Localisation/NumberToWords/ScaleLeadingCompoundNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/ScaleLeadingCompoundNumberToWordsConverter.cs
@@ -1,9 +1,12 @@
 namespace Humanizer;
 
 /// <summary>
-/// Renders decimal numbering systems where scale nouns lead their counts, for example
-/// "hundred two" or "thousand one", while sub-hundred compounds keep a tens-plus-unit
-/// conjunction.
+/// Renders decimal numbering systems where scale nouns lead their count words, for example
+/// "hundred one and two" or "thousand two", while sub-hundred compounds keep a
+/// tens-plus-unit conjunction.
+///
+/// The conjunction supplied by the profile is inserted between tens and units and before
+/// terminal sub-hundred remainders only. Higher-scale remainders are space-joined.
 /// </summary>
 class ScaleLeadingCompoundNumberToWordsConverter(ScaleLeadingCompoundNumberToWordsProfile profile) : GenderlessNumberToWordsConverter
 {
@@ -31,12 +34,25 @@ class ScaleLeadingCompoundNumberToWordsConverter(ScaleLeadingCompoundNumberToWor
     /// <inheritdoc />
     public override string ConvertToOrdinal(int number)
     {
-        if (profile.OrdinalMap.TryGetValue(number, out var ordinal))
+        if (number < 0)
+        {
+            var magnitude = number == int.MinValue
+                ? (ulong)int.MaxValue + 1UL
+                : (ulong)-number;
+            return profile.MinusWord + " " + ConvertPositiveToOrdinal(magnitude);
+        }
+
+        return ConvertPositiveToOrdinal((ulong)number);
+    }
+
+    string ConvertPositiveToOrdinal(ulong number)
+    {
+        if (number <= int.MaxValue && profile.OrdinalMap.TryGetValue((int)number, out var ordinal))
         {
             return ordinal;
         }
 
-        return profile.OrdinalPrefix + Convert(number) + profile.OrdinalSuffix;
+        return profile.OrdinalPrefix + ConvertPositive(number) + profile.OrdinalSuffix;
     }
 
     string ConvertPositive(ulong number)
@@ -108,20 +124,62 @@ sealed class ScaleLeadingCompoundNumberToWordsProfile(
     public string ZeroWord { get; } = zeroWord;
     /// <summary>Gets the word used to prefix negative numbers.</summary>
     public string MinusWord { get; } = minusWord;
-    /// <summary>Gets the conjunction inserted before sub-hundred remainders and between tens and units.</summary>
+    /// <summary>
+    /// Gets the conjunction inserted between tens and units and before terminal sub-hundred
+    /// remainders. The scale-leading engine does not insert this conjunction before
+    /// remainders of one hundred or greater.
+    /// </summary>
     public string ConjunctionWord { get; } = conjunctionWord;
     /// <summary>Gets the ordinal prefix used when no exact ordinal exists.</summary>
     public string OrdinalPrefix { get; } = ordinalPrefix;
     /// <summary>Gets the ordinal suffix used when no exact ordinal exists.</summary>
     public string OrdinalSuffix { get; } = ordinalSuffix;
     /// <summary>Gets cardinal words for zero through nineteen.</summary>
-    public string[] UnitsMap { get; } = unitsMap;
+    public string[] UnitsMap { get; } = ValidateUnitsMap(unitsMap);
     /// <summary>Gets decade words keyed by their tens digit.</summary>
-    public string[] TensMap { get; } = tensMap;
+    public string[] TensMap { get; } = ValidateTensMap(tensMap);
     /// <summary>Gets descending scale rows.</summary>
-    public ScaleLeadingCompoundScale[] Scales { get; } = scales;
+    public ScaleLeadingCompoundScale[] Scales { get; } = ValidateScales(scales);
     /// <summary>Gets exact ordinal words keyed by numeric value.</summary>
     public FrozenDictionary<int, string> OrdinalMap { get; } = ordinalMap ?? FrozenDictionary<int, string>.Empty;
+
+    static string[] ValidateUnitsMap(string[] value)
+    {
+        if (value.Length < 20)
+        {
+            throw new InvalidOperationException("Scale-leading compound number profiles require unit words for 0 through 19.");
+        }
+
+        return value;
+    }
+
+    static string[] ValidateTensMap(string[] value)
+    {
+        if (value.Length < 10)
+        {
+            throw new InvalidOperationException("Scale-leading compound number profiles require decade words keyed through index 9.");
+        }
+
+        return value;
+    }
+
+    static ScaleLeadingCompoundScale[] ValidateScales(ScaleLeadingCompoundScale[] value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i].Value <= 0)
+            {
+                throw new InvalidOperationException("Scale-leading compound number profiles require positive scale values.");
+            }
+
+            if (i > 0 && value[i - 1].Value <= value[i].Value)
+            {
+                throw new InvalidOperationException("Scale-leading compound number profiles require scales in descending order.");
+            }
+        }
+
+        return value;
+    }
 }
 
 /// <summary>

--- a/src/Humanizer/Localisation/WordsToNumber/ScaleLeadingCompoundWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/ScaleLeadingCompoundWordsToNumberConverter.cs
@@ -65,9 +65,11 @@ internal class ScaleLeadingCompoundWordsToNumberConverter(ScaleLeadingCompoundWo
 
         try
         {
-            if (TryParseValue(tokens, 0, tokens.Length, long.MaxValue, out var value, out var next) && next == tokens.Length)
+            var maxValue = negative ? (ulong)long.MaxValue + 1UL : long.MaxValue;
+            if (TryParseValue(tokens, 0, tokens.Length, maxValue, out var value, out var next) &&
+                next == tokens.Length &&
+                TryCoerceParsedValue(value, negative, out parsedValue))
             {
-                parsedValue = negative ? -value : value;
                 unrecognizedWord = null;
                 return true;
             }
@@ -81,7 +83,7 @@ internal class ScaleLeadingCompoundWordsToNumberConverter(ScaleLeadingCompoundWo
         return false;
     }
 
-    bool TryParseValue(string[] tokens, int start, int end, long maxValue, out long value, out int next)
+    bool TryParseValue(string[] tokens, int start, int end, ulong maxValue, out ulong value, out int next)
     {
         value = 0;
         next = start;
@@ -90,18 +92,19 @@ internal class ScaleLeadingCompoundWordsToNumberConverter(ScaleLeadingCompoundWo
         for (var scaleIndex = 0; scaleIndex < profile.Scales.Length; scaleIndex++)
         {
             var scale = profile.Scales[scaleIndex];
-            if (scale.Value > maxValue || next >= end || tokens[next] != scale.Name)
+            var scaleValue = (ulong)scale.Value;
+            if (scaleValue > maxValue || next >= end || tokens[next] != scale.Name)
             {
                 continue;
             }
 
-            var maxCount = Math.Min(GetMaximumCountForScale(scaleIndex), maxValue / scale.Value);
+            var maxCount = Math.Min(GetMaximumCountForScale(scaleIndex), maxValue / scaleValue);
             if (maxCount <= 0 || !TryParseCount(tokens, next + 1, end, maxCount, out var count, out var afterCount) || count <= 0)
             {
                 return false;
             }
 
-            value = checked(value + checked(count * scale.Value));
+            value = checked(value + checked(count * scaleValue));
             next = afterCount;
             consumed = true;
         }
@@ -114,7 +117,7 @@ internal class ScaleLeadingCompoundWordsToNumberConverter(ScaleLeadingCompoundWo
                 remainderStart++;
             }
 
-            var remainingMax = maxValue == long.MaxValue ? long.MaxValue : maxValue - value;
+            var remainingMax = maxValue == ulong.MaxValue ? ulong.MaxValue : maxValue - value;
             if (TryParseUnderOneHundred(tokens, remainderStart, end, Math.Min(remainingMax, 99), out var remainder, out var afterRemainder))
             {
                 value = checked(value + remainder);
@@ -126,7 +129,7 @@ internal class ScaleLeadingCompoundWordsToNumberConverter(ScaleLeadingCompoundWo
         return consumed;
     }
 
-    bool TryParseCount(string[] tokens, int start, int end, long maxValue, out long value, out int next)
+    bool TryParseCount(string[] tokens, int start, int end, ulong maxValue, out ulong value, out int next)
     {
         if (maxValue <= 9)
         {
@@ -141,35 +144,39 @@ internal class ScaleLeadingCompoundWordsToNumberConverter(ScaleLeadingCompoundWo
         return TryParseValue(tokens, start, end, maxValue, out value, out next);
     }
 
-    bool TryParseUnderOneHundred(string[] tokens, int start, int end, long maxValue, out long value, out int next)
+    bool TryParseUnderOneHundred(string[] tokens, int start, int end, ulong maxValue, out ulong value, out int next)
     {
         if (TryParseUnit(tokens, start, end, maxValue, out value, out next))
         {
             return true;
         }
 
-        if (start >= end || !profile.Tens.TryGetValue(tokens[start], out var tensValue) || tensValue > maxValue)
+        if (start >= end || !profile.Tens.TryGetValue(tokens[start], out var rawTensValue) || rawTensValue < 0 || (ulong)rawTensValue > maxValue)
         {
             value = default;
             next = start;
             return false;
         }
 
-        value = tensValue;
+        value = (ulong)rawTensValue;
         next = start + 1;
-        if (next + 1 < end && tokens[next] == profile.ConjunctionWord && profile.Units.TryGetValue(tokens[next + 1], out var unitValue) && unitValue is >= 1 and <= 9 && value + unitValue <= maxValue)
+        if (next + 1 < end && tokens[next] == profile.ConjunctionWord && profile.Units.TryGetValue(tokens[next + 1], out var rawUnitValue) && rawUnitValue is >= 1 and <= 9 && value + (ulong)rawUnitValue <= maxValue)
         {
-            value += unitValue;
+            value += (ulong)rawUnitValue;
             next += 2;
         }
 
         return true;
     }
 
-    bool TryParseUnit(string[] tokens, int start, int end, long maxValue, out long value, out int next)
+    bool TryParseUnit(string[] tokens, int start, int end, ulong maxValue, out ulong value, out int next)
     {
-        if (start < end && profile.Units.TryGetValue(tokens[start], out value) && value <= maxValue)
+        if (start < end &&
+            profile.Units.TryGetValue(tokens[start], out var rawValue) &&
+            rawValue >= 0 &&
+            (ulong)rawValue <= maxValue)
         {
+            value = (ulong)rawValue;
             next = start + 1;
             return true;
         }
@@ -179,14 +186,40 @@ internal class ScaleLeadingCompoundWordsToNumberConverter(ScaleLeadingCompoundWo
         return false;
     }
 
-    long GetMaximumCountForScale(int scaleIndex)
+    static bool TryCoerceParsedValue(ulong value, bool negative, out long parsedValue)
+    {
+        if (negative)
+        {
+            if (value == (ulong)long.MaxValue + 1UL)
+            {
+                parsedValue = long.MinValue;
+                return true;
+            }
+
+            if (value <= long.MaxValue)
+            {
+                parsedValue = -(long)value;
+                return true;
+            }
+        }
+        else if (value <= long.MaxValue)
+        {
+            parsedValue = (long)value;
+            return true;
+        }
+
+        parsedValue = default;
+        return false;
+    }
+
+    ulong GetMaximumCountForScale(int scaleIndex)
     {
         if (scaleIndex == 0)
         {
-            return long.MaxValue / profile.Scales[scaleIndex].Value;
+            return ulong.MaxValue / (ulong)profile.Scales[scaleIndex].Value;
         }
 
-        return profile.Scales[scaleIndex - 1].Value / profile.Scales[scaleIndex].Value - 1;
+        return (ulong)(profile.Scales[scaleIndex - 1].Value / profile.Scales[scaleIndex].Value - 1);
     }
 
     static string Normalize(string value) =>

--- a/src/Humanizer/Localisation/WordsToNumber/ScaleLeadingCompoundWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/ScaleLeadingCompoundWordsToNumberConverter.cs
@@ -27,7 +27,9 @@ internal class ScaleLeadingCompoundWordsToNumberConverter(ScaleLeadingCompoundWo
     {
         if (string.IsNullOrWhiteSpace(words))
         {
-            throw new ArgumentException("Input words cannot be empty.");
+            parsedValue = default;
+            unrecognizedWord = words ?? string.Empty;
+            return false;
         }
 
         var normalized = Normalize(words);
@@ -38,12 +40,7 @@ internal class ScaleLeadingCompoundWordsToNumberConverter(ScaleLeadingCompoundWo
             normalized = normalized[(profile.MinusWord.Length + 1)..];
         }
 
-        if (profile.OrdinalMap.TryGetValue(normalized, out var ordinalValue))
-        {
-            parsedValue = negative ? -ordinalValue : ordinalValue;
-            unrecognizedWord = null;
-            return true;
-        }
+        var ordinalCandidate = normalized;
 
         if (profile.OrdinalPrefix.Length > 0 && normalized.StartsWith(profile.OrdinalPrefix, StringComparison.Ordinal))
         {
@@ -63,23 +60,29 @@ internal class ScaleLeadingCompoundWordsToNumberConverter(ScaleLeadingCompoundWo
             return false;
         }
 
-        try
+        var maxValue = negative ? (ulong)long.MaxValue + 1UL : long.MaxValue;
+        if (TryParseValue(tokens, 0, tokens.Length, maxValue, out var value, out var next) &&
+            next == tokens.Length)
         {
-            var maxValue = negative ? (ulong)long.MaxValue + 1UL : long.MaxValue;
-            if (TryParseValue(tokens, 0, tokens.Length, maxValue, out var value, out var next) &&
-                next == tokens.Length &&
-                TryCoerceParsedValue(value, negative, out parsedValue))
+            if (TryCoerceParsedValue(value, negative, out parsedValue))
             {
                 unrecognizedWord = null;
                 return true;
             }
+
+            parsedValue = default;
+            unrecognizedWord = words;
+            return false;
         }
-        catch (OverflowException)
+
+        if (TryParseOrdinalCandidate(ordinalCandidate, normalized, negative, out parsedValue))
         {
+            unrecognizedWord = null;
+            return true;
         }
 
         parsedValue = default;
-        unrecognizedWord = tokens[0];
+        unrecognizedWord = GetUnrecognizedWord(tokens, next, words);
         return false;
     }
 
@@ -104,7 +107,13 @@ internal class ScaleLeadingCompoundWordsToNumberConverter(ScaleLeadingCompoundWo
                 return false;
             }
 
-            value = checked(value + checked(count * scaleValue));
+            if (count > (maxValue - value) / scaleValue)
+            {
+                next = afterCount;
+                return false;
+            }
+
+            value += count * scaleValue;
             next = afterCount;
             consumed = true;
         }
@@ -120,7 +129,13 @@ internal class ScaleLeadingCompoundWordsToNumberConverter(ScaleLeadingCompoundWo
             var remainingMax = maxValue == ulong.MaxValue ? ulong.MaxValue : maxValue - value;
             if (TryParseUnderOneHundred(tokens, remainderStart, end, Math.Min(remainingMax, 99), out var remainder, out var afterRemainder))
             {
-                value = checked(value + remainder);
+                if (remainder > maxValue - value)
+                {
+                    next = afterRemainder;
+                    return false;
+                }
+
+                value += remainder;
                 next = afterRemainder;
                 consumed = true;
             }
@@ -219,7 +234,60 @@ internal class ScaleLeadingCompoundWordsToNumberConverter(ScaleLeadingCompoundWo
             return ulong.MaxValue / (ulong)profile.Scales[scaleIndex].Value;
         }
 
-        return (ulong)(profile.Scales[scaleIndex - 1].Value / profile.Scales[scaleIndex].Value - 1);
+        var previous = (ulong)profile.Scales[scaleIndex - 1].Value;
+        var current = (ulong)profile.Scales[scaleIndex].Value;
+        if (previous <= current || previous % current != 0)
+        {
+            throw new InvalidOperationException("Scale-leading compound parser profiles require descending scales where each larger scale is divisible by the next smaller scale.");
+        }
+
+        return previous / current - 1UL;
+    }
+
+    bool TryParseOrdinalCandidate(string originalCandidate, string strippedCandidate, bool negative, out long parsedValue)
+    {
+        if (TryParseOrdinalCandidate(originalCandidate, negative, out parsedValue))
+        {
+            return true;
+        }
+
+        return !string.Equals(originalCandidate, strippedCandidate, StringComparison.Ordinal) &&
+            TryParseOrdinalCandidate(strippedCandidate, negative, out parsedValue);
+    }
+
+    bool TryParseOrdinalCandidate(string candidate, bool negative, out long parsedValue)
+    {
+        if (profile.OrdinalMap.TryGetValue(candidate, out var ordinalValue))
+        {
+            parsedValue = negative ? -ordinalValue : ordinalValue;
+            return true;
+        }
+
+        parsedValue = default;
+        return false;
+    }
+
+    string GetUnrecognizedWord(string[] tokens, int next, string words)
+    {
+        if (next > 0 && next < tokens.Length)
+        {
+            return tokens[next];
+        }
+
+        foreach (var token in tokens)
+        {
+            if (token != profile.ConjunctionWord &&
+                token != profile.MinusWord &&
+                !profile.Units.ContainsKey(token) &&
+                !profile.Tens.ContainsKey(token) &&
+                !profile.OrdinalMap.ContainsKey(token) &&
+                !profile.Scales.Any(scale => scale.Name == token))
+            {
+                return token;
+            }
+        }
+
+        return words;
     }
 
     static string Normalize(string value) =>
@@ -244,7 +312,7 @@ internal sealed class ScaleLeadingCompoundWordsToNumberProfile(
     /// <summary>Gets decade tokens.</summary>
     public FrozenDictionary<string, long> Tens { get; } = tens;
     /// <summary>Gets descending scale rows.</summary>
-    public ScaleLeadingCompoundScale[] Scales { get; } = scales;
+    public ScaleLeadingCompoundScale[] Scales { get; } = ValidateScales(scales);
     /// <summary>Gets the conjunction token.</summary>
     public string ConjunctionWord { get; } = conjunctionWord;
     /// <summary>Gets the negative prefix token.</summary>
@@ -255,4 +323,27 @@ internal sealed class ScaleLeadingCompoundWordsToNumberProfile(
     public string OrdinalSuffix { get; } = ordinalSuffix;
     /// <summary>Gets exact ordinal tokens.</summary>
     public FrozenDictionary<string, long> OrdinalMap { get; } = ordinalMap ?? FrozenDictionary<string, long>.Empty;
+
+    static ScaleLeadingCompoundScale[] ValidateScales(ScaleLeadingCompoundScale[] value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i].Value <= 0)
+            {
+                throw new InvalidOperationException("Scale-leading compound parser profiles require positive scale values.");
+            }
+
+            if (i > 0)
+            {
+                var previous = (ulong)value[i - 1].Value;
+                var current = (ulong)value[i].Value;
+                if (previous <= current || previous % current != 0)
+                {
+                    throw new InvalidOperationException("Scale-leading compound parser profiles require descending scales where each larger scale is divisible by the next smaller scale.");
+                }
+            }
+        }
+
+        return value;
+    }
 }

--- a/src/Humanizer/Localisation/WordsToNumber/ScaleLeadingCompoundWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/ScaleLeadingCompoundWordsToNumberConverter.cs
@@ -1,0 +1,225 @@
+namespace Humanizer;
+
+/// <summary>
+/// Parses decimal number words whose scale nouns precede their count words.
+/// </summary>
+internal class ScaleLeadingCompoundWordsToNumberConverter(ScaleLeadingCompoundWordsToNumberProfile profile) : GenderlessWordsToNumberConverter
+{
+    readonly ScaleLeadingCompoundWordsToNumberProfile profile = profile;
+
+    /// <inheritdoc />
+    public override long Convert(string words)
+    {
+        if (!TryConvert(words, out var parsedValue, out var unrecognizedWord))
+        {
+            throw new ArgumentException($"Unrecognized number word: {unrecognizedWord}");
+        }
+
+        return parsedValue;
+    }
+
+    /// <inheritdoc />
+    public override bool TryConvert(string words, out long parsedValue) =>
+        TryConvert(words, out parsedValue, out _);
+
+    /// <inheritdoc />
+    public override bool TryConvert(string words, out long parsedValue, out string? unrecognizedWord)
+    {
+        if (string.IsNullOrWhiteSpace(words))
+        {
+            throw new ArgumentException("Input words cannot be empty.");
+        }
+
+        var normalized = Normalize(words);
+        var negative = false;
+        if (normalized.StartsWith(profile.MinusWord + " ", StringComparison.Ordinal))
+        {
+            negative = true;
+            normalized = normalized[(profile.MinusWord.Length + 1)..];
+        }
+
+        if (profile.OrdinalMap.TryGetValue(normalized, out var ordinalValue))
+        {
+            parsedValue = negative ? -ordinalValue : ordinalValue;
+            unrecognizedWord = null;
+            return true;
+        }
+
+        if (profile.OrdinalPrefix.Length > 0 && normalized.StartsWith(profile.OrdinalPrefix, StringComparison.Ordinal))
+        {
+            normalized = normalized[profile.OrdinalPrefix.Length..].TrimStart();
+        }
+
+        if (profile.OrdinalSuffix.Length > 0 && normalized.EndsWith(profile.OrdinalSuffix, StringComparison.Ordinal))
+        {
+            normalized = normalized[..^profile.OrdinalSuffix.Length].TrimEnd();
+        }
+
+        var tokens = normalized.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length == 0)
+        {
+            parsedValue = default;
+            unrecognizedWord = words;
+            return false;
+        }
+
+        try
+        {
+            if (TryParseValue(tokens, 0, tokens.Length, long.MaxValue, out var value, out var next) && next == tokens.Length)
+            {
+                parsedValue = negative ? -value : value;
+                unrecognizedWord = null;
+                return true;
+            }
+        }
+        catch (OverflowException)
+        {
+        }
+
+        parsedValue = default;
+        unrecognizedWord = tokens[0];
+        return false;
+    }
+
+    bool TryParseValue(string[] tokens, int start, int end, long maxValue, out long value, out int next)
+    {
+        value = 0;
+        next = start;
+        var consumed = false;
+
+        for (var scaleIndex = 0; scaleIndex < profile.Scales.Length; scaleIndex++)
+        {
+            var scale = profile.Scales[scaleIndex];
+            if (scale.Value > maxValue || next >= end || tokens[next] != scale.Name)
+            {
+                continue;
+            }
+
+            var maxCount = Math.Min(GetMaximumCountForScale(scaleIndex), maxValue / scale.Value);
+            if (maxCount <= 0 || !TryParseCount(tokens, next + 1, end, maxCount, out var count, out var afterCount) || count <= 0)
+            {
+                return false;
+            }
+
+            value = checked(value + checked(count * scale.Value));
+            next = afterCount;
+            consumed = true;
+        }
+
+        if (next < end)
+        {
+            var remainderStart = next;
+            if (consumed && tokens[remainderStart] == profile.ConjunctionWord)
+            {
+                remainderStart++;
+            }
+
+            var remainingMax = maxValue == long.MaxValue ? long.MaxValue : maxValue - value;
+            if (TryParseUnderOneHundred(tokens, remainderStart, end, Math.Min(remainingMax, 99), out var remainder, out var afterRemainder))
+            {
+                value = checked(value + remainder);
+                next = afterRemainder;
+                consumed = true;
+            }
+        }
+
+        return consumed;
+    }
+
+    bool TryParseCount(string[] tokens, int start, int end, long maxValue, out long value, out int next)
+    {
+        if (maxValue <= 9)
+        {
+            return TryParseUnit(tokens, start, end, maxValue, out value, out next);
+        }
+
+        if (maxValue < 100)
+        {
+            return TryParseUnderOneHundred(tokens, start, end, maxValue, out value, out next);
+        }
+
+        return TryParseValue(tokens, start, end, maxValue, out value, out next);
+    }
+
+    bool TryParseUnderOneHundred(string[] tokens, int start, int end, long maxValue, out long value, out int next)
+    {
+        if (TryParseUnit(tokens, start, end, maxValue, out value, out next))
+        {
+            return true;
+        }
+
+        if (start >= end || !profile.Tens.TryGetValue(tokens[start], out var tensValue) || tensValue > maxValue)
+        {
+            value = default;
+            next = start;
+            return false;
+        }
+
+        value = tensValue;
+        next = start + 1;
+        if (next + 1 < end && tokens[next] == profile.ConjunctionWord && profile.Units.TryGetValue(tokens[next + 1], out var unitValue) && unitValue is >= 1 and <= 9 && value + unitValue <= maxValue)
+        {
+            value += unitValue;
+            next += 2;
+        }
+
+        return true;
+    }
+
+    bool TryParseUnit(string[] tokens, int start, int end, long maxValue, out long value, out int next)
+    {
+        if (start < end && profile.Units.TryGetValue(tokens[start], out value) && value <= maxValue)
+        {
+            next = start + 1;
+            return true;
+        }
+
+        value = default;
+        next = start;
+        return false;
+    }
+
+    long GetMaximumCountForScale(int scaleIndex)
+    {
+        if (scaleIndex == 0)
+        {
+            return long.MaxValue / profile.Scales[scaleIndex].Value;
+        }
+
+        return profile.Scales[scaleIndex - 1].Value / profile.Scales[scaleIndex].Value - 1;
+    }
+
+    static string Normalize(string value) =>
+        string.Join(" ", value.Trim().ToLowerInvariant().Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+}
+
+/// <summary>
+/// Immutable generated profile for <see cref="ScaleLeadingCompoundWordsToNumberConverter"/>.
+/// </summary>
+internal sealed class ScaleLeadingCompoundWordsToNumberProfile(
+    FrozenDictionary<string, long> units,
+    FrozenDictionary<string, long> tens,
+    ScaleLeadingCompoundScale[] scales,
+    string conjunctionWord,
+    string minusWord,
+    string ordinalPrefix,
+    string ordinalSuffix,
+    FrozenDictionary<string, long>? ordinalMap = null)
+{
+    /// <summary>Gets unit and teen tokens.</summary>
+    public FrozenDictionary<string, long> Units { get; } = units;
+    /// <summary>Gets decade tokens.</summary>
+    public FrozenDictionary<string, long> Tens { get; } = tens;
+    /// <summary>Gets descending scale rows.</summary>
+    public ScaleLeadingCompoundScale[] Scales { get; } = scales;
+    /// <summary>Gets the conjunction token.</summary>
+    public string ConjunctionWord { get; } = conjunctionWord;
+    /// <summary>Gets the negative prefix token.</summary>
+    public string MinusWord { get; } = minusWord;
+    /// <summary>Gets the ordinal prefix token.</summary>
+    public string OrdinalPrefix { get; } = ordinalPrefix;
+    /// <summary>Gets the ordinal suffix token.</summary>
+    public string OrdinalSuffix { get; } = ordinalSuffix;
+    /// <summary>Gets exact ordinal tokens.</summary>
+    public FrozenDictionary<string, long> OrdinalMap { get; } = ordinalMap ?? FrozenDictionary<string, long>.Empty;
+}

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.CanonicalSchema.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.CanonicalSchema.cs
@@ -195,6 +195,7 @@ surfaces:
 
         Assert.Contains("ScaleLeadingCompoundNumberToWordsConverter", numberToWordsSource, StringComparison.Ordinal);
         Assert.Contains("ScaleLeadingCompoundScale", numberToWordsSource, StringComparison.Ordinal);
+        Assert.Contains("new string[] { \"\", \"\", \"twenty\", \"thirty\"", numberToWordsSource, StringComparison.Ordinal);
         Assert.Contains("ScaleLeadingCompoundWordsToNumberConverter", wordsToNumberSource, StringComparison.Ordinal);
         Assert.Contains("[\"twenty\"] = 20", wordsToNumberSource, StringComparison.Ordinal);
     }

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.CanonicalSchema.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.CanonicalSchema.cs
@@ -101,6 +101,104 @@ surfaces:
         Assert.Contains("[\"huge\"] = 2147483648", childTokenMapSource, StringComparison.Ordinal);
     }
 
+
+    [Fact]
+    public void CanonicalLocaleSchemaEmitsScaleLeadingCompoundNumberProfiles()
+    {
+        const string locale = """
+locale: 'zz-scale'
+surfaces:
+  number:
+    words:
+      engine: 'scale-leading-compound'
+      zeroWord: 'zero'
+      minusWord: 'minus'
+      conjunctionWord: 'and'
+      ordinalPrefix: 'ord '
+      unitsMap:
+        - 'zero'
+        - 'one'
+        - 'two'
+        - 'three'
+        - 'four'
+        - 'five'
+        - 'six'
+        - 'seven'
+        - 'eight'
+        - 'nine'
+        - 'ten'
+        - 'eleven'
+        - 'twelve'
+        - 'thirteen'
+        - 'fourteen'
+        - 'fifteen'
+        - 'sixteen'
+        - 'seventeen'
+        - 'eighteen'
+        - 'nineteen'
+      tensMap:
+        2: 'twenty'
+        3: 'thirty'
+        4: 'forty'
+        5: 'fifty'
+        6: 'sixty'
+        7: 'seventy'
+        8: 'eighty'
+        9: 'ninety'
+      scales:
+        -
+          value: 1000
+          name: 'thousand'
+        -
+          value: 100
+          name: 'hundred'
+      ordinalMap:
+        1: 'first'
+    parse:
+      engine: 'scale-leading-compound'
+      minusWord: 'minus'
+      conjunctionWord: 'and'
+      ordinalPrefix: 'ord '
+      unitsMap:
+        zero: 0
+        one: 1
+        two: 2
+        ten: 10
+      tensMap:
+        twenty: 20
+        thirty: 30
+      scales:
+        -
+          value: 1000
+          name: 'thousand'
+        -
+          value: 100
+          name: 'hundred'
+      ordinalMap:
+        first: 1
+""";
+
+        var runResult = RunGenerator(new InMemoryAdditionalText(
+            "src/Humanizer/Locales/zz-scale.yml",
+            locale));
+
+        Assert.Empty(runResult.Diagnostics);
+
+        var numberToWordsSource = runResult.Results[0].GeneratedSources
+            .Single(source => source.HintName == "NumberToWordsProfileCatalog.g.cs")
+            .SourceText
+            .ToString();
+        var wordsToNumberSource = runResult.Results[0].GeneratedSources
+            .Single(source => source.HintName == "WordsToNumberProfileCatalog.g.cs")
+            .SourceText
+            .ToString();
+
+        Assert.Contains("ScaleLeadingCompoundNumberToWordsConverter", numberToWordsSource, StringComparison.Ordinal);
+        Assert.Contains("ScaleLeadingCompoundScale", numberToWordsSource, StringComparison.Ordinal);
+        Assert.Contains("ScaleLeadingCompoundWordsToNumberConverter", wordsToNumberSource, StringComparison.Ordinal);
+        Assert.Contains("[\"twenty\"] = 20", wordsToNumberSource, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void CanonicalLocaleSchemaRejectsOldTopLevelFeatureBlocks()
     {

--- a/tests/Humanizer.Tests/Localisation/LocaleCoverageData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleCoverageData.cs
@@ -13,6 +13,7 @@ static class LocaleCoverageData
     // Representative non-first-of-month date sample.
     public static TheoryData<string, DateExpectationRow> DateToOrdinalWords2022January25ExpectationTheoryData { get; } = new()
     {
+        { "sw", new(2022, 1, 25, "25 Januari 2022") },
         { "hi", new(2022, 1, 25, "25 जनवरी 2022") },
 
         { "af", new(2022, 1, 25, "25 Januarie 2022") },
@@ -85,6 +86,7 @@ static class LocaleCoverageData
     // First-of-month sample where many locales change the day form.
     public static TheoryData<string, DateExpectationRow> DateToOrdinalWords2015January1ExpectationTheoryData { get; } = new()
     {
+        { "sw", new(2015, 1, 1, "1 Januari 2015") },
         { "hi", new(2015, 1, 1, "1 जनवरी 2015") },
 
         { "af", new(2015, 1, 1, "1 Januarie 2015") },
@@ -157,6 +159,7 @@ static class LocaleCoverageData
     // Early-month sample used to catch plain numeric-day formatting.
     public static TheoryData<string, DateExpectationRow> DateToOrdinalWords2015February3ExpectationTheoryData { get; } = new()
     {
+        { "sw", new(2015, 2, 3, "3 Februari 2015") },
         { "hi", new(2015, 2, 3, "3 फ़रवरी 2015") },
 
         { "af", new(2015, 2, 3, "3 Februarie 2015") },
@@ -278,6 +281,7 @@ static class LocaleCoverageData
     // Unrounded afternoon clock sample.
     public static TheoryData<string, ClockExpectationRow> TimeOnlyToClockNotation1323ExpectationTheoryData { get; } = new()
     {
+        { "sw", new(13, 23, "saa moja na dakika ishirini na tatu mchana") },
         { "hi", new(13, 23, "दोपहर एक बजकर तेईस मिनट") },
 
         { "af", new(13, 23, "een uur drie en twintig") },
@@ -350,6 +354,7 @@ static class LocaleCoverageData
     // Same afternoon clock sample rounded to the nearest five minutes.
     public static TheoryData<string, ClockExpectationRow> TimeOnlyToClockNotation1323RoundedExpectationTheoryData { get; } = new()
     {
+        { "sw", new(13, 23, "saa moja na dakika ishirini na tano mchana") },
         { "hi", new(13, 23, "दोपहर एक बजकर पच्चीस मिनट") },
 
         { "af", new(13, 23, "een uur vyf en twintig") },
@@ -422,6 +427,7 @@ static class LocaleCoverageData
     // Early-morning sample that catches one-o'clock phrasing and culture short-time output.
     public static TheoryData<string, ClockExpectationRow> TimeOnlyToClockNotation0105ExpectationTheoryData { get; } = new()
     {
+        { "sw", new(1, 5, "saa moja na dakika tano asubuhi") },
         { "hi", new(1, 5, "सुबह एक बजकर पाँच मिनट") },
 
         { "af", new(1, 5, "een uur vyf") },
@@ -877,6 +883,7 @@ static class LocaleCoverageData
             { "zh-Hans", "昨天", "2 天" },
             { "zh-Hant", "昨天", "2 天" },
             { "zu-ZA", "izolo", "2 izinsuku" },
+            { "sw", "jana", "siku 2" },
                     { "hi", "कल", "2 दिन" },
         };
 
@@ -948,6 +955,7 @@ static class LocaleCoverageData
             { "zh-Hans", "1、2", "1、2、3" },
             { "zh-Hant", "1、2", "1、2、3" },
             { "zu-ZA", "1 na 2", "1, 2 na 3" },
+            { "sw", "1 na 2", "1, 2 na 3" },
                     { "hi", "1 और 2", "1, 2 और 3" },
         };
 
@@ -1019,6 +1027,7 @@ static class LocaleCoverageData
             { "zh-Hans", 1, "第 一" },
             { "zh-Hant", 1, "第 一" },
             { "zu-ZA", 1, "okokuqala" },
+            { "sw", 1, "kwanza" },
                     { "hi", 1, "पहली" },
         };
 
@@ -1090,6 +1099,7 @@ static class LocaleCoverageData
             { "zh-Hans", 1, "一" },
             { "zh-Hant", 1, "一" },
             { "zu-ZA", 1, "kanye" },
+            { "sw", 1, "moja" },
                     { "hi", 1, "एक" },
         };
 
@@ -1197,6 +1207,7 @@ static class LocaleCoverageData
             { "zh-Hans", 21, "二十一" },
             { "zh-Hant", 21, "二十一" },
             { "zu-ZA", 21, "amashumi amabili kanye" },
+            { "sw", 21, "ishirini na moja" },
                     { "hi", 21, "इक्कीस" },
         };
 

--- a/tests/Humanizer.Tests/Localisation/LocaleCoverageData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleCoverageData.cs
@@ -281,7 +281,7 @@ static class LocaleCoverageData
     // Unrounded afternoon clock sample.
     public static TheoryData<string, ClockExpectationRow> TimeOnlyToClockNotation1323ExpectationTheoryData { get; } = new()
     {
-        { "sw", new(13, 23, "saa moja na dakika ishirini na tatu mchana") },
+        { "sw", new(13, 23, "saa saba na dakika ishirini na tatu mchana") },
         { "hi", new(13, 23, "दोपहर एक बजकर तेईस मिनट") },
 
         { "af", new(13, 23, "een uur drie en twintig") },
@@ -354,7 +354,7 @@ static class LocaleCoverageData
     // Same afternoon clock sample rounded to the nearest five minutes.
     public static TheoryData<string, ClockExpectationRow> TimeOnlyToClockNotation1323RoundedExpectationTheoryData { get; } = new()
     {
-        { "sw", new(13, 23, "saa moja na dakika ishirini na tano mchana") },
+        { "sw", new(13, 23, "saa saba na dakika ishirini na tano mchana") },
         { "hi", new(13, 23, "दोपहर एक बजकर पच्चीस मिनट") },
 
         { "af", new(13, 23, "een uur vyf en twintig") },
@@ -427,7 +427,7 @@ static class LocaleCoverageData
     // Early-morning sample that catches one-o'clock phrasing and culture short-time output.
     public static TheoryData<string, ClockExpectationRow> TimeOnlyToClockNotation0105ExpectationTheoryData { get; } = new()
     {
-        { "sw", new(1, 5, "saa moja na dakika tano asubuhi") },
+        { "sw", new(1, 5, "saa saba na dakika tano asubuhi") },
         { "hi", new(1, 5, "सुबह एक बजकर पाँच मिनट") },
 
         { "af", new(1, 5, "een uur vyf") },

--- a/tests/Humanizer.Tests/Localisation/LocaleFormatterExactTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleFormatterExactTheoryData.cs
@@ -326,7 +326,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, TimeUnitSymbolExpectationRow> TimeUnitSymbolCases => new()
     {
-        { "sw", new("ms", "sekunde", "dakika", "saa", "siku", "wiki", "mwezi", "mwaka") },
+        { "sw", new("ms", "sek", "dak", "saa", "sk", "wk", "mwez", "mwk") },
         { "af", new("ms", "sek.", "min.", "uur", "dag", "week", "maand", "jaar") },
         { "ar", new("مللي ثانية", "ثانية", "دقيقة", "ساعة", "يوم", "أسبوع", "شهر", "سنة") },
         { "az", new("ms", "saniyə", "dəqiqə", "saat", "gün", "həftə", "ay", "il") },

--- a/tests/Humanizer.Tests/Localisation/LocaleFormatterExactTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleFormatterExactTheoryData.cs
@@ -182,6 +182,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, DateDayPluralExpectationRow> DateDayPluralCases => new()
     {
+        { "sw", new("2 siku zilizopita", "3 siku zilizopita", "4 siku zilizopita", "5 siku zilizopita", "11 siku zilizopita", "21 siku zilizopita", "baada ya siku 2", "baada ya siku 3", "baada ya siku 4", "baada ya siku 5", "baada ya siku 11", "baada ya siku 21") },
         { "af", new("2 dae gelede", "3 dae gelede", "4 dae gelede", "5 dae gelede", "11 dae gelede", "21 dae gelede", "oor 2 dae", "oor 3 dae", "oor 4 dae", "oor 5 dae", "oor 11 dae", "oor 21 dae") },
         { "ar", new("منذ يومين", "منذ 3 أيام", "منذ 4 أيام", "منذ 5 أيام", "منذ 11 يوم", "منذ 21 يوم", "في غضون يومين من الآن", "في غضون 3 أيام من الآن", "في غضون 4 أيام من الآن", "في غضون 5 أيام من الآن", "في غضون 11 يوم من الآن", "في غضون 21 يوم من الآن") },
         { "az", new("2 gün əvvəl", "3 gün əvvəl", "4 gün əvvəl", "5 gün əvvəl", "11 gün əvvəl", "21 gün əvvəl", "2 gün sonra", "3 gün sonra", "4 gün sonra", "5 gün sonra", "11 gün sonra", "21 gün sonra") },
@@ -253,6 +254,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, MultiPartTimeSpanExpectationRow> MultiPartTimeSpanCases => new()
     {
+        { "sw", new("wiki 2, siku 1 na saa 1", "siku 1, dakika 3 na sekunde 4", "siku 1 na dakika 3") },
         { "af", new("2 weke, 1 dag en 1 uur", "1 dag, 3 minute en 4 sekondes", "1 dag en 3 minute") },
         { "ar", new("أسبوعين, يوم واحد وساعة واحدة", "يوم واحد, 3 دقائق و4 ثوان", "يوم واحد و3 دقائق") },
         { "az", new("2 həftə, 1 gün və 1 saat", "1 gün, 3 dəqiqə və 4 saniyə", "1 gün və 3 dəqiqə") },
@@ -324,6 +326,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, TimeUnitSymbolExpectationRow> TimeUnitSymbolCases => new()
     {
+        { "sw", new("ms", "sekunde", "dakika", "saa", "siku", "wiki", "mwezi", "mwaka") },
         { "af", new("ms", "sek.", "min.", "uur", "dag", "week", "maand", "jaar") },
         { "ar", new("مللي ثانية", "ثانية", "دقيقة", "ساعة", "يوم", "أسبوع", "شهر", "سنة") },
         { "az", new("ms", "saniyə", "dəqiqə", "saat", "gün", "həftə", "ay", "il") },
@@ -416,6 +419,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, ByteSizeSymbolExpectationRow> ByteSizeSymbolCases => new()
     {
+        { "sw", new("1 b", "2 B", "1.95 KB", "2048 KB") },
         { "af", new("1 b", "2 B", "1,95 KB", "2048 KB") },
         { "ar", new("1 b", "2 B", ArabicKilobytes, "2048 KB") },
         { "az", new("1 b", "2 B", "1,95 KB", "2048 KB") },
@@ -487,6 +491,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, ByteSizeFullWordExpectationRow> ByteSizeFullWordCases => new()
     {
+        { "sw", new("1 biti", "1 baiti", "2 baiti", "2 kilobaiti", "2 megabaiti") },
         { "af", new("1 bit", "1 byte", "2 bytes", "2 kilobytes", "2 megabytes") },
         { "ar", new("1 بت", "1 بايت", "2 بايت", "2 كيلوبايت", "2 ميجابايت") },
         { "az", new("1 bit", "1 bayt", "2 bayt", "2 kilobayt", "2 meqabayt") },
@@ -558,6 +563,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, CollectionHumanizeExpectationRow> CollectionHumanizeCases => new()
     {
+        { "sw", new("1 na 2", "1, 2 na 3", "1, 2, 3 na 4") },
         { "af", new("1 en 2", "1, 2 en 3", "1, 2, 3 en 4") },
         { "ar", new("1 و2", "1, 2 و3", "1, 2, 3 و4") },
         { "az", new("1 və 2", "1, 2 və 3", "1, 2, 3 və 4") },
@@ -629,6 +635,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, HeadingExpectationRow> HeadingCases => new()
     {
+        { "sw", new("K", "KKM", "KM", "MKM", "M", "MKS", "KS", "KKS", "S", "KKG", "KG", "MKG", "G", "MKGz", "KGz", "KKGz", "kaskazini", "kaskazini-kaskazini mashariki", "kaskazini mashariki", "mashariki-kaskazini mashariki", "mashariki", "mashariki-kusini mashariki", "kusini mashariki", "kusini-kusini mashariki", "kusini", "kusini-kusini magharibi", "kusini magharibi", "magharibi-kusini magharibi", "magharibi", "magharibi-kaskazini magharibi", "kaskazini magharibi", "kaskazini-kaskazini magharibi") },
         { "af", new("N", "NNO", "NO", "ONO", "O", "OSO", "SO", "SSO", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW", "noord", "noordnoordoos", "noordoos", "oosnoordoos", "oos", "oossuidoos", "suidoos", "suidsuidoos", "suid", "suidsuidwes", "suidwes", "wessuidwes", "wes", "wesnoordwes", "noordwes", "noordnoordwes") },
         { "ar", new("ش", "ش.ش.ق", "ش.ق", "ق.ش.ق", "ق", "ق.ج.ق", "ج.ق", "ج.ج.ق", "ج", "ج.ج.غ", "ج.غ", "غ.ج.غ", "غ", "غ.ش.غ", "ش.غ", "ش.ش.غ", "شمال", "شمال-شمال-شرق", "شمال-شرق", "شرق-شمال-شرق", "شرق", "شرق-جنوب-شرق", "جنوب-شرق", "جنوب-جنوب-شرق", "جنوب", "جنوب-جنوب-غرب", "جنوب-غرب", "غرب-جنوب-غرب", "غرب", "غرب-شمال-غرب", "شمال-غرب", "شمال-شمال-غرب") },
         { "az", new("Ş", "ŞŞŞ", "ŞŞ", "Ş-ŞŞ", "Şər", "Ş-CŞ", "CŞ", "CCŞ", "C", "CCQ", "CQ", "Q-CQ", "Q", "Q-ŞQ", "ŞQ", "ŞŞQ", "şimal", "şimal-şimal-şərq", "şimal-şərq", "şərq-şimal-şərq", "şərq", "şərq-cənub-şərq", "cənub-şərq", "cənub-cənub-şərq", "cənub", "cənub-cənub-qərb", "cənub-qərb", "qərb-cənub-qərb", "qərb", "qərb-şimal-qərb", "şimal-qərb", "şimal-şimal-qərb") },
@@ -700,6 +707,7 @@ public static class LocaleFormatterExactTheoryData
 
     public static TheoryData<string, CardinalHeadingExpectationRow> HeadingAbbreviatedCardinalCases => new()
     {
+        { "sw", new("K", "M", "S", "G") },
         { "af", new("N", "O", "S", "W") },
         { "ar", new("ش", "ق", "ج", "غ") },
         { "az", new("Ş", "Şər", "C", "Q") },

--- a/tests/Humanizer.Tests/Localisation/LocaleNumberMagnitudeTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleNumberMagnitudeTheoryData.cs
@@ -4,6 +4,8 @@ public static class LocaleNumberMagnitudeTheoryData
 {
     public static TheoryData<string, long, string> MagnitudeCardinalCases => new()
     {
+        { "sw", 1001L, "elfu moja na moja" },
+        { "sw", 1000001L, "milioni moja na moja" },
         { "af", 1001L, "een duisend en een" },
         { "af", 1000001L, "een miljoen en een" },
         { "ar", 1001L, "ألف و واحد" },
@@ -146,6 +148,8 @@ public static class LocaleNumberMagnitudeTheoryData
 
     public static TheoryData<string, long, string> ExtendedMagnitudeCardinalCases => new()
     {
+        { "sw", 1001000001L, "bilioni moja milioni moja na moja" },
+        { "sw", 4325010007018L, "trilioni nne bilioni mia tatu na ishirini na tano milioni kumi elfu saba na kumi na nane" },
         { "af", 1001000001L, "een miljard een miljoen en een" },
         { "af", 4325010007018L, "vier biljoene drie honderd vyf en twintig miljard tien miljoen sewe duisend en agtien" },
         { "ar", 1001000001L, "مليار و   مليون و واحد" },
@@ -367,6 +371,8 @@ public static class LocaleNumberMagnitudeTheoryData
 
     public static TheoryData<string, long, string> HighRangeRoundTripCases => new()
     {
+        { "sw", 1000000000000000000L, "kwintilioni moja" },
+        { "sw", 1000000000000000001L, "kwintilioni moja na moja" },
         { "ar", 1000000000000000000L, "كوينتليون" },
         { "ar", 1000000000000000001L, "كوينتليون و واحد" },
         { "az", 1000000000000000000L, "bir kvintilyon" },
@@ -437,6 +443,7 @@ public static class LocaleNumberMagnitudeTheoryData
 
     public static TheoryData<string, long> HighRangeRoundTripOnlyCases => new()
     {
+        { "sw", 1234567890123456L },
         { "ja", 10000000000000000L },
         { "zh-CN", 1234567890123456L },
         { "zh-CN", 10000000000000000L },

--- a/tests/Humanizer.Tests/Localisation/LocaleNumberOverloadTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleNumberOverloadTheoryData.cs
@@ -4,6 +4,7 @@ public static class LocaleNumberOverloadTheoryData
 {
     public static TheoryData<string, long, string> AddAndCases => new()
     {
+        { "sw", 21, "ishirini na moja" },
         { "af", 1001001L, "een miljoen een duisend en een" },
         { "af", 1001000001L, "een miljard een miljoen en een" },
         { "af", 4325010007018L, "vier biljoene drie honderd vyf en twintig miljard tien miljoen sewe duisend en agtien" },
@@ -205,6 +206,7 @@ public static class LocaleNumberOverloadTheoryData
 
     public static TheoryData<string, long, string> WordFormCases => new()
     {
+        { "sw", 21, "ishirini na moja" },
         { "af", 1001001L, "een miljoen een duisend en een" },
         { "af", 1001000001L, "een miljard een miljoen en een" },
         { "af", 4325010007018L, "vier biljoene drie honderd vyf en twintig miljard tien miljoen sewe duisend en agtien" },
@@ -406,6 +408,7 @@ public static class LocaleNumberOverloadTheoryData
 
     public static TheoryData<string, long, string> GenderCases => new()
     {
+        { "sw", 21, "ishirini na moja" },
         { "af", 1001001L, "een miljoen een duisend en een" },
         { "af", 1001000001L, "een miljard een miljoen en een" },
         { "af", 4325010007018L, "vier biljoene drie honderd vyf en twintig miljard tien miljoen sewe duisend en agtien" },
@@ -607,6 +610,7 @@ public static class LocaleNumberOverloadTheoryData
 
     public static TheoryData<string, long, string> WordFormGenderCases => new()
     {
+        { "sw", 21, "ishirini na moja" },
         { "af", 1001001L, "een miljoen een duisend en een" },
         { "af", 1001000001L, "een miljard een miljoen en een" },
         { "af", 4325010007018L, "vier biljoene drie honderd vyf en twintig miljard tien miljoen sewe duisend en agtien" },

--- a/tests/Humanizer.Tests/Localisation/LocaleNumberTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleNumberTheoryData.cs
@@ -4,6 +4,11 @@ static class LocaleNumberTheoryData
 {
     public static TheoryData<string, int, string> CardinalCases => new()
     {
+        { "sw", 0, "sifuri" },
+        { "sw", 1, "moja" },
+        { "sw", 21, "ishirini na moja" },
+        { "sw", 105, "mia moja na tano" },
+        { "sw", 1234, "elfu moja mia mbili na thelathini na nne" },
         { "af", 0, "nul" },
         { "af", 1, "een" },
         { "af", 2, "twee" },
@@ -2676,6 +2681,10 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, bool, string> CardinalAddAndCases => new()
     {
+        { "sw", 101, true, "mia moja na moja" },
+        { "sw", 101, false, "mia moja na moja" },
+        { "sw", 121, true, "mia moja na ishirini na moja" },
+        { "sw", 121, false, "mia moja na ishirini na moja" },
         { "af", 101, true, "een honderd en een" },
         { "af", 101, false, "een honderd en een" },
         { "af", 105, true, "een honderd en vyf" },
@@ -3441,6 +3450,8 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, WordForm, string> CardinalWordFormCases => new()
     {
+        { "sw", 1, WordForm.Abbreviation, "moja" },
+        { "sw", 21, WordForm.Abbreviation, "ishirini na moja" },
         { "af", 1, WordForm.Abbreviation, "een" },
         { "af", 21, WordForm.Abbreviation, "een en twintig" },
         { "af", 31, WordForm.Abbreviation, "een en dertig" },
@@ -3831,6 +3842,9 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, GrammaticalGender, string> CardinalGenderCases => new()
     {
+        { "sw", 1, GrammaticalGender.Feminine, "moja" },
+        { "sw", 1, GrammaticalGender.Masculine, "moja" },
+        { "sw", 1, GrammaticalGender.Neuter, "moja" },
         { "af", 1, GrammaticalGender.Feminine, "een" },
         { "af", 1, GrammaticalGender.Masculine, "een" },
         { "af", 1, GrammaticalGender.Neuter, "een" },
@@ -4239,6 +4253,9 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, WordForm, GrammaticalGender, string> CardinalWordFormGenderCases => new()
     {
+        { "sw", 1, WordForm.Abbreviation, GrammaticalGender.Feminine, "moja" },
+        { "sw", 1, WordForm.Abbreviation, GrammaticalGender.Masculine, "moja" },
+        { "sw", 1, WordForm.Abbreviation, GrammaticalGender.Neuter, "moja" },
         { "af", 21, WordForm.Abbreviation, GrammaticalGender.Feminine, "een en twintig" },
         { "af", 21, WordForm.Abbreviation, GrammaticalGender.Masculine, "een en twintig" },
         { "af", 21, WordForm.Abbreviation, GrammaticalGender.Neuter, "een en twintig" },
@@ -4442,6 +4459,9 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, string> OrdinalCases => new()
     {
+        { "sw", 1, "kwanza" },
+        { "sw", 2, "pili" },
+        { "sw", 21, "ya ishirini na moja" },
         { "af", 0, "nulste" },
         { "af", 1, "eerste" },
         { "af", 2, "tweede" },
@@ -5775,6 +5795,10 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, WordForm, string> OrdinalWordFormCases => new()
     {
+        { "sw", 1, WordForm.Abbreviation, "kwanza" },
+        { "sw", 1, WordForm.Normal, "kwanza" },
+        { "sw", 21, WordForm.Abbreviation, "ya ishirini na moja" },
+        { "sw", 21, WordForm.Normal, "ya ishirini na moja" },
         { "af", 1, WordForm.Abbreviation, "eerste" },
         { "af", 2, WordForm.Abbreviation, "tweede" },
         { "af", 3, WordForm.Abbreviation, "derde" },
@@ -6115,6 +6139,9 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, GrammaticalGender, string> OrdinalGenderCases => new()
     {
+        { "sw", 1, GrammaticalGender.Feminine, "kwanza" },
+        { "sw", 1, GrammaticalGender.Masculine, "kwanza" },
+        { "sw", 1, GrammaticalGender.Neuter, "kwanza" },
         { "af", 1, GrammaticalGender.Feminine, "eerste" },
         { "af", 1, GrammaticalGender.Masculine, "eerste" },
         { "af", 1, GrammaticalGender.Neuter, "eerste" },
@@ -6942,6 +6969,9 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, int, GrammaticalGender, WordForm, string> OrdinalWordFormGenderCases => new()
     {
+        { "sw", 1, GrammaticalGender.Feminine, WordForm.Abbreviation, "kwanza" },
+        { "sw", 1, GrammaticalGender.Masculine, WordForm.Abbreviation, "kwanza" },
+        { "sw", 1, GrammaticalGender.Neuter, WordForm.Abbreviation, "kwanza" },
         { "af", 3, GrammaticalGender.Feminine, WordForm.Abbreviation, "derde" },
         { "af", 3, GrammaticalGender.Masculine, WordForm.Abbreviation, "derde" },
         { "af", 3, GrammaticalGender.Neuter, WordForm.Abbreviation, "derde" },
@@ -7144,6 +7174,7 @@ static class LocaleNumberTheoryData
 };
     public static TheoryData<string, int, string> TupleCases => new()
     {
+        { "sw", 2, "mbili" },
         { "af", 2, "twee" },
         { "ar", 2, "اثنان" },
         { "az", 2, "iki" },
@@ -7216,6 +7247,8 @@ static class LocaleNumberTheoryData
 
     public static TheoryData<string, string, long> WordsToNumberCases => new()
     {
+        { "sw", "ishirini na moja", 21L },
+        { "sw", "mia moja na tano", 105L },
         { "af", "een en twintig", 21L },
         { "ar", "واحد و عشرون", 21L },
         { "az", "iyirmi bir", 21L },

--- a/tests/Humanizer.Tests/Localisation/LocaleOrdinalizerMatrixData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleOrdinalizerMatrixData.cs
@@ -5,6 +5,15 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, int, string> OrdinalizerExpectationTheoryData =>
         new()
         {
+            { "sw", 0, "0" },
+            { "sw", 1, "1" },
+            { "sw", 2, "2" },
+            { "sw", 3, "3" },
+            { "sw", 10, "10" },
+            { "sw", 23, "23" },
+            { "sw", 100, "100" },
+            { "sw", 101, "101" },
+            { "sw", 1001, "1001" },
             { "af", 0, "0de" },
             { "af", 1, "1ste" },
             { "af", 2, "2de" },
@@ -598,6 +607,9 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, int, GrammaticalGender, string> OrdinalizerGenderExpectationTheoryData =>
         new()
         {
+            { "sw", 1, GrammaticalGender.Feminine, "1" },
+            { "sw", 1, GrammaticalGender.Masculine, "1" },
+            { "sw", 1, GrammaticalGender.Neuter, "1" },
             { "af", 0, GrammaticalGender.Masculine, "0de" },
             { "af", 1, GrammaticalGender.Masculine, "1ste" },
             { "af", 2, GrammaticalGender.Masculine, "2de" },
@@ -3337,6 +3349,15 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, string, string> OrdinalizerDefaultExpectationTheoryData =>
         new()
         {
+            { "sw", "0", "0" },
+            { "sw", "1", "1" },
+            { "sw", "2", "2" },
+            { "sw", "3", "3" },
+            { "sw", "10", "10" },
+            { "sw", "23", "23" },
+            { "sw", "100", "100" },
+            { "sw", "101", "101" },
+            { "sw", "1001", "1001" },
             { "af", "0", "0de" },
             { "af", "1", "1ste" },
             { "af", "2", "2de" },
@@ -3929,6 +3950,11 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, int, string> OrdinalizerNegativeExpectationTheoryData =>
         new()
         {
+            { "sw", -1, "-1" },
+            { "sw", -2, "-2" },
+            { "sw", -10, "-10" },
+            { "sw", -23, "-23" },
+            { "sw", -2147483648, "-2147483648" },
             { "af", -1, "-1ste" },
             { "af", -2, "-2de" },
             { "af", -10, "-10de" },
@@ -4261,6 +4287,12 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, int, WordForm, string> OrdinalizerWordFormExpectationTheoryData =>
         new()
         {
+            { "sw", 1, WordForm.Abbreviation, "1" },
+            { "sw", 1, WordForm.Normal, "1" },
+            { "sw", 2, WordForm.Abbreviation, "2" },
+            { "sw", 2, WordForm.Normal, "2" },
+            { "sw", 21, WordForm.Abbreviation, "21" },
+            { "sw", 21, WordForm.Normal, "21" },
             { "af", 1, WordForm.Abbreviation, "1ste" },
             { "af", 1, WordForm.Normal, "1ste" },
             { "af", 2, WordForm.Abbreviation, "2de" },
@@ -4788,6 +4820,12 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, int, GrammaticalGender, WordForm, string> OrdinalizerWordFormGenderExpectationTheoryData =>
         new()
         {
+            { "sw", 1, GrammaticalGender.Feminine, WordForm.Abbreviation, "1" },
+            { "sw", 1, GrammaticalGender.Feminine, WordForm.Normal, "1" },
+            { "sw", 1, GrammaticalGender.Masculine, WordForm.Abbreviation, "1" },
+            { "sw", 1, GrammaticalGender.Masculine, WordForm.Normal, "1" },
+            { "sw", 1, GrammaticalGender.Neuter, WordForm.Abbreviation, "1" },
+            { "sw", 1, GrammaticalGender.Neuter, WordForm.Normal, "1" },
             { "af", 1, GrammaticalGender.Masculine, WordForm.Abbreviation, "1ste" },
             { "af", 1, GrammaticalGender.Masculine, WordForm.Normal, "1ste" },
             { "af", 1, GrammaticalGender.Feminine, WordForm.Abbreviation, "1ste" },
@@ -6339,6 +6377,9 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, string, GrammaticalGender, string> OrdinalizerStringExactExpectationTheoryData =>
         new()
         {
+            { "sw", "1", GrammaticalGender.Feminine, "1" },
+            { "sw", "1", GrammaticalGender.Masculine, "1" },
+            { "sw", "1", GrammaticalGender.Neuter, "1" },
             { "af", "0", GrammaticalGender.Masculine, "0de" },
             { "af", "1", GrammaticalGender.Masculine, "1ste" },
             { "af", "2", GrammaticalGender.Masculine, "2de" },
@@ -8892,6 +8933,9 @@ static class LocaleOrdinalizerMatrixData
     public static TheoryData<string, int, GrammaticalGender, string> OrdinalizerNumberExactExpectationTheoryData =>
         new()
         {
+            { "sw", 1, GrammaticalGender.Feminine, "1" },
+            { "sw", 1, GrammaticalGender.Masculine, "1" },
+            { "sw", 1, GrammaticalGender.Neuter, "1" },
             { "af", 0, GrammaticalGender.Masculine, "0de" },
             { "af", 1, GrammaticalGender.Masculine, "1ste" },
             { "af", 2, GrammaticalGender.Masculine, "2de" },

--- a/tests/Humanizer.Tests/Localisation/LocalePhraseTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocalePhraseTheoryData.cs
@@ -4,6 +4,11 @@ static class LocalePhraseTheoryData
 {
     public static TheoryData<string, int, TimeUnit, Tense, string> DateHumanizeCases => new()
     {
+        { "sw", 1, TimeUnit.Day, Tense.Past, "jana" },
+        { "sw", 1, TimeUnit.Day, Tense.Future, "kesho" },
+        { "sw", 2, TimeUnit.Day, Tense.Past, "2 siku zilizopita" },
+        { "sw", 2, TimeUnit.Day, Tense.Future, "baada ya siku 2" },
+        { "sw", 0, TimeUnit.Second, Tense.Future, "sasa" },
         { "af", 1, TimeUnit.Second, Tense.Past, "1 sekonde terug" },
         { "af", 2, TimeUnit.Second, Tense.Future, "oor 2 sekondes" },
         { "af", 1, TimeUnit.Minute, Tense.Past, "1 minuut terug" },
@@ -1441,6 +1446,7 @@ static class LocalePhraseTheoryData
 
     public static TheoryData<string, string> NullDateHumanizeCases => new()
     {
+        { "sw", "kamwe" },
         { "af", "nooit" },
         { "ar", "أبدًا" },
         { "az", "heç vaxt" },
@@ -1548,6 +1554,10 @@ static class LocalePhraseTheoryData
 
     public static TheoryData<string, int, TimeUnit, bool, string> TimeSpanHumanizeCases => new()
     {
+        { "sw", 1, TimeUnit.Second, false, "sekunde 1" },
+        { "sw", 2, TimeUnit.Second, false, "sekunde 2" },
+        { "sw", 1, TimeUnit.Minute, true, "dakika moja" },
+        { "sw", 0, TimeUnit.Millisecond, true, "hakuna muda" },
         { "af", 1, TimeUnit.Second, false, "1 sekonde" },
         { "af", 2, TimeUnit.Second, false, "2 sekondes" },
         { "af", 1, TimeUnit.Minute, false, "1 minuut" },

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliClockNotationTests.cs
@@ -5,11 +5,11 @@ namespace Humanizer.Tests.Localisation.sw;
 public class SwahiliClockNotationTests
 {
     [Theory]
-    [InlineData(1, 0, "saa moja asubuhi")]
-    [InlineData(1, 5, "saa moja na dakika tano asubuhi")]
-    [InlineData(13, 23, "saa moja na dakika ishirini na tatu mchana")]
-    [InlineData(20, 0, "saa nane jioni")]
-    [InlineData(23, 40, "saa kumi na moja na dakika arobaini usiku")]
+    [InlineData(1, 0, "saa saba asubuhi")]
+    [InlineData(1, 5, "saa saba na dakika tano asubuhi")]
+    [InlineData(13, 23, "saa saba na dakika ishirini na tatu mchana")]
+    [InlineData(20, 0, "saa mbili jioni")]
+    [InlineData(23, 40, "saa tano na dakika arobaini usiku")]
     public void ToClockNotation_ExactOutput(int hours, int minutes, string expected)
     {
         Assert.Equal(expected, new TimeOnly(hours, minutes).ToClockNotation());
@@ -18,7 +18,7 @@ public class SwahiliClockNotationTests
     [Fact]
     public void ToClockNotation_Rounded_ExactOutput()
     {
-        Assert.Equal("saa moja na dakika ishirini na tano mchana", new TimeOnly(13, 23).ToClockNotation(ClockNotationRounding.NearestFiveMinutes));
+        Assert.Equal("saa saba na dakika ishirini na tano mchana", new TimeOnly(13, 23).ToClockNotation(ClockNotationRounding.NearestFiveMinutes));
     }
 }
 #endif

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliClockNotationTests.cs
@@ -1,0 +1,24 @@
+namespace Humanizer.Tests.Localisation.sw;
+
+#if NET6_0_OR_GREATER
+[UseCulture("sw")]
+public class SwahiliClockNotationTests
+{
+    [Theory]
+    [InlineData(1, 0, "saa moja asubuhi")]
+    [InlineData(1, 5, "saa moja na dakika tano asubuhi")]
+    [InlineData(13, 23, "saa moja na dakika ishirini na tatu mchana")]
+    [InlineData(20, 0, "saa nane jioni")]
+    [InlineData(23, 40, "saa kumi na moja na dakika arobaini usiku")]
+    public void ToClockNotation_ExactOutput(int hours, int minutes, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(hours, minutes).ToClockNotation());
+    }
+
+    [Fact]
+    public void ToClockNotation_Rounded_ExactOutput()
+    {
+        Assert.Equal("saa moja na dakika ishirini na tano mchana", new TimeOnly(13, 23).ToClockNotation(ClockNotationRounding.NearestFiveMinutes));
+    }
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliCompassTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliCompassTests.cs
@@ -1,0 +1,30 @@
+namespace Humanizer.Tests.Localisation.sw;
+
+[UseCulture("sw")]
+public class SwahiliCompassTests
+{
+    [Theory]
+    [InlineData(0.0, "kaskazini")]
+    [InlineData(45.0, "kaskazini mashariki")]
+    [InlineData(90.0, "mashariki")]
+    [InlineData(135.0, "kusini mashariki")]
+    [InlineData(180.0, "kusini")]
+    [InlineData(225.0, "kusini magharibi")]
+    [InlineData(270.0, "magharibi")]
+    [InlineData(315.0, "kaskazini magharibi")]
+    public void FullDirections(double angle, string expected)
+    {
+        Assert.Equal(expected, angle.ToHeading(HeadingStyle.Full));
+    }
+
+    [Theory]
+    [InlineData(0.0, "K")]
+    [InlineData(45.0, "KM")]
+    [InlineData(90.0, "M")]
+    [InlineData(180.0, "S")]
+    [InlineData(270.0, "G")]
+    public void AbbreviatedDirections(double angle, string expected)
+    {
+        Assert.Equal(expected, angle.ToHeading(HeadingStyle.Abbreviated));
+    }
+}

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliDataUnitsTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliDataUnitsTests.cs
@@ -1,0 +1,22 @@
+namespace Humanizer.Tests.Localisation.sw;
+
+[UseCulture("sw")]
+public class SwahiliDataUnitsTests
+{
+    [Theory]
+    [InlineData(DataUnit.Byte, "baiti")]
+    [InlineData(DataUnit.Kilobyte, "kilobaiti")]
+    [InlineData(DataUnit.Megabyte, "megabaiti")]
+    public void DataUnitHumanize_UsesSwahiliNames(DataUnit unit, string expected)
+    {
+        var formatter = Configurator.Formatters.ResolveForCulture(new CultureInfo("sw"));
+        Assert.Equal(expected, formatter.DataUnitHumanize(unit, 2, toSymbol: false));
+    }
+
+    [Fact]
+    public void DataUnitHumanize_UsesSymbols()
+    {
+        var formatter = Configurator.Formatters.ResolveForCulture(new CultureInfo("sw"));
+        Assert.Equal("KB", formatter.DataUnitHumanize(DataUnit.Kilobyte, 2, toSymbol: true));
+    }
+}

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliDateToOrdinalWordsTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliDateToOrdinalWordsTests.cs
@@ -1,0 +1,23 @@
+namespace Humanizer.Tests.Localisation.sw;
+
+[UseCulture("sw")]
+public class SwahiliDateToOrdinalWordsTests
+{
+    [Theory]
+    [InlineData(2022, 1, 25, "25 Januari 2022")]
+    [InlineData(2015, 2, 3, "3 Februari 2015")]
+    public void DateTimeToOrdinalWords_UsesSwahiliDatePattern(int year, int month, int day, string expected)
+    {
+        Assert.Equal(expected, new DateTime(year, month, day).ToOrdinalWords());
+    }
+
+#if NET6_0_OR_GREATER
+    [Theory]
+    [InlineData(2022, 1, 25, "25 Januari 2022")]
+    [InlineData(2015, 2, 3, "3 Februari 2015")]
+    public void DateOnlyToOrdinalWords_UsesSwahiliDatePattern(int year, int month, int day, string expected)
+    {
+        Assert.Equal(expected, new DateOnly(year, month, day).ToOrdinalWords());
+    }
+#endif
+}

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliDurationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliDurationTests.cs
@@ -1,0 +1,29 @@
+namespace Humanizer.Tests.Localisation.sw;
+
+[UseCulture("sw")]
+public class SwahiliDurationTests
+{
+    [Theory]
+    [InlineData(TimeUnit.Day, 1, "siku 1")]
+    [InlineData(TimeUnit.Day, 2, "siku 2")]
+    [InlineData(TimeUnit.Month, 1, "mwezi 1")]
+    [InlineData(TimeUnit.Month, 2, "miezi 2")]
+    public void TimeSpanHumanize_UsesSwahiliDurationPhrases(TimeUnit unit, int count, string expected)
+    {
+        var formatter = Configurator.Formatters.ResolveForCulture(new CultureInfo("sw"));
+        Assert.Equal(expected, formatter.TimeSpanHumanize(unit, count));
+    }
+
+    [Fact]
+    public void TimeSpanHumanize_ToWords_UsesSwahiliSingleWordForm()
+    {
+        var formatter = Configurator.Formatters.ResolveForCulture(new CultureInfo("sw"));
+        Assert.Equal("siku moja", formatter.TimeSpanHumanize(TimeUnit.Day, 1, toWords: true));
+    }
+
+    [Fact]
+    public void ToAge_UsesSwahiliTemplate()
+    {
+        Assert.Equal("umri wa mwaka 1", TimeSpan.FromDays(366).ToAge(new CultureInfo("sw")));
+    }
+}

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliListHumanizeTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliListHumanizeTests.cs
@@ -1,0 +1,20 @@
+namespace Humanizer.Tests.Localisation.sw;
+
+[UseCulture("sw")]
+public class SwahiliListHumanizeTests
+{
+    static readonly int[] Pair = [1, 2];
+    static readonly int[] Triple = [1, 2, 3];
+
+    [Fact]
+    public void TwoElements_UsesNa()
+    {
+        Assert.Equal("1 na 2", Pair.Humanize());
+    }
+
+    [Fact]
+    public void ThreeElements_UsesCommaAndNa()
+    {
+        Assert.Equal("1, 2 na 3", Triple.Humanize());
+    }
+}

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliListHumanizeTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliListHumanizeTests.cs
@@ -3,18 +3,17 @@ namespace Humanizer.Tests.Localisation.sw;
 [UseCulture("sw")]
 public class SwahiliListHumanizeTests
 {
-    static readonly int[] Pair = [1, 2];
-    static readonly int[] Triple = [1, 2, 3];
-
     [Fact]
     public void TwoElements_UsesNa()
     {
-        Assert.Equal("1 na 2", Pair.Humanize());
+        var pair = new[] { 1, 2 };
+        Assert.Equal("1 na 2", pair.Humanize());
     }
 
     [Fact]
     public void ThreeElements_UsesCommaAndNa()
     {
-        Assert.Equal("1, 2 na 3", Triple.Humanize());
+        var triple = new[] { 1, 2, 3 };
+        Assert.Equal("1, 2 na 3", triple.Humanize());
     }
 }

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliNumberToWordsTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliNumberToWordsTests.cs
@@ -1,0 +1,70 @@
+namespace Humanizer.Tests.Localisation.sw;
+
+[UseCulture("sw")]
+public class SwahiliNumberToWordsTests
+{
+    static readonly CultureInfo Sw = new("sw");
+
+    [Theory]
+    [InlineData(0, "sifuri")]
+    [InlineData(5, "tano")]
+    [InlineData(21, "ishirini na moja")]
+    [InlineData(99, "tisini na tisa")]
+    [InlineData(100, "mia moja")]
+    [InlineData(105, "mia moja na tano")]
+    [InlineData(120, "mia moja na ishirini")]
+    [InlineData(234, "mia mbili na thelathini na nne")]
+    [InlineData(1000, "elfu moja")]
+    [InlineData(2021, "elfu mbili na ishirini na moja")]
+    [InlineData(1234, "elfu moja mia mbili na thelathini na nne")]
+    [InlineData(100000, "laki moja")]
+    [InlineData(1000000, "milioni moja")]
+    [InlineData(2000000, "milioni mbili")]
+    public void NumberToWords_ProducesExpectedSwahiliOutput(long number, string expected)
+    {
+        Assert.Equal(expected, number.ToWords(Sw));
+    }
+
+    [Theory]
+    [InlineData(-5, "minus tano")]
+    [InlineData(-1000, "minus elfu moja")]
+    public void NumberToWords_UsesSwahiliNegativePrefix(long number, string expected)
+    {
+        Assert.Equal(expected, number.ToWords(Sw));
+    }
+
+    [Theory]
+    [InlineData(1, "kwanza")]
+    [InlineData(2, "pili")]
+    [InlineData(21, "ya ishirini na moja")]
+    [InlineData(100, "ya mia moja")]
+    public void NumberToOrdinalWords_ProducesExpectedSwahiliOutput(int number, string expected)
+    {
+        Assert.Equal(expected, number.ToOrdinalWords(Sw));
+    }
+
+    [Theory]
+    [InlineData(21, "ishirini na moja")]
+    [InlineData(99, "tisini na tisa")]
+    [InlineData(105, "mia moja na tano")]
+    [InlineData(120, "mia moja na ishirini")]
+    [InlineData(1234, "elfu moja mia mbili na thelathini na nne")]
+    [InlineData(2021, "elfu mbili na ishirini na moja")]
+    [InlineData(100000, "laki moja")]
+    [InlineData(2000000, "milioni mbili")]
+    public void WordsToNumber_RoundTripsSwahiliCardinals(long number, string words)
+    {
+        Assert.Equal(number, words.ToNumber(Sw));
+        Assert.True(words.TryToNumber(out var parsed, Sw, out var unrecognizedWord));
+        Assert.Equal(number, parsed);
+        Assert.Null(unrecognizedWord);
+    }
+
+    [Theory]
+    [InlineData("kwanza", 1)]
+    [InlineData("ya ishirini na moja", 21)]
+    public void WordsToNumber_ParsesSwahiliOrdinals(string words, long expected)
+    {
+        Assert.Equal(expected, words.ToNumber(Sw));
+    }
+}

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliNumberToWordsTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliNumberToWordsTests.cs
@@ -33,6 +33,14 @@ public class SwahiliNumberToWordsTests
         Assert.Equal(expected, number.ToWords(Sw));
     }
 
+    [Fact]
+    public void ToWords_HandlesLongMinValueWithoutOverflow()
+    {
+        var words = long.MinValue.ToWords(Sw);
+        Assert.StartsWith("minus kwintilioni tisa", words, StringComparison.Ordinal);
+        Assert.Contains("na nane", words, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(1, "kwanza")]
     [InlineData(2, "pili")]

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliNumberToWordsTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliNumberToWordsTests.cs
@@ -26,8 +26,8 @@ public class SwahiliNumberToWordsTests
     }
 
     [Theory]
-    [InlineData(-5, "minus tano")]
-    [InlineData(-1000, "minus elfu moja")]
+    [InlineData(-5, "hasi tano")]
+    [InlineData(-1000, "hasi elfu moja")]
     public void NumberToWords_UsesSwahiliNegativePrefix(long number, string expected)
     {
         Assert.Equal(expected, number.ToWords(Sw));
@@ -37,7 +37,7 @@ public class SwahiliNumberToWordsTests
     public void ToWords_HandlesLongMinValueWithoutOverflow()
     {
         var words = long.MinValue.ToWords(Sw);
-        Assert.StartsWith("minus kwintilioni tisa", words, StringComparison.Ordinal);
+        Assert.StartsWith("hasi kwintilioni tisa", words, StringComparison.Ordinal);
         Assert.Contains("na nane", words, StringComparison.Ordinal);
         Assert.Equal(long.MinValue, words.ToNumber(Sw));
     }
@@ -47,6 +47,8 @@ public class SwahiliNumberToWordsTests
     [InlineData(2, "pili")]
     [InlineData(21, "ya ishirini na moja")]
     [InlineData(100, "ya mia moja")]
+    [InlineData(-1, "hasi kwanza")]
+    [InlineData(-21, "hasi ya ishirini na moja")]
     public void NumberToOrdinalWords_ProducesExpectedSwahiliOutput(int number, string expected)
     {
         Assert.Equal(expected, number.ToOrdinalWords(Sw));
@@ -72,8 +74,40 @@ public class SwahiliNumberToWordsTests
     [Theory]
     [InlineData("kwanza", 1)]
     [InlineData("ya ishirini na moja", 21)]
+    [InlineData("hasi kwanza", -1)]
+    [InlineData("hasi ya ishirini na moja", -21)]
     public void WordsToNumber_ParsesSwahiliOrdinals(string words, long expected)
     {
         Assert.Equal(expected, words.ToNumber(Sw));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryToNumber_ReturnsFalseForBlankInput(string words)
+    {
+        Assert.False(words.TryToNumber(out var parsed, Sw, out var unrecognizedWord));
+        Assert.Equal(0, parsed);
+        Assert.Equal(words, unrecognizedWord);
+    }
+
+    [Fact]
+    public void TryToNumber_ReturnsFalseForNullInput()
+    {
+        string words = null!;
+
+        Assert.False(words.TryToNumber(out var parsed, Sw, out var unrecognizedWord));
+        Assert.Equal(0, parsed);
+        Assert.Equal(string.Empty, unrecognizedWord);
+    }
+
+    [Theory]
+    [InlineData("mia moja blerg", "blerg")]
+    [InlineData("kwintilioni kumi", "kwintilioni kumi")]
+    public void TryToNumber_ReturnsUsefulUnrecognizedWord(string words, string expectedUnrecognizedWord)
+    {
+        Assert.False(words.TryToNumber(out var parsed, Sw, out var unrecognizedWord));
+        Assert.Equal(0, parsed);
+        Assert.Equal(expectedUnrecognizedWord, unrecognizedWord);
     }
 }

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliNumberToWordsTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliNumberToWordsTests.cs
@@ -39,6 +39,7 @@ public class SwahiliNumberToWordsTests
         var words = long.MinValue.ToWords(Sw);
         Assert.StartsWith("minus kwintilioni tisa", words, StringComparison.Ordinal);
         Assert.Contains("na nane", words, StringComparison.Ordinal);
+        Assert.Equal(long.MinValue, words.ToNumber(Sw));
     }
 
     [Theory]

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliOrdinalTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliOrdinalTests.cs
@@ -1,0 +1,17 @@
+namespace Humanizer.Tests.Localisation.sw;
+
+[UseCulture("sw")]
+public class SwahiliOrdinalTests
+{
+    static readonly CultureInfo Sw = new("sw");
+
+    [Theory]
+    [InlineData(1, "1")]
+    [InlineData(2, "2")]
+    [InlineData(21, "21")]
+    public void Ordinalize_UsesSwahiliNumericTemplate(int number, string expected)
+    {
+        Assert.Equal(expected, number.Ordinalize(Sw));
+        Assert.Equal(expected, number.ToString(CultureInfo.InvariantCulture).Ordinalize(Sw));
+    }
+}

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliOrdinalTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliOrdinalTests.cs
@@ -1,6 +1,5 @@
 namespace Humanizer.Tests.Localisation.sw;
 
-[UseCulture("sw")]
 public class SwahiliOrdinalTests
 {
     static readonly CultureInfo Sw = new("sw");
@@ -13,5 +12,15 @@ public class SwahiliOrdinalTests
     {
         Assert.Equal(expected, number.Ordinalize(Sw));
         Assert.Equal(expected, number.ToString(CultureInfo.InvariantCulture).Ordinalize(Sw));
+    }
+
+    [Theory]
+    [InlineData(1, "kwanza")]
+    [InlineData(2, "pili")]
+    [InlineData(21, "ya ishirini na moja")]
+    [InlineData(-1, "hasi kwanza")]
+    public void NumberToOrdinalWords_UsesSwahiliOrdinalWords(int number, string expected)
+    {
+        Assert.Equal(expected, number.ToOrdinalWords(Sw));
     }
 }

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliOrdinalTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliOrdinalTests.cs
@@ -1,17 +1,16 @@
 namespace Humanizer.Tests.Localisation.sw;
 
+[UseCulture("sw")]
 public class SwahiliOrdinalTests
 {
-    static readonly CultureInfo Sw = new("sw");
-
     [Theory]
     [InlineData(1, "1")]
     [InlineData(2, "2")]
     [InlineData(21, "21")]
     public void Ordinalize_UsesSwahiliNumericTemplate(int number, string expected)
     {
-        Assert.Equal(expected, number.Ordinalize(Sw));
-        Assert.Equal(expected, number.ToString(CultureInfo.InvariantCulture).Ordinalize(Sw));
+        Assert.Equal(expected, number.Ordinalize());
+        Assert.Equal(expected, number.ToString(CultureInfo.InvariantCulture).Ordinalize());
     }
 
     [Theory]
@@ -21,6 +20,6 @@ public class SwahiliOrdinalTests
     [InlineData(-1, "hasi kwanza")]
     public void NumberToOrdinalWords_UsesSwahiliOrdinalWords(int number, string expected)
     {
-        Assert.Equal(expected, number.ToOrdinalWords(Sw));
+        Assert.Equal(expected, number.ToOrdinalWords());
     }
 }

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliRelativeDateTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliRelativeDateTests.cs
@@ -1,0 +1,26 @@
+namespace Humanizer.Tests.Localisation.sw;
+
+[UseCulture("sw")]
+public class SwahiliRelativeDateTests
+{
+    [Theory]
+    [InlineData(1, TimeUnit.Day, Tense.Past, "jana")]
+    [InlineData(1, TimeUnit.Day, Tense.Future, "kesho")]
+    [InlineData(2, TimeUnit.Day, Tense.Past, "2 siku zilizopita")]
+    [InlineData(2, TimeUnit.Day, Tense.Future, "baada ya siku 2")]
+    [InlineData(1, TimeUnit.Month, Tense.Past, "mwezi 1 uliopita")]
+    [InlineData(2, TimeUnit.Month, Tense.Past, "2 miezi iliyopita")]
+    [InlineData(0, TimeUnit.Second, Tense.Future, "sasa")]
+    public void DateHumanize_UsesSwahiliPhrases(int count, TimeUnit unit, Tense tense, string expected)
+    {
+        var formatter = Configurator.Formatters.ResolveForCulture(new CultureInfo("sw"));
+        Assert.Equal(expected, formatter.DateHumanize(unit, tense, count));
+    }
+
+    [Fact]
+    public void NullableDateHumanize_NullDateUsesSwahiliNeverPhrase()
+    {
+        DateTime? date = null;
+        Assert.Equal("kamwe", date.Humanize(culture: new CultureInfo("sw")));
+    }
+}

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliTimeUnitTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliTimeUnitTests.cs
@@ -4,10 +4,10 @@ namespace Humanizer.Tests.Localisation.sw;
 public class SwahiliTimeUnitTests
 {
     [Theory]
-    [InlineData(TimeUnit.Second, "sekunde")]
-    [InlineData(TimeUnit.Minute, "dakika")]
+    [InlineData(TimeUnit.Second, "sek")]
+    [InlineData(TimeUnit.Minute, "dak")]
     [InlineData(TimeUnit.Hour, "saa")]
-    [InlineData(TimeUnit.Day, "siku")]
+    [InlineData(TimeUnit.Day, "sk")]
     public void TimeUnitHumanize_UsesSwahiliLabels(TimeUnit unit, string expected)
     {
         var formatter = Configurator.Formatters.ResolveForCulture(new CultureInfo("sw"));

--- a/tests/Humanizer.Tests/Localisation/sw/SwahiliTimeUnitTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sw/SwahiliTimeUnitTests.cs
@@ -1,0 +1,16 @@
+namespace Humanizer.Tests.Localisation.sw;
+
+[UseCulture("sw")]
+public class SwahiliTimeUnitTests
+{
+    [Theory]
+    [InlineData(TimeUnit.Second, "sekunde")]
+    [InlineData(TimeUnit.Minute, "dakika")]
+    [InlineData(TimeUnit.Hour, "saa")]
+    [InlineData(TimeUnit.Day, "siku")]
+    public void TimeUnitHumanize_UsesSwahiliLabels(TimeUnit unit, string expected)
+    {
+        var formatter = Configurator.Formatters.ResolveForCulture(new CultureInfo("sw"));
+        Assert.Equal(expected, formatter.TimeUnitHumanize(unit));
+    }
+}


### PR DESCRIPTION
## Summary
- Add Swahili (`sw`) locale YAML covering list, formatter phrases, numbers, parsing, ordinals, clock, compass, and date ordinal surfaces.
- Add a reusable shared `scale-leading-compound` render/parse engine for scale-noun-before-count number systems, scoped to the Swahili/Hausa baseline strategy.
- Add exact-output Swahili tests plus locale matrix coverage and source-generator contract coverage for the new shared engine.

## Shared strategy scope
- Implemented the narrowed generic `scale-leading-compound` family for Swahili/Hausa-style scale-leading compounds.
- Did not implement Telugu continuing stems or singular/plural scale inflection; that remains a separate strategy.

## Validation
- `dotnet test tests/Humanizer.SourceGenerators.Tests/Humanizer.SourceGenerators.Tests.csproj --framework net11.0`
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0`
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0`
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0`
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o artifacts/locale-parity-validation`
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity minimal`

## Hygiene
- Artifacts are uncommitted and gitignored.
- Staged diff was checked for machine-specific full paths before commit.
