### PR TITLE
Generalize conjoined gendered scale forms

### DIFF
--- a/docs/locale-yaml-reference.md
+++ b/docs/locale-yaml-reference.md
@@ -1253,7 +1253,15 @@ Fields:
 - `hundredsMap`
 - `hundredsOrdinalMap`
 - `unitsOrdinal`
+- `unitForms` with optional `masculine`, `feminine`, and `neuter` unit override maps
+- `ordinalZero` with `masculine`, `feminine`, and `neuter` forms
+- `ordinalOverHundredSuffixes` with `masculine`, `feminine`, and `neuter` suffixes for hundreds and scale stems
+- `ordinalUnitsAndTensSuffixes` with `masculine`, `feminine`, and `neuter` suffixes for unit and tens stems
 - `scales`
+
+Notes:
+
+- Omitted `unitForms` gender maps, or missing entries inside a gender map, fall back to `unitsMap`. The ordinal form blocks are required because there is no safe runtime fallback for locale-specific ordinal wording.
 
 ### `conjunctional-scale`
 

--- a/src/Humanizer.SourceGenerators/Common/EngineContractCatalog.cs
+++ b/src/Humanizer.SourceGenerators/Common/EngineContractCatalog.cs
@@ -105,6 +105,26 @@ public sealed partial class HumanizerSourceGenerator
                             Member("string-array", "hundredsMap", null, null, null, null, null, null),
                             Member("string-array", "hundredsOrdinalMap", null, null, null, null, null, null),
                             Member("string-array", "unitsOrdinal", null, null, null, null, null, null),
+                            Member("profile-object", "unitForms", "ConjoinedGenderedUnitForms", null, null, null, null, null,
+                                        Member("nullable-int-string-dictionary", "masculine", null, null, null, null, null, "empty"),
+                                        Member("nullable-int-string-dictionary", "feminine", null, null, null, null, null, "empty"),
+                                        Member("nullable-int-string-dictionary", "neuter", null, null, null, null, null, "empty")
+                                    ),
+                            Member("profile-object", "ordinalZero", "ConjoinedGenderedOrdinalForms", null, null, null, null, null,
+                                        Member("string", "masculine", null, null, null, null, null, null),
+                                        Member("string", "feminine", null, null, null, null, null, null),
+                                        Member("string", "neuter", null, null, null, null, null, null)
+                                    ),
+                            Member("profile-object", "ordinalOverHundredSuffixes", "ConjoinedGenderedOrdinalForms", null, null, null, null, null,
+                                        Member("string", "masculine", null, null, null, null, null, null),
+                                        Member("string", "feminine", null, null, null, null, null, null),
+                                        Member("string", "neuter", null, null, null, null, null, null)
+                                    ),
+                            Member("profile-object", "ordinalUnitsAndTensSuffixes", "ConjoinedGenderedOrdinalForms", null, null, null, null, null,
+                                        Member("string", "masculine", null, null, null, null, null, null),
+                                        Member("string", "feminine", null, null, null, null, null, null),
+                                        Member("string", "neuter", null, null, null, null, null, null)
+                                    ),
                             Member("builder", "scales", null, null, "conjoined-gendered-scale-array", null, null, null)
                         )
             ),

--- a/src/Humanizer/Locales/bg.yml
+++ b/src/Humanizer/Locales/bg.yml
@@ -318,6 +318,24 @@ surfaces:
         17: 'седемнадесет'
         18: 'осемнадесет'
         19: 'деветнадесет'
+      unitForms:
+        masculine:
+          1: 'един'
+          2: 'два'
+        feminine:
+          1: 'една'
+      ordinalZero:
+        masculine: 'нулев'
+        feminine: 'нулева'
+        neuter: 'нулево'
+      ordinalOverHundredSuffixes:
+        masculine: 'ен'
+        feminine: 'на'
+        neuter: 'но'
+      ordinalUnitsAndTensSuffixes:
+        masculine: 'и'
+        feminine: 'а'
+        neuter: 'о'
       scales:
         -
           divisor: 1000000000000000000

