### PR TITLE
docs: update locale parity references

### DIFF
--- a/docs/adding-a-locale.md
+++ b/docs/adding-a-locale.md
@@ -349,7 +349,7 @@ A residual locale-specific converter is acceptable only when at least one of the
 
 If a runtime kernel still hard-codes language-specific behavior, do not pretend it is generic. Either make it structurally generic for real or keep the locale name.
 
-Note: as of the locale parity completion, no clock residual leaves remain. All 65 shipped locale files use the unified `phrase-clock` engine for clock notation.
+Note: in the current checked-in locale set, no clock residual leaves remain. All shipped locales resolve clock notation through the unified `phrase-clock` engine, either directly or through locale inheritance.
 
 ## Step-By-Step: Add A Brand New Locale
 

--- a/docs/locale-yaml-how-to.md
+++ b/docs/locale-yaml-how-to.md
@@ -319,6 +319,7 @@ Supported parse engines in current checked-in YAML include:
 - `greedy-compound`
 - `inverted-tens`
 - `linking-affix`
+- `scale-leading-compound`
 - `prefixed-tens-scale`
 - `suffix-scale`
 - `token-map`

--- a/docs/locale-yaml-how-to.md
+++ b/docs/locale-yaml-how-to.md
@@ -281,6 +281,8 @@ Supported render engines in current checked-in YAML include:
 - `hyphenated-scale`
 - `hyphenated-ordinal`
 - `indian-grouping`
+- `indian-grouping-gendered`
+- `indian-scale-forms`
 - `inverted-tens`
 - `joined-scale`
 - `linking-scale`
@@ -288,6 +290,7 @@ Supported render engines in current checked-in YAML include:
 - `dual-form-scale`
 - `ordinal-prefix-scale`
 - `pluralized-scale`
+- `scale-leading-compound`
 - `scale-strategy`
 - `segmented-scale`
 - `south-slavic-cardinal`
@@ -350,7 +353,7 @@ Put here:
 
 Supported engine:
 
-- `phrase-clock` — the unified clock engine used by all 65 shipped locale files
+- `phrase-clock` — the unified clock engine all shipped locales resolve to directly or through locale inheritance
 
 ### `compass`
 

--- a/docs/locale-yaml-reference.md
+++ b/docs/locale-yaml-reference.md
@@ -1022,6 +1022,33 @@ Fields:
 - `ignoredTokens`
 - `negativePrefixes`
 
+### `scale-leading-compound` (parser)
+
+Fields:
+
+- `unitsMap`
+- `tensMap`
+- `scales`
+- `conjunctionWord`
+- `terminalRemainderConjunctionWord`
+- `minusWord`
+- `ordinalPrefix`
+- `ordinalSuffix`
+- `ordinalMap`
+
+Nested `scales` fields:
+
+- `value`
+- `name`
+
+Notes:
+
+- This parser is the `number.parse` counterpart to the scale-leading renderer used by Hausa (`ha`) and Swahili (`sw`). It accepts scale names before their count tokens and tokenizes multi-word unit and scale phrases.
+- Unlike the render-side `unitsMap` and `tensMap` arrays, parser maps are token-to-number dictionaries. Include every spelling variant that should parse.
+- `scales` must be ordered from larger to smaller values, and each larger value must be divisible by the next smaller value.
+- `conjunctionWord` joins tens-plus-units and terminal remainders. `terminalRemainderConjunctionWord` can override the terminal-remainder phrase and falls back to `conjunctionWord` when omitted.
+- Exact ordinal phrases belong in `ordinalMap`; otherwise the parser can strip `ordinalPrefix`/`ordinalSuffix` and parse the remaining cardinal phrase.
+
 ### `prefixed-tens-scale`
 
 Fields:
@@ -1085,10 +1112,10 @@ Notes:
 - `ordinalScaleMap` holds ordinal scale words such as "millionth".
 - `gluedOrdinalScaleSuffixes` supports glued forms where the scale is expressed as a suffix.
 - `compositeScaleMap` supports composite multi-token scales.
