### PR TITLE
Add linked-vigesimal alternate terminal joiner

### DIFF
--- a/docs/locale-yaml-reference.md
+++ b/docs/locale-yaml-reference.md
@@ -1529,7 +1529,7 @@ Nested `scales` fields:
 - `countOverrides` (optional exact phrases keyed by scale count)
 - `countOverridesWithRemainder` (optional exact phrases keyed by scale count)
 
-Parse fields mirror render-side `words`, `scales`, `terminalRemainderJoiner`, `terminalRemainderAlternateJoiner`, and `terminalRemainderAlternateJoinerInitials`, plus optional `negativePrefixes`, `ordinalSuffixes`, `ordinalMap`, and `additionalCardinals`. Parsers accept both the base and alternate terminal joiner tokens.
+Parse fields mirror render-side `words`, `scales`, `terminalRemainderJoiner`, and optional `terminalRemainderAlternateJoiner`, plus optional `negativePrefixes`, `ordinalSuffixes`, `ordinalMap`, and `additionalCardinals`. Parsers accept both the base and alternate terminal joiner tokens; parser profiles do not need `terminalRemainderAlternateJoinerInitials` because they match explicit joiner tokens rather than selecting a joiner while rendering.
 
 ### `stemmed-scale`
 

--- a/docs/locale-yaml-reference.md
+++ b/docs/locale-yaml-reference.md
@@ -1510,6 +1510,8 @@ Render fields:
 - `negativeJoiner`
 - `partJoiner`
 - `terminalRemainderJoiner`
+- `terminalRemainderAlternateJoiner` (optional; used when the rendered terminal remainder starts with a configured initial)
+- `terminalRemainderAlternateJoinerInitials` (optional initial-character set for the alternate joiner)
 - `terminalRemainderThreshold`
 - `ordinalSuffix`
 - `words` — dense cardinal words from zero through the highest lexicalized low number
@@ -1527,7 +1529,7 @@ Nested `scales` fields:
 - `countOverrides` (optional exact phrases keyed by scale count)
 - `countOverridesWithRemainder` (optional exact phrases keyed by scale count)
 
-Parse fields mirror render-side `words`, `scales`, and `terminalRemainderJoiner`, plus optional `negativePrefixes`, `ordinalSuffixes`, `ordinalMap`, and `additionalCardinals`.
+Parse fields mirror render-side `words`, `scales`, `terminalRemainderJoiner`, `terminalRemainderAlternateJoiner`, and `terminalRemainderAlternateJoinerInitials`, plus optional `negativePrefixes`, `ordinalSuffixes`, `ordinalMap`, and `additionalCardinals`. Parsers accept both the base and alternate terminal joiner tokens.
 
 ### `stemmed-scale`
 

--- a/src/Humanizer.SourceGenerators/Common/EngineContractCatalog.cs
+++ b/src/Humanizer.SourceGenerators/Common/EngineContractCatalog.cs
@@ -669,7 +669,9 @@ public sealed partial class HumanizerSourceGenerator
                             Member("string", "ordinalSuffix", null, null, null, "", null, null),
                             Member("string-array", "words", null, null, null, null, null, null),
                             Member("builder", "scales", null, null, "linked-vigesimal-scale-array", null, null, null),
-                            Member("nullable-int-string-dictionary", "ordinalExceptions", null, null, null, null, null, "empty")
+                            Member("nullable-int-string-dictionary", "ordinalExceptions", null, null, null, null, null, "empty"),
+                            Member("string", "terminalRemainderAlternateJoiner", null, null, null, "", null, null),
+                            Member("string", "terminalRemainderAlternateJoinerInitials", null, null, null, "", null, null)
                         )
             ),
                 // Shared engine for locales whose scale count is a bound stem and whose scale suffix

--- a/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/WordsToNumberEngineContractFactory.cs
+++ b/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/WordsToNumberEngineContractFactory.cs
@@ -125,8 +125,7 @@ public sealed partial class HumanizerSourceGenerator
             CreateOptionalStringArrayExpression(root, "ordinalSuffixes") + ", " +
             CreateOptionalStringLongFrozenDictionaryExpression(root, "ordinalMap") + ", " +
             CreateOptionalStringLongFrozenDictionaryExpression(root, "additionalCardinals") + ", " +