--- a/src/Humanizer/Localisation/NumberToWords/ConjoinedGenderedScaleNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/ConjoinedGenderedScaleNumberToWordsConverter.cs
@@ -35,7 +35,7 @@ class ConjoinedGenderedScaleNumberToWordsConverter(ConjoinedGenderedScaleNumberT
     {
         if (input == 0)
         {
-            return isOrdinal ? OrdinalZero(gender) : profile.UnitsMap[0];
+            return isOrdinal ? profile.OrdinalZero.Get(gender) : profile.UnitsMap[0];
         }
 
         var parts = new List<string>();
@@ -153,40 +153,15 @@ class ConjoinedGenderedScaleNumberToWordsConverter(ConjoinedGenderedScaleNumberT
     }
 
     string GetUnit(long number, GrammaticalGender gender) =>
-        (number, gender) switch
-        {
-            (1, GrammaticalGender.Masculine) => "един",
-            (1, GrammaticalGender.Feminine) => "една",
-            (2, GrammaticalGender.Masculine) => "два",
-            _ => profile.UnitsMap[number],
-        };
+        profile.UnitForms.Get(gender).TryGetValue((int)number, out var genderedUnit)
+            ? genderedUnit
+            : profile.UnitsMap[number];
 
-    static string OrdinalZero(GrammaticalGender gender) =>
-        gender switch
-        {
-            GrammaticalGender.Masculine => "нулев",
-            GrammaticalGender.Feminine => "нулева",
-            GrammaticalGender.Neuter => "нулево",
-            _ => throw new ArgumentOutOfRangeException(nameof(gender), gender, null)
-        };
+    string ToOrdinalOverAHundred(string word, GrammaticalGender gender) =>
+        word + profile.OrdinalOverHundredSuffixes.Get(gender);
 
-    static string ToOrdinalOverAHundred(string word, GrammaticalGender gender) =>
-        gender switch
-        {
-            GrammaticalGender.Masculine => $"{word}ен",
-            GrammaticalGender.Feminine => $"{word}на",
-            GrammaticalGender.Neuter => $"{word}но",
-            _ => throw new ArgumentOutOfRangeException(nameof(gender))
-        };
-
-    static string ToOrdinalUnitsAndTens(string word, GrammaticalGender gender) =>
-        gender switch
-        {
-            GrammaticalGender.Masculine => $"{word}и",
-            GrammaticalGender.Feminine => $"{word}а",
-            GrammaticalGender.Neuter => $"{word}о",
-            _ => throw new ArgumentOutOfRangeException(nameof(gender))
-        };
+    string ToOrdinalUnitsAndTens(string word, GrammaticalGender gender) =>
+        word + profile.OrdinalUnitsAndTensSuffixes.Get(gender);
 }
 
 /// <summary>
@@ -200,6 +175,10 @@ sealed class ConjoinedGenderedScaleNumberToWordsProfile(
     string[] hundredsMap,
     string[] hundredsOrdinalMap,
     string[] unitsOrdinal,
+    ConjoinedGenderedUnitForms unitForms,
+    ConjoinedGenderedOrdinalForms ordinalZero,
+    ConjoinedGenderedOrdinalForms ordinalOverHundredSuffixes,
+    ConjoinedGenderedOrdinalForms ordinalUnitsAndTensSuffixes,
     ConjoinedGenderedScale[] scales)
 {
     /// <summary>
@@ -231,9 +210,64 @@ sealed class ConjoinedGenderedScaleNumberToWordsProfile(
     /// </summary>
     public string[] UnitsOrdinal { get; } = unitsOrdinal;
     /// <summary>
+    /// Gets gender-specific cardinal unit overrides.
+    /// </summary>
+    public ConjoinedGenderedUnitForms UnitForms { get; } = unitForms;
+    /// <summary>
+    /// Gets the gender-specific words for zero ordinals.
+    /// </summary>
+    public ConjoinedGenderedOrdinalForms OrdinalZero { get; } = ordinalZero;
+    /// <summary>
+    /// Gets the gender-specific suffixes appended to hundreds and scale ordinal stems.
+    /// </summary>
+    public ConjoinedGenderedOrdinalForms OrdinalOverHundredSuffixes { get; } = ordinalOverHundredSuffixes;
+    /// <summary>
+    /// Gets the gender-specific suffixes appended to unit and tens ordinal stems.
+    /// </summary>
+    public ConjoinedGenderedOrdinalForms OrdinalUnitsAndTensSuffixes { get; } = ordinalUnitsAndTensSuffixes;
+    /// <summary>
     /// Gets the descending scale rows used during decomposition.
     /// </summary>
     public ConjoinedGenderedScale[] Scales { get; } = scales;
+}
+
+/// <summary>
+/// Cardinal unit overrides keyed by grammatical gender.
+/// </summary>
+sealed class ConjoinedGenderedUnitForms(
+    FrozenDictionary<int, string> masculine,
+    FrozenDictionary<int, string> feminine,
+    FrozenDictionary<int, string> neuter)
+{
+    /// <summary>
+    /// Gets the unit override map for the requested gender.
+    /// </summary>
+    public FrozenDictionary<int, string> Get(GrammaticalGender gender) =>
+        gender switch
+        {
+            GrammaticalGender.Masculine => masculine,
+            GrammaticalGender.Feminine => feminine,
+            GrammaticalGender.Neuter => neuter,
+            _ => throw new ArgumentOutOfRangeException(nameof(gender), gender, null)
+        };
+}
+
+/// <summary>
+/// Gender-specific ordinal words or suffixes.
+/// </summary>
+sealed class ConjoinedGenderedOrdinalForms(string masculine, string feminine, string neuter)
+{
+    /// <summary>
+    /// Gets the ordinal form for the requested gender.
+    /// </summary>
+    public string Get(GrammaticalGender gender) =>
+        gender switch
+        {
+            GrammaticalGender.Masculine => masculine,
+            GrammaticalGender.Feminine => feminine,
+            GrammaticalGender.Neuter => neuter,
+            _ => throw new ArgumentOutOfRangeException(nameof(gender), gender, null)
+        };
 }
 
 /// <summary>

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.cs
@@ -852,6 +852,79 @@ numberToWords:
     }
 
     [Fact]
+    public void ConjoinedGenderedScaleProfilesEmitGenderedFormsFromLocaleData()
+    {
+        const string locale = """
+numberToWords:
+  engine: 'conjoined-gendered-scale'
+  maximumValue: 1000
+  minusWord: 'minus'
+  conjunction: 'and'
+  unitsMap:
+    - 'zero'
+    - 'one'
+    - 'two'
+  tensMap:
+    - 'zero'
+    - 'ten'
+    - 'twenty'
+  hundredsMap:
+    - 'zero'
+    - 'hundred'
+  hundredsOrdinalMap:
+    1: 'hundred'
+  unitsOrdinal:
+    1: 'first'
+    2: 'second'
+  unitForms:
+    masculine:
+      1: 'one-m'
+      2: 'two-m'
+    feminine:
+      1: 'one-f'
+  ordinalZero:
+    masculine: 'zero-m'
+    feminine: 'zero-f'
+    neuter: 'zero-n'
+  ordinalOverHundredSuffixes:
+    masculine: '-over-m'
+    feminine: '-over-f'
+    neuter: '-over-n'
+  ordinalUnitsAndTensSuffixes:
+    masculine: '-unit-m'
+    feminine: '-unit-f'
+    neuter: '-unit-n'
+  scales:
+    -
+      divisor: 1000
+      gender: 'feminine'
+      singular: 'thousand'
+      plural: 'thousands'
+      ordinalStem: 'thousandth'
+""";
+
+        var runResult = RunGenerator(new InMemoryAdditionalText(
+            @"E:\Dev\Humanizer\src\Humanizer\Locales\zz-conjoined-gendered-scale.yml",
+            locale));
+
+        Assert.Empty(runResult.Diagnostics);
+
+        var source = GetGeneratedSource(runResult, "NumberToWordsProfileCatalog.g.cs");
+        var profileBlock = ExtractCacheClassBody(source, "zz_conjoined_gendered_scale_cache");
+
+        Assert.Contains("new ConjoinedGenderedUnitForms(", profileBlock);
+        Assert.Contains("[1] = \"one-m\"", profileBlock);
+        Assert.Contains("[2] = \"two-m\"", profileBlock);
+        Assert.Contains("[1] = \"one-f\"", profileBlock);
+        Assert.Contains("FrozenDictionary<int, string>.Empty", profileBlock);
+        Assert.Contains("new ConjoinedGenderedOrdinalForms(\"zero-m\", \"zero-f\", \"zero-n\")", profileBlock);
+        Assert.Contains("new ConjoinedGenderedOrdinalForms(\"-over-m\", \"-over-f\", \"-over-n\")", profileBlock);
+        Assert.Contains("new ConjoinedGenderedOrdinalForms(\"-unit-m\", \"-unit-f\", \"-unit-n\")", profileBlock);
+        Assert.Contains("new(1000, GrammaticalGender.Feminine, \"thousand\", \"thousands\", \"thousandth\")", profileBlock);
+        Assert.DoesNotContain("нулев", profileBlock);
+    }
+
+    [Fact]
     public void JoinedScaleProfilesEmitOptionalGenderedOrdinalBlocks()
     {
         const string locale = """

--- a/tests/Humanizer.Tests/Localisation/ConjoinedGenderedScaleNumberToWordsConverterTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ConjoinedGenderedScaleNumberToWordsConverterTests.cs
@@ -1,0 +1,84 @@
+using System.Collections.Frozen;
+
+namespace Humanizer.Tests.Localisation;
+
+public class ConjoinedGenderedScaleNumberToWordsConverterTests
+{
+    [Fact]
+    public void UsesProfileDataForGenderedCardinalUnits()
+    {
+        var converter = CreateConverter();
+
+        Assert.Equal("one-m", converter.Convert(1, GrammaticalGender.Masculine));
+        Assert.Equal("one-f", converter.Convert(1, GrammaticalGender.Feminine));
+        Assert.Equal("one-n", converter.Convert(1, GrammaticalGender.Neuter));
+        Assert.Equal("two-m", converter.Convert(2, GrammaticalGender.Masculine));
+        Assert.Equal("two", converter.Convert(2, GrammaticalGender.Feminine));
+        Assert.Equal("two", converter.Convert(2, GrammaticalGender.Neuter));
+    }
+
+    [Theory]
+    [InlineData(0, GrammaticalGender.Feminine, "zero-f")]
+    [InlineData(1, GrammaticalGender.Masculine, "first-u-m")]
+    [InlineData(20, GrammaticalGender.Neuter, "twenty-u-n")]
+    [InlineData(100, GrammaticalGender.Feminine, "hundred-o-f")]
+    [InlineData(1000, GrammaticalGender.Masculine, "one-f thousand-o-m")]
+    public void UsesProfileDataForGenderedOrdinalForms(int number, GrammaticalGender gender, string expected)
+    {
+        var converter = CreateConverter();
+
+        Assert.Equal(expected, converter.ConvertToOrdinal(number, gender));
+    }
+
+    static ConjoinedGenderedScaleNumberToWordsConverter CreateConverter() =>
+        new(new(
+            "minus",
+            "and",
+            CreateMap(20, index => index switch
+            {
+                0 => "zero",
+                1 => "one",
+                2 => "two",
+                _ => index.ToString(CultureInfo.InvariantCulture)
+            }),
+            CreateMap(10, index => index switch
+            {
+                2 => "twenty",
+                _ => index.ToString(CultureInfo.InvariantCulture)
+            }),
+            CreateMap(10, index => index switch
+            {
+                1 => "one hundred",
+                _ => index.ToString(CultureInfo.InvariantCulture)
+            }),
+            CreateMap(10, index => index switch
+            {
+                1 => "hundred",
+                _ => index.ToString(CultureInfo.InvariantCulture)
+            }),
+            CreateMap(20, index => index switch
+            {
+                1 => "first",
+                _ => index.ToString(CultureInfo.InvariantCulture)
+            }),
+            new(
+                new Dictionary<int, string> { [1] = "one-m", [2] = "two-m" }.ToFrozenDictionary(),
+                new Dictionary<int, string> { [1] = "one-f" }.ToFrozenDictionary(),
+                new Dictionary<int, string> { [1] = "one-n" }.ToFrozenDictionary()),
+            new("zero-m", "zero-f", "zero-n"),
+            new("-o-m", "-o-f", "-o-n"),
+            new("-u-m", "-u-f", "-u-n"),
+            [new(1000, GrammaticalGender.Feminine, "thousand", "thousands", "thousand")]
+        ));
+
+    static string[] CreateMap(int length, Func<int, string> valueFactory)
+    {
+        var values = new string[length];
+        for (var index = 0; index < values.Length; index++)
+        {
+            values[index] = valueFactory(index);
+        }
+
+        return values;
+    }
+}

--- a/tests/Humanizer.Tests/Localisation/bg/BulgarianNumberToWordsTests.cs
+++ b/tests/Humanizer.Tests/Localisation/bg/BulgarianNumberToWordsTests.cs
@@ -1,0 +1,37 @@
+namespace Humanizer.Tests.Localisation.bg;
+
+[UseCulture("bg")]
+public class BulgarianNumberToWordsTests
+{
+    static readonly CultureInfo Bg = new("bg");
+
+    [Theory]
+    [InlineData(1, GrammaticalGender.Masculine, "един")]
+    [InlineData(1, GrammaticalGender.Feminine, "една")]
+    [InlineData(1, GrammaticalGender.Neuter, "едно")]
+    [InlineData(2, GrammaticalGender.Masculine, "два")]
+    [InlineData(2, GrammaticalGender.Feminine, "две")]
+    [InlineData(2, GrammaticalGender.Neuter, "две")]
+    [InlineData(1000, GrammaticalGender.Neuter, "една хиляда")]
+    public void ToWords_UsesBulgarianGenderedUnitForms(int number, GrammaticalGender gender, string expected) =>
+        Assert.Equal(expected, number.ToWords(gender, Bg));
+
+    [Theory]
+    [InlineData(0, GrammaticalGender.Masculine, "нулев")]
+    [InlineData(0, GrammaticalGender.Feminine, "нулева")]
+    [InlineData(0, GrammaticalGender.Neuter, "нулево")]
+    [InlineData(1, GrammaticalGender.Masculine, "първи")]
+    [InlineData(1, GrammaticalGender.Feminine, "първа")]
+    [InlineData(1, GrammaticalGender.Neuter, "първо")]
+    [InlineData(20, GrammaticalGender.Masculine, "двадесети")]
+    [InlineData(20, GrammaticalGender.Feminine, "двадесета")]
+    [InlineData(20, GrammaticalGender.Neuter, "двадесето")]
+    [InlineData(100, GrammaticalGender.Masculine, "стотен")]
+    [InlineData(100, GrammaticalGender.Feminine, "стотна")]
+    [InlineData(100, GrammaticalGender.Neuter, "стотно")]
+    [InlineData(1000, GrammaticalGender.Masculine, "една хиляден")]
+    [InlineData(1000, GrammaticalGender.Feminine, "една хилядна")]
+    [InlineData(1000, GrammaticalGender.Neuter, "една хилядно")]
+    public void ToOrdinalWords_UsesBulgarianGenderedOrdinalForms(int number, GrammaticalGender gender, string expected) =>
+        Assert.Equal(expected, number.ToOrdinalWords(gender, Bg));
+}


### PR DESCRIPTION
## Summary
- Move conjoined-gendered-scale unit and ordinal forms into generated profile data
- Author the existing Bulgarian forms explicitly in bg.yml to preserve current behavior
- Add source-generator, runtime, and Bulgarian regression coverage plus YAML reference docs

## Validation
- dotnet test tests/Humanizer.SourceGenerators.Tests/Humanizer.SourceGenerators.Tests.csproj --framework net10.0
- dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0
- dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0
- dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0
- dotnet pack src/Humanizer/Humanizer.csproj -c Release -o artifacts/locale-parity-validation
- MSBUILDDISABLENODEREUSE=1 dotnet format Humanizer.slnx --no-restore --verify-no-changes --verbosity minimal
- git diff --check