-- `ordinalGenderVariant` tells the token-map generator which gender variants should be synthesized from the referenced number-to-words converter when `ordinalNumberToWordsKind` is present. Use `none` for the converter's default ordinal form, `masculine-and-feminine` for two-gender ordinal systems, and `all` when default, feminine, and neuter forms are distinct and should parse.
-- `ordinalNumberToWordsKind: 'self'` is an authoring alias for the current locale's generated number-to-words profile. The generator rewrites it to the concrete locale profile key before emitting the parser catalog, so locale YAML does not need to know internal generated profile names.
-- `normalizationProfile` is the first field to pick for a new locale because it determines how aggressively the generated parser cleans incoming text before tokenization. The same normalization is applied to explicit ordinal tokens and to any generated ordinal forms from `ordinalNumberToWordsKind`.
-- `cardinalMap` is the authoritative literal-token dictionary for this engine. If a token should parse, it must appear here or in one of the explicit ordinal/scale maps, or be generated from `ordinalNumberToWordsKind` according to `ordinalGenderVariant`.
+- `ordinalGenderVariant` is validated as token-map metadata when present. Do not rely on it by itself to create parseable ordinal tokens; token-map parsing recognizes explicit ordinal maps and the prefix/suffix rules emitted into `TokenMapWordsToNumberRules`.
+- `ordinalNumberToWordsKind: 'self'` is an authoring alias for the current locale's generated number-to-words profile. The generator normalizes that alias to the concrete locale profile key, but token-map locales should still author the ordinal lexemes they need to parse in `ordinalMap`, `ordinalScaleMap`, `gluedOrdinalScaleSuffixes`, or `compositeScaleMap` unless the token-map emitter is extended to synthesize additional ordinal maps.
+- `normalizationProfile` is the first field to pick for a new locale because it determines how aggressively the generated parser cleans incoming text before tokenization. The same normalization is applied to explicit ordinal tokens.
+- `cardinalMap` is the authoritative literal-token dictionary for this engine. If a cardinal token should parse, it must appear here; ordinal tokens must appear in one of the explicit ordinal/scale maps or be covered by the documented prefix/suffix rules.
 
 ### `vigesimal-compound`
 

--- a/docs/locale-yaml-reference.md
+++ b/docs/locale-yaml-reference.md
@@ -353,7 +353,7 @@ Notes:
 
 - `clock` is the canonical YAML authoring surface.
 - The generator emits this surface into the runtime `timeOnlyToClockNotation` feature slot.
-- All 65 shipped locale files use the unified `phrase-clock` engine. There are no residual handwritten clock leaves.
+- All shipped locales resolve clock notation through the unified `phrase-clock` engine, either directly or through locale inheritance. There are no residual handwritten clock leaves.
 
 Supported engine:
 
@@ -927,7 +927,7 @@ The `{dayPeriod}` placeholder allows inline day-period placement within bucket t
 
 Notes:
 
-- All 65 shipped locale files use `phrase-clock`. There are no residual handwritten clock leaves.
+- All shipped locales resolve clock notation through `phrase-clock`, either directly or through locale inheritance. There are no residual handwritten clock leaves.
 - Non-bucketed minutes fall to range-based defaults or `defaultTemplate`.
 - Day-period hour resolution is template-aware: templates that reference `{nextHour}` or `{nextArticle}` base the day period on hour+1 (since the phrasing is relative to the next hour), while templates using `{hour}` base the period on the current hour.
 
@@ -1085,9 +1085,10 @@ Notes:
 - `ordinalScaleMap` holds ordinal scale words such as "millionth".
 - `gluedOrdinalScaleSuffixes` supports glued forms where the scale is expressed as a suffix.
 - `compositeScaleMap` supports composite multi-token scales.