-            QuoteLiteral(GetOptionalString(root, "terminalRemainderAlternateJoiner") ?? string.Empty) + ", " +
-            QuoteLiteral(GetOptionalString(root, "terminalRemainderAlternateJoinerInitials") ?? string.Empty) +
+            QuoteLiteral(GetOptionalString(root, "terminalRemainderAlternateJoiner") ?? string.Empty) +
             "))";
 
         static string CreateScaleLeadingCompoundExpression(JsonElement root) =>

--- a/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/WordsToNumberEngineContractFactory.cs
+++ b/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/WordsToNumberEngineContractFactory.cs
@@ -124,7 +124,9 @@ public sealed partial class HumanizerSourceGenerator
             CreateOptionalStringArrayExpression(root, "negativePrefixes") + ", " +
             CreateOptionalStringArrayExpression(root, "ordinalSuffixes") + ", " +
             CreateOptionalStringLongFrozenDictionaryExpression(root, "ordinalMap") + ", " +
-            CreateOptionalStringLongFrozenDictionaryExpression(root, "additionalCardinals") +
+            CreateOptionalStringLongFrozenDictionaryExpression(root, "additionalCardinals") + ", " +
+            QuoteLiteral(GetOptionalString(root, "terminalRemainderAlternateJoiner") ?? string.Empty) + ", " +
+            QuoteLiteral(GetOptionalString(root, "terminalRemainderAlternateJoinerInitials") ?? string.Empty) +
             "))";
 
         static string CreateScaleLeadingCompoundExpression(JsonElement root) =>