-- `ordinalGenderVariant` tells the token-map generator which gender variants are already present in the YAML data.
-- `normalizationProfile` is the first field to pick for a new locale because it determines how aggressively the generated parser cleans incoming text before tokenization.
-- `cardinalMap` is the authoritative literal-token dictionary for this engine. If a token should parse, it must appear here or in one of the explicit ordinal/scale maps.
+- `ordinalGenderVariant` tells the token-map generator which gender variants should be synthesized from the referenced number-to-words converter when `ordinalNumberToWordsKind` is present. Use `none` for the converter's default ordinal form, `masculine-and-feminine` for two-gender ordinal systems, and `all` when default, feminine, and neuter forms are distinct and should parse.
+- `ordinalNumberToWordsKind: 'self'` is an authoring alias for the current locale's generated number-to-words profile. The generator rewrites it to the concrete locale profile key before emitting the parser catalog, so locale YAML does not need to know internal generated profile names.
+- `normalizationProfile` is the first field to pick for a new locale because it determines how aggressively the generated parser cleans incoming text before tokenization. The same normalization is applied to explicit ordinal tokens and to any generated ordinal forms from `ordinalNumberToWordsKind`.
+- `cardinalMap` is the authoritative literal-token dictionary for this engine. If a token should parse, it must appear here or in one of the explicit ordinal/scale maps, or be generated from `ordinalNumberToWordsKind` according to `ordinalGenderVariant`.
 
 ### `vigesimal-compound`
 
@@ -1427,6 +1428,34 @@ Fields:
 - `tupleMap`
 - `tupleFallbackWord`
 
+### `indian-scale-forms`
+
+Fields:
+
+- `zeroWord`
+- `negativeWord`
+- `ordinalSuffix`
+- `denseUnitsMap`
+- `scales`
+- `ordinalMap`
+- `ordinalTerminalReplacements`
+
+Nested `scales` fields:
+
+- `value`
+- `singular`
+- `singularWithRemainder`
+- `plural`
+- `pluralWithRemainder`
+- `omitOne`
+
+Notes:
+
+- Use this engine for Indian-grouped decimal systems whose scale nouns have singular, plural, and continuing forms. Telugu (`te`) uses it for forms such as lakh/crore scale phrases that change when a lower remainder follows.
+- `denseUnitsMap` must provide words for 0 through 99; the lowest scale value must be covered by that dense range.
+- `scales` are ordered from larger to smaller scale values. Each row can omit the explicit one-count word with `omitOne`.
+- `ordinalTerminalReplacements` rewrites terminal cardinal tokens before appending `ordinalSuffix`, while `ordinalMap` handles exact irregular ordinals.
+
 ### `indian-grouping`
 
 Fields:
@@ -1459,6 +1488,36 @@ Fields:
 - `croreContinuingSuffix`
 - `ordinalSuffix`
 - `ordinalExceptions`
+
+### `indian-grouping-gendered`
+
+Fields:
+
+- `zeroWord`
+- `negativeWord`
+- `hundredWord`
+- `thousandWord`
+- `lakhWord`
+- `singleLakhWord`
+- `croreWord`
+- `arabWord`
+- `kharabWord`
+- `denseUnitsMap`
+- `ordinal`
+
+Nested `ordinal` fields:
+
+- `masculine.defaultSuffix`
+- `masculine.exactReplacements`
+- `feminine.defaultSuffix`
+- `feminine.exactReplacements`
+- `neuterFallback`
+
+Notes:
+
+- This engine is used by Indian-subcontinent locales with lakh/crore/arab/kharab grouping and gendered word ordinals, such as Hindi, Punjabi, and Urdu.
+- `denseUnitsMap` supplies the cardinal word forms used below one hundred and for recursive scale counts.
+- `ordinal.masculine` and `ordinal.feminine` model productive suffixes plus exact low-number replacements. `neuterFallback` must be `masculine` or `feminine` and is used when callers request `GrammaticalGender.Neuter` for a two-gender locale.
 
 ### `inverted-tens`
 
@@ -1634,6 +1693,34 @@ Fields:
 - `ordinalTensMap`
 - `ordinalHundredsMap`
 - `useCulture`
+
+### `scale-leading-compound`
+
+Fields:
+
+- `zeroWord`
+- `minusWord`
+- `conjunctionWord`
+- `terminalRemainderConjunctionWord`
+- `ordinalPrefix`
+- `ordinalSuffix`
+- `unitsMap`
+- `tensMap`
+- `scales`
+- `ordinalMap`
+
+Nested `scales` fields:
+
+- `value`
+- `name`
+
+Notes:
+
+- Use this engine for languages whose scale noun precedes the count token, for example a structure like "hundred one and two". Hausa (`ha`) and Swahili (`sw`) use this shared family.
+- `unitsMap` must cover 0 through 19 and `tensMap` must be keyed through index 9.
+- `scales` are ordered from larger to smaller scale values and must include a scale no greater than 100 so the recursive renderer can decompose all larger numbers.
+- `conjunctionWord` joins tens-plus-units and terminal sub-hundred remainders. `terminalRemainderConjunctionWord` can override that conjunction for potentially ambiguous terminal remainders after larger scales; when omitted, it falls back to `conjunctionWord`.
+- Ordinals use `ordinalMap` for exact values. Otherwise the engine wraps the cardinal phrase with `ordinalPrefix` and `ordinalSuffix`.
 
 ### `scale-strategy`
 

--- a/docs/locale-yaml-reference.md
+++ b/docs/locale-yaml-reference.md
@@ -302,6 +302,8 @@ Supported engines in current checked-in YAML:
 - `hyphenated-scale`
 - `hyphenated-ordinal`
 - `indian-grouping`
+- `indian-grouping-gendered`
+- `indian-scale-forms`
 - `inverted-tens`
 - `joined-scale`
 - `linking-scale`
@@ -309,6 +311,7 @@ Supported engines in current checked-in YAML:
 - `dual-form-scale`
 - `ordinal-prefix-scale`
 - `pluralized-scale`
+- `scale-leading-compound`
 - `scale-strategy`
 - `segmented-scale`
 - `south-slavic-cardinal`
@@ -336,6 +339,7 @@ Supported engines in current checked-in YAML:
 - `greedy-compound`
 - `inverted-tens`
 - `linking-affix`
+- `scale-leading-compound`
 - `prefixed-tens-scale`
 - `suffix-scale`
 - `token-map`

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -4,11 +4,13 @@ Humanizer supports many languages and cultures across number, date, time, ordina
 
 Most consumers only need to set a culture. Contributors now author locale-specific generated behavior in one YAML file per locale, and shared runtime kernels are used whenever the behavior is structurally reusable.
 
-## Supported Languages
+## Supported Locales
 
-Humanizer includes localization for:
+Humanizer includes generated locale data for 72 checked-in locale files:
 
-Afrikaans (af), Arabic (ar), Azerbaijani (az), Bengali (bn), Bulgarian (bg), Catalan (ca), Chinese (zh-CN, zh-Hans, zh-Hant), Croatian (hr), Czech (cs), Danish (da), Dutch (nl), English (en, en-GB, en-IN, en-US), Finnish (fi), Filipino (fil), French (fr, fr-BE, fr-CH), German (de, de-CH, de-LI), Greek (el), Hebrew (he), Hungarian (hu), Armenian (hy), Icelandic (is), Indonesian (id), Italian (it), Japanese (ja), Korean (ko), Kurdish (ku), Latvian (lv), Lithuanian (lt), Luxembourgish (lb), Malay (ms), Maltese (mt), Norwegian Bokmal (nb), Norwegian Nynorsk (nn), Persian (fa), Polish (pl), Portuguese (pt, pt-BR), Romanian (ro), Russian (ru), Serbian (sr, sr-Latn), Slovak (sk), Slovenian (sl), Spanish (es), Swedish (sv), Tamil (ta), Thai (th), Turkish (tr), Ukrainian (uk), Uzbek (uz-Cyrl-UZ, uz-Latn-UZ), Vietnamese (vi), Zulu (zu-ZA).
+Afrikaans (af), Amharic (am), Arabic (ar), Azerbaijani (az), Bengali (bn), Bulgarian (bg), Catalan (ca), Chinese (zh-CN, zh-Hans, zh-Hant), Croatian (hr), Czech (cs), Danish (da), Dutch (nl), English (en, en-GB, en-IN, en-US), Finnish (fi), Filipino (fil), French (fr, fr-BE, fr-CH), German (de, de-CH, de-LI), Greek (el), Hausa (ha), Hebrew (he), Hindi (hi), Hungarian (hu), Armenian (hy), Icelandic (is), Indonesian (id), Italian (it), Japanese (ja), Korean (ko), Kurdish (ku), Latvian (lv), Lithuanian (lt), Luxembourgish (lb), Malay (ms), Maltese (mt), Norwegian Bokmål (nb), Norwegian Nynorsk (nn), Persian (fa), Polish (pl), Portuguese (pt, pt-BR), Punjabi (pa, pa-Arab), Romanian (ro), Russian (ru), Serbian (sr, sr-Latn), Slovak (sk), Slovenian (sl), Spanish (es), Swahili (sw), Swedish (sv), Tamil (ta), Telugu (te), Thai (th), Turkish (tr), Ukrainian (uk), Urdu (ur, ur-IN, ur-PK), Uzbek (uz-Cyrl-UZ, uz-Latn-UZ), Vietnamese (vi), Zulu (zu-ZA).
+
+The supported set above reflects checked-in locale files. Locale files under active, unmerged batch work are not listed as supported until they merge.
 
 ## Installing Humanizer
 