--- a/src/Humanizer/Localisation/NumberToWords/LinkedVigesimalNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/LinkedVigesimalNumberToWordsConverter.cs
@@ -80,12 +80,13 @@ class LinkedVigesimalNumberToWordsConverter(LinkedVigesimalNumberToWordsProfile 
 
         if (remainder > 0)
         {
+            var renderedRemainder = ConvertPositive(remainder);
             if (remainder < (ulong)profile.TerminalRemainderThreshold)
             {
-                parts.Add(profile.TerminalRemainderJoiner);
+                parts.Add(profile.GetTerminalRemainderJoiner(renderedRemainder));
             }
 
-            parts.Add(ConvertPositive(remainder));
+            parts.Add(renderedRemainder);
         }
 
         return string.Join(profile.PartJoiner, parts);
@@ -130,7 +131,9 @@ sealed class LinkedVigesimalNumberToWordsProfile(
     string ordinalSuffix,
     string[] words,
     LinkedVigesimalScale[] scales,
-    FrozenDictionary<int, string>? ordinalExceptions = null)
+    FrozenDictionary<int, string>? ordinalExceptions = null,
+    string terminalRemainderAlternateJoiner = "",
+    string terminalRemainderAlternateJoinerInitials = "")
 {
     /// <summary>Gets the word used for zero.</summary>
     public string ZeroWord { get; } = zeroWord;
@@ -142,6 +145,10 @@ sealed class LinkedVigesimalNumberToWordsProfile(
     public string PartJoiner { get; } = partJoiner;
     /// <summary>Gets the linker inserted before terminal low remainders.</summary>
     public string TerminalRemainderJoiner { get; } = terminalRemainderJoiner;
+    /// <summary>Gets the alternate linker inserted before matching terminal low remainders.</summary>
+    public string TerminalRemainderAlternateJoiner { get; } = terminalRemainderAlternateJoiner;
+    /// <summary>Gets the terminal low-remainder initials that use the alternate linker.</summary>
+    public string TerminalRemainderAlternateJoinerInitials { get; } = terminalRemainderAlternateJoinerInitials;
     /// <summary>Gets the threshold below which terminal remainders receive the linker.</summary>
     public int TerminalRemainderThreshold { get; } = terminalRemainderThreshold;
     /// <summary>Gets the fallback ordinal suffix.</summary>
@@ -152,6 +159,19 @@ sealed class LinkedVigesimalNumberToWordsProfile(
     public LinkedVigesimalScale[] Scales { get; } = ValidateScales(scales);
     /// <summary>Gets exact ordinal words keyed by numeric value.</summary>
     public FrozenDictionary<int, string> OrdinalExceptions { get; } = ordinalExceptions ?? FrozenDictionary<int, string>.Empty;
+
+    /// <summary>Gets the terminal low-remainder linker for the rendered remainder.</summary>
+    public string GetTerminalRemainderJoiner(string renderedRemainder)
+    {
+        if (TerminalRemainderAlternateJoiner.Length > 0 &&
+            renderedRemainder.Length > 0 &&
+            TerminalRemainderAlternateJoinerInitials.Contains(renderedRemainder[0]))
+        {
+            return TerminalRemainderAlternateJoiner;
+        }
+
+        return TerminalRemainderJoiner;
+    }
 
     static string[] ValidateWords(string[] value)
     {

--- a/src/Humanizer/Localisation/WordsToNumber/LinkedVigesimalWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/LinkedVigesimalWordsToNumberConverter.cs
@@ -97,7 +97,7 @@ internal class LinkedVigesimalWordsToNumberConverter(LinkedVigesimalWordsToNumbe
 
         while (next < end)
         {
-            if (TryMatchTokenPhrase(tokens, next, end, profile.TerminalRemainderJoinerTokens, out var afterJoiner))
+            if (TryMatchAnyTokenPhrase(tokens, next, end, profile.TerminalRemainderJoinerTokenPhrases, out var afterJoiner))
             {
                 next = afterJoiner;
                 continue;
@@ -252,6 +252,20 @@ internal class LinkedVigesimalWordsToNumberConverter(LinkedVigesimalWordsToNumbe
         return false;
     }
 
+    static bool TryMatchAnyTokenPhrase(string[] tokens, int start, int end, string[][] phraseTokenSets, out int next)
+    {
+        foreach (var phraseTokens in phraseTokenSets)
+        {
+            if (TryMatchTokenPhrase(tokens, start, end, phraseTokens, out next))
+            {
+                return true;
+            }
+        }
+
+        next = start;
+        return false;
+    }
+
     static bool TryMatchTokenPhrase(string[] tokens, int start, int end, string[] phraseTokens, out int next)
     {
         if (phraseTokens.Length == 0)
@@ -355,14 +369,21 @@ internal sealed class LinkedVigesimalWordsToNumberProfile
         string[]? ordinalSuffixes = null,
         FrozenDictionary<string, long>? ordinalMap = null,
         FrozenDictionary<string, long>? additionalCardinals = null,
+        string terminalRemainderAlternateJoiner = "",
+        string terminalRemainderAlternateJoinerInitials = "",
         long scaleCountCompositeThreshold = 100)
     {
+        _ = terminalRemainderAlternateJoinerInitials;
         ExactWords = BuildExactWords(words, scales, additionalCardinals);
         MultiTokenExactWords = TokenizeNumberWords(ExactWords);
         MaximumExactTokenCount = GetMaximumTokenCount(ExactWords.Keys);
         Scales = ValidateScales(scales);
         TokenizedScales = TokenizeScales(Scales);
-        TerminalRemainderJoinerTokens = Tokenize(terminalRemainderJoiner);
+        TerminalRemainderJoinerTokenPhrases = TokenizeTerminalRemainderJoiners(terminalRemainderJoiner, terminalRemainderAlternateJoiner);
+        TerminalRemainderJoinerTokens = TerminalRemainderJoinerTokenPhrases
+            .SelectMany(static tokens => tokens)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
         NegativePrefixes = negativePrefixes ?? [];
         OrdinalSuffixes = ordinalSuffixes ?? [];
         OrdinalMap = ordinalMap ?? FrozenDictionary<string, long>.Empty;
@@ -379,7 +400,9 @@ internal sealed class LinkedVigesimalWordsToNumberProfile
     public LinkedVigesimalScale[] Scales { get; }
     /// <summary>Gets tokenized descending scale rows.</summary>
     public TokenizedLinkedVigesimalScale[] TokenizedScales { get; }
-    /// <summary>Gets pre-tokenized terminal remainder linker.</summary>
+    /// <summary>Gets pre-tokenized terminal remainder linker phrases.</summary>
+    public string[][] TerminalRemainderJoinerTokenPhrases { get; }
+    /// <summary>Gets distinct tokens from terminal remainder linkers.</summary>
     public string[] TerminalRemainderJoinerTokens { get; }
     /// <summary>Gets negative prefixes.</summary>
     public string[] NegativePrefixes { get; }
@@ -444,6 +467,12 @@ internal sealed class LinkedVigesimalWordsToNumberProfile
 
         return maximum;
     }
+
+    static string[][] TokenizeTerminalRemainderJoiners(string terminalRemainderJoiner, string terminalRemainderAlternateJoiner) =>
+        new[] { terminalRemainderJoiner, terminalRemainderAlternateJoiner }
+            .Select(Tokenize)
+            .Where(static tokens => tokens.Length > 0)
+            .ToArray();
 
     static string[] Tokenize(string value) =>
         value.Split(' ', StringSplitOptions.RemoveEmptyEntries);

--- a/src/Humanizer/Localisation/WordsToNumber/LinkedVigesimalWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/LinkedVigesimalWordsToNumberConverter.cs
@@ -370,10 +370,8 @@ internal sealed class LinkedVigesimalWordsToNumberProfile
         FrozenDictionary<string, long>? ordinalMap = null,
         FrozenDictionary<string, long>? additionalCardinals = null,
         string terminalRemainderAlternateJoiner = "",
-        string terminalRemainderAlternateJoinerInitials = "",
         long scaleCountCompositeThreshold = 100)
     {
-        _ = terminalRemainderAlternateJoinerInitials;
         ExactWords = BuildExactWords(words, scales, additionalCardinals);
         MultiTokenExactWords = TokenizeNumberWords(ExactWords);
         MaximumExactTokenCount = GetMaximumTokenCount(ExactWords.Keys);

--- a/src/Humanizer/Localisation/WordsToNumber/LinkedVigesimalWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/LinkedVigesimalWordsToNumberConverter.cs
@@ -472,6 +472,7 @@ internal sealed class LinkedVigesimalWordsToNumberProfile
         new[] { terminalRemainderJoiner, terminalRemainderAlternateJoiner }
             .Select(Tokenize)
             .Where(static tokens => tokens.Length > 0)
+            .OrderByDescending(static tokens => tokens.Length)
             .ToArray();
 
     static string[] Tokenize(string value) =>

--- a/src/Humanizer/Localisation/WordsToNumber/LinkedVigesimalWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/LinkedVigesimalWordsToNumberConverter.cs
@@ -254,9 +254,10 @@ internal class LinkedVigesimalWordsToNumberConverter(LinkedVigesimalWordsToNumbe
 
     static bool TryMatchAnyTokenPhrase(string[] tokens, int start, int end, string[][] phraseTokenSets, out int next)
     {
-        foreach (var phraseTokens in phraseTokenSets)
+        for (var index = 0; index < phraseTokenSets.Length; index++)
         {
-            if (TryMatchTokenPhrase(tokens, start, end, phraseTokens, out next))
+            var phraseTokens = phraseTokenSets[index];
+            if (phraseTokens.Length > 0 && TryMatchTokenPhrase(tokens, start, end, phraseTokens, out next))
             {
                 return true;
             }

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.cs
@@ -1790,7 +1790,6 @@ wordsToNumber:
   engine: 'linked-vigesimal'
   terminalRemainderJoiner: 'a'
   terminalRemainderAlternateJoiner: 'ac'
-  terminalRemainderAlternateJoinerInitials: 'ae'
   words:
     - 'zero'
     - 'apple'
@@ -1818,7 +1817,7 @@ wordsToNumber:
         Assert.Contains("new LinkedVigesimalNumberToWordsProfile(", numberBlock);
         Assert.Contains("FrozenDictionary<int, string>.Empty, \"ac\", \"ae\")", numberBlock);
         Assert.Contains("new LinkedVigesimalWordsToNumberProfile(", wordsBlock);
-        Assert.Contains("null, null, \"ac\", \"ae\")", wordsBlock);
+        Assert.Contains("null, null, \"ac\")", wordsBlock);
     }
 
     [Fact]

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.cs
@@ -1765,6 +1765,63 @@ numberToWords:
     }
 
     [Fact]
+    public void LinkedVigesimalProfilesEmitAlternateTerminalRemainderJoinerFields()
+    {
+        const string locale = """
+numberToWords:
+  engine: 'linked-vigesimal'
+  zeroWord: 'zero'
+  negativeWord: 'minus'
+  terminalRemainderJoiner: 'a'
+  terminalRemainderAlternateJoiner: 'ac'
+  terminalRemainderAlternateJoinerInitials: 'ae'
+  words:
+    - 'zero'
+    - 'apple'
+    - 'bee'
+  scales:
+    -
+      value: 20
+      one: 'twenty'
+      oneWithRemainder: 'twenty-r'
+      name: 'score'
+      nameWithRemainder: 'score-r'
+wordsToNumber:
+  engine: 'linked-vigesimal'
+  terminalRemainderJoiner: 'a'
+  terminalRemainderAlternateJoiner: 'ac'
+  terminalRemainderAlternateJoinerInitials: 'ae'
+  words:
+    - 'zero'
+    - 'apple'
+    - 'bee'
+  scales:
+    -
+      value: 20
+      one: 'twenty'
+      oneWithRemainder: 'twenty-r'
+      name: 'score'
+      nameWithRemainder: 'score-r'
+""";
+
+        var runResult = RunGenerator(new InMemoryAdditionalText(
+            @"E:\Dev\Humanizer\src\Humanizer\Locales\zz-linked-vigesimal-joiner.yml",
+            locale));
+
+        Assert.Empty(runResult.Diagnostics);
+
+        var numberSource = GetGeneratedSource(runResult, "NumberToWordsProfileCatalog.g.cs");
+        var wordsSource = GetGeneratedSource(runResult, "WordsToNumberProfileCatalog.g.cs");
+        var numberBlock = ExtractCacheClassBody(numberSource, "zz_linked_vigesimal_joiner_cache");
+        var wordsBlock = ExtractCacheClassBody(wordsSource, "zz_linked_vigesimal_joiner_cache");
+
+        Assert.Contains("new LinkedVigesimalNumberToWordsProfile(", numberBlock);
+        Assert.Contains("FrozenDictionary<int, string>.Empty, \"ac\", \"ae\")", numberBlock);
+        Assert.Contains("new LinkedVigesimalWordsToNumberProfile(", wordsBlock);
+        Assert.Contains("null, null, \"ac\", \"ae\")", wordsBlock);
+    }
+
+    [Fact]
     public void WordsToNumberProfilesAcceptOmittedEmptyIgnoredToken()
     {
         const string locale = """

--- a/tests/Humanizer.Tests/Localisation/LinkedVigesimalNumberToWordsConverterTests.cs
+++ b/tests/Humanizer.Tests/Localisation/LinkedVigesimalNumberToWordsConverterTests.cs
@@ -41,6 +41,18 @@ public class LinkedVigesimalNumberToWordsConverterTests
         Assert.Equal(expected, converter.Convert(words));
     }
 
+    [Fact]
+    public void WordsToNumberMatchesLongerTerminalRemainderJoinerBeforePrefix()
+    {
+        var converter = new LinkedVigesimalWordsToNumberConverter(new(
+            CreateWords(),
+            CreateScales(),
+            "a",
+            terminalRemainderAlternateJoiner: "a plus"));
+
+        Assert.Equal(21, converter.Convert("twenty-r a plus apple"));
+    }
+
     static LinkedVigesimalNumberToWordsProfile CreateNumberProfile(
         string terminalRemainderAlternateJoiner = "",
         string terminalRemainderAlternateJoinerInitials = "") =>

--- a/tests/Humanizer.Tests/Localisation/LinkedVigesimalNumberToWordsConverterTests.cs
+++ b/tests/Humanizer.Tests/Localisation/LinkedVigesimalNumberToWordsConverterTests.cs
@@ -35,8 +35,7 @@ public class LinkedVigesimalNumberToWordsConverterTests
             CreateWords(),
             CreateScales(),
             "a",
-            terminalRemainderAlternateJoiner: "ac",
-            terminalRemainderAlternateJoinerInitials: "ae"));
+            terminalRemainderAlternateJoiner: "ac"));
 
         Assert.Equal(expected, converter.Convert(words));
     }

--- a/tests/Humanizer.Tests/Localisation/LinkedVigesimalNumberToWordsConverterTests.cs
+++ b/tests/Humanizer.Tests/Localisation/LinkedVigesimalNumberToWordsConverterTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Frozen;
+
+namespace Humanizer.Tests.Localisation;
+
+public class LinkedVigesimalNumberToWordsConverterTests
+{
+    [Fact]
+    public void UsesBaseTerminalRemainderJoinerWhenAlternateIsNotConfigured()
+    {
+        var converter = new LinkedVigesimalNumberToWordsConverter(CreateNumberProfile());
+
+        Assert.Equal("twenty-r a apple", converter.Convert(21));
+    }
+
+    [Theory]
+    [InlineData(21, "twenty-r ac apple")]
+    [InlineData(22, "twenty-r a bee")]
+    public void ChoosesAlternateTerminalRemainderJoinerByRenderedRemainderInitial(long number, string expected)
+    {
+        var converter = new LinkedVigesimalNumberToWordsConverter(CreateNumberProfile(
+            terminalRemainderAlternateJoiner: "ac",
+            terminalRemainderAlternateJoinerInitials: "ae"));
+
+        Assert.Equal(expected, converter.Convert(number));
+    }
+
+    [Theory]
+    [InlineData("twenty-r a apple", 21)]
+    [InlineData("twenty-r ac apple", 21)]
+    [InlineData("twenty-r a bee", 22)]
+    [InlineData("twenty-r ac bee", 22)]
+    public void WordsToNumberAcceptsBaseAndAlternateTerminalRemainderJoiners(string words, long expected)
+    {
+        var converter = new LinkedVigesimalWordsToNumberConverter(new(
+            CreateWords(),
+            CreateScales(),
+            "a",
+            terminalRemainderAlternateJoiner: "ac",
+            terminalRemainderAlternateJoinerInitials: "ae"));
+
+        Assert.Equal(expected, converter.Convert(words));
+    }
+
+    static LinkedVigesimalNumberToWordsProfile CreateNumberProfile(
+        string terminalRemainderAlternateJoiner = "",
+        string terminalRemainderAlternateJoinerInitials = "") =>
+        new(
+            "zero",
+            "minus",
+            " ",
+            " ",
+            "a",
+            100,
+            "",
+            CreateWords(),
+            CreateScales(),
+            terminalRemainderAlternateJoiner: terminalRemainderAlternateJoiner,
+            terminalRemainderAlternateJoinerInitials: terminalRemainderAlternateJoinerInitials);
+
+    static string[] CreateWords() =>
+    [
+        "zero",
+        "apple",
+        "bee",
+        "three",
+        "four",
+        "five",
+        "six",
+        "seven",
+        "eight",
+        "nine",
+        "ten",
+        "eleven",
+        "twelve",
+        "thirteen",
+        "fourteen",
+        "fifteen",
+        "sixteen",
+        "seventeen",
+        "eighteen",
+        "nineteen"
+    ];
+
+    static LinkedVigesimalScale[] CreateScales() =>
+    [
+        new(
+            20,
+            "twenty",
+            "twenty-r",
+            "score",
+            "score-r",
+            " ",
+            FrozenDictionary<int, string>.Empty,
+            FrozenDictionary<int, string>.Empty)
+    ];
+}


### PR DESCRIPTION
## Summary
- add optional alternate terminal remainder joiner support to the linked-vigesimal number-to-words engine
- teach linked-vigesimal words-to-number parsing to accept both base and alternate terminal joiners
- document the YAML fields and add source-generator/runtime coverage

## Context
This unblocks Welsh (`cy`) locale parity by letting the shared linked-vigesimal engine render terminal `ac` before configured initials while retaining the existing base joiner behavior.

## Validation
- `dotnet test tests/Humanizer.SourceGenerators.Tests/Humanizer.SourceGenerators.Tests.csproj`
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0`
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0`
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0`
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o artifacts/shared-cy-joiner-pack`
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