@@ -68,7 +70,7 @@ Principles:
 2. Locale inheritance is declared in that same file with `variantOf`.
 3. Top-level properties are exactly `locale`, `variantOf`, and `surfaces`.
 4. Canonical authoring surfaces under `surfaces` are exactly `list`, `formatter`, `phrases`, `number`, `ordinal`, `clock`, `compass`, and `calendar`.
-5. Canonical nested members are `number.words`, `number.parse`, `number.formatting`, `ordinal.numeric`, `ordinal.date`, `ordinal.dateOnly`, `calendar.months`, and `calendar.monthsGenitive`.
+5. Canonical nested members are `number.words`, `number.parse`, `number.formatting`, `ordinal.numeric`, `ordinal.date`, `ordinal.dateOnly`, `calendar.months`, `calendar.monthsGenitive`, and `calendar.hijriMonths`.
 6. Omit a `surfaces.<surface>` block to inherit it unchanged from the parent locale.
 7. Inside a mapped surface, omit unchanged fields to inherit them from the parent mapping.
 8. Child sequences replace parent sequences.
@@ -149,10 +151,13 @@ Good structural names:
 - `ConjunctionalScaleNumberToWordsConverter`
 - `VariantDecadeNumberToWordsConverter`
 - `UnitLeadingCompoundNumberToWordsConverter`
+- `ScaleLeadingCompoundNumberToWordsConverter`
+- `IndianScaleFormNumberToWordsConverter`
+- `IndianGroupingGenderedNumberToWordsConverter`
 - `ContractedScaleWordsToNumberConverter`
 - `ProfiledFormatter`
 
-Residual locale names are acceptable only when the behavior is still genuinely locale-specific and forcing it into a shared schema would create imperative hooks or exception-bucket metadata. As of the locale parity completion, no residual leaves remain for any surface.
+Residual locale names are acceptable only when the behavior is still genuinely locale-specific and forcing it into a shared schema would create imperative hooks or exception-bucket metadata. In the current checked-in locale set, no residual leaves remain for any surface.
 
 ## Adding Or Updating A Locale
 


### PR DESCRIPTION
## Summary
- update localization docs to list the 72 checked-in supported locale files, including Urdu-era and later merged locales through Hausa
- document newer shared locale engines and parser behavior: scale-leading-compound, indian-scale-forms, indian-grouping-gendered, token-map ordinal generation, and neuter fallback for gendered Indian ordinals
- replace stale "65 shipped locale files" wording with inheritance-safe phrase-clock wording

## Validation
- Python docs consistency check: supported locale list matches `src/Humanizer/Locales/*.yml` and excludes active unmerged batch codes
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
