### PR TITLE
docs: add locale batch orchestration skill

### DIFF
--- a/.agents/skills/add-locale-batch/SKILL.md
+++ b/.agents/skills/add-locale-batch/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: add-locale-batch
+description: Use when coordinating multiple Humanizer locale parity efforts across isolated worktrees, branches, PRs, review/CI babysitting, merges, and cleanup. This is the parent orchestration skill for locale batches; delegate each individual locale to add-locale rather than implementing locale details directly.
+---
+
+# Humanizer Locale Batch Orchestration
+
+Use this skill when the task is to run, resume, or monitor more than one Humanizer locale parity PR.
+
+This is an orchestration skill. It does not replace `$add-locale`; each locale subagent must still use `$add-locale` for implementation and parity proof.
+
+## Core Rules
+
+- Keep the parent as coordinator only: plan, dispatch, track, verify, merge, and clean up.
+- Use one isolated sibling worktree and branch per locale.
+- Never allow a locale subagent to edit the main checkout or another locale's worktree.
+- Dispatch one locale orchestrator per locale. Give it only its locale, worktree, branch, PR context, and current phase.
+- Centralize PR polling in the parent where practical. Wake locale agents only for actionable review, CI, conflict, or merge/cleanup work.
+- Pause conflicting locale work when several locales need the same shared generator/runtime/schema change. Land one explicit shared PR first, then resume locales.
+- Do not use draft PRs unless the user explicitly changes policy.
+- Squash merge only after final gates are clean: approved or acceptable review state, zero unresolved non-outdated review threads, required checks green, mergeable clean, and babysit clean.
+- After merge, remove the locale worktree and delete/prune merged branches when safe.
+- Do not commit artifacts that contain full local filesystem paths.
+
+## Minimal Workflow
+
+1. Create or load a batch plan/status file. See `references/batch-state.md`.
+2. Create one worktree/branch per active locale.
+3. Dispatch each locale orchestrator with the compact contract in `references/locale-orchestrator-contract.md`.
+4. Poll PR gates centrally using `scripts/locale_batch_status.py` or equivalent `gh` queries.
+5. Steer only deltas to agents: unresolved review threads, CI failures, rebase requirements, or merge/cleanup authorization.
+6. Update batch status after every meaningful transition.
+7. Stop starting new locales when the user says to hold; keep closing already-active PRs unless told otherwise.
+8. Final rollup: locale, PR URL, merge commit, validation result, babysit status, cleanup status, and deferred locales.
+
+## Dispatch Pattern
+
+Use this brief shape instead of repeating the whole workflow:
+
+```text
+Read .agents/skills/add-locale-batch/references/locale-orchestrator-contract.md.
+You are assigned only: <culture-code> / <language-name>.
+Worktree: <relative-worktree-path>.
+Branch: <branch>.
+PR: <number-or-new>.
+Phase: <implement|review-fix|babysit|merge-cleanup>.
+Known blockers: <short list or none>.
+Report compact JSON status only unless blocked.
+```
+
+The locale orchestrator must set its own goal from `.agents/skills/add-locale/references/goal-template.md`, filled with its culture code/name and worktree context.
+
+## References
+
+- `references/batch-state.md` — batch/status file format and phase state machine.
+- `references/locale-orchestrator-contract.md` — compact child-agent contract.
+- `references/pr-gates.md` — centralized PR polling, merge gates, and cleanup rules.
+
+## Token Discipline
+
+- Prefer compact JSON status over narrative updates.
+- Include failed logs only; passing validation should be command + pass/fail + URL if applicable.
+- Do not keep implementation agents alive just to narrate CI polling when the parent can poll PR state.
+- Resume from status files, not chat history.

--- a/.agents/skills/add-locale-batch/SKILL.md
+++ b/.agents/skills/add-locale-batch/SKILL.md
@@ -5,60 +5,40 @@ description: Use when coordinating multiple Humanizer locale parity efforts acro
 
 # Humanizer Locale Batch Orchestration
 
-Use this skill when the task is to run, resume, or monitor more than one Humanizer locale parity PR.
+Use this for multi-locale Humanizer parity work. It is a parent orchestration skill: each locale subagent still uses `$add-locale` for implementation and proof.
 
-This is an orchestration skill. It does not replace `$add-locale`; each locale subagent must still use `$add-locale` for implementation and parity proof.
+## Non-negotiables
 
-## Core Rules
+- Parent coordinates only: plan, dispatch, track, verify, merge, cleanup.
+- One isolated sibling worktree and branch per locale; no child may edit main or a sibling worktree.
+- Each locale orchestrator must read `$add-locale` and set its own goal from `.agents/skills/add-locale/references/goal-template.md`.
+- Do not use draft PRs unless the user changes policy.
+- Merge only when every gate in `references/pr-gates.md` passes.
+- If multiple locales need the same generator/runtime/schema change, hold them and land one shared PR first; see `references/batch-state.md`.
+- After merge, clean the worktree/branches as described in `references/pr-gates.md`.
+- Never commit artifacts containing full local filesystem paths.
 
-- Keep the parent as coordinator only: plan, dispatch, track, verify, merge, and clean up.
-- Use one isolated sibling worktree and branch per locale.
-- Never allow a locale subagent to edit the main checkout or another locale's worktree.
-- Dispatch one locale orchestrator per locale. Give it only its locale, worktree, branch, PR context, and current phase.
-- Centralize PR polling in the parent where practical. Wake locale agents only for actionable review, CI, conflict, or merge/cleanup work.
-- Pause conflicting locale work when several locales need the same shared generator/runtime/schema change. Land one explicit shared PR first, then resume locales.
-- Do not use draft PRs unless the user explicitly changes policy.
-- Squash merge only after final gates are clean: approved or acceptable review state, zero unresolved non-outdated review threads, required checks green, mergeable clean, and babysit clean.
-- After merge, remove the locale worktree and delete/prune merged branches when safe.
-- Do not commit artifacts that contain full local filesystem paths.
+## Workflow
 
-## Minimal Workflow
-
-1. Create or load a batch plan/status file. See `references/batch-state.md`.
+1. Load or create batch state (`references/batch-state.md`).
 2. Create one worktree/branch per active locale.
-3. Dispatch each locale orchestrator with the compact contract in `references/locale-orchestrator-contract.md`.
-4. Poll PR gates centrally using `scripts/locale_batch_status.py` or equivalent `gh` queries.
-5. Steer only deltas to agents: unresolved review threads, CI failures, rebase requirements, or merge/cleanup authorization.
-6. Update batch status after every meaningful transition.
-7. Stop starting new locales when the user says to hold; keep closing already-active PRs unless told otherwise.
-8. Final rollup: locale, PR URL, merge commit, validation result, babysit status, cleanup status, and deferred locales.
+3. Dispatch locale orchestrators with `references/locale-orchestrator-contract.md`.
+4. Poll with `scripts/locale_batch_status.py`; update phases; wake children only for deltas.
+5. Hold new locales when asked; keep closing already-active PRs unless told otherwise.
+6. Final rollup: locale, PR, merge commit, validation, babysit result, cleanup, deferred locales.
 
-## Dispatch Pattern
-
-Use this brief shape instead of repeating the whole workflow:
+## Compact dispatch
 
 ```text
 Read .agents/skills/add-locale-batch/references/locale-orchestrator-contract.md.
-You are assigned only: <culture-code> / <language-name>.
-Worktree: <relative-worktree-path>.
-Branch: <branch>.
-PR: <number-or-new>.
-Phase: <implement|review-fix|babysit|merge-cleanup>.
-Known blockers: <short list or none>.
+Locale: <code> / <name>.
+Worktree: <relative-path>. Branch: <branch>. PR: <number-or-new>.
+Phase: <batch-state phase>. Known blockers: <none|summary>.
 Report compact JSON status only unless blocked.
 ```
 
-The locale orchestrator must set its own goal from `.agents/skills/add-locale/references/goal-template.md`, filled with its culture code/name and worktree context.
-
 ## References
 
-- `references/batch-state.md` — batch/status file format and phase state machine.
-- `references/locale-orchestrator-contract.md` — compact child-agent contract.
-- `references/pr-gates.md` — centralized PR polling, merge gates, and cleanup rules.
-
-## Token Discipline
-
-- Prefer compact JSON status over narrative updates.
-- Include failed logs only; passing validation should be command + pass/fail + URL if applicable.
-- Do not keep implementation agents alive just to narrate CI polling when the parent can poll PR state.
-- Resume from status files, not chat history.
+- `references/batch-state.md` — plan/status schema, phases, shared-change hold flow.
+- `references/locale-orchestrator-contract.md` — child-agent contract.
+- `references/pr-gates.md` — PR polling, merge gate, cleanup.

--- a/.agents/skills/add-locale-batch/agents/openai.yaml
+++ b/.agents/skills/add-locale-batch/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Add Locale Batch"
+  short_description: "Coordinate multi-locale Humanizer PR batches"
+  default_prompt: "Use $add-locale-batch to orchestrate a batch of Humanizer locale parity work across isolated worktrees, PRs, CI, review, merges, and cleanup."

--- a/.agents/skills/add-locale-batch/agents/openai.yaml
+++ b/.agents/skills/add-locale-batch/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Add Locale Batch"
   short_description: "Coordinate multi-locale Humanizer PR batches"
-  default_prompt: "Use $add-locale-batch to orchestrate a batch of Humanizer locale parity work across isolated worktrees, PRs, CI, review, merges, and cleanup."
+  default_prompt: "Use $add-locale-batch to coordinate Humanizer locale parity PRs across isolated worktrees."

--- a/.agents/skills/add-locale-batch/references/batch-state.md
+++ b/.agents/skills/add-locale-batch/references/batch-state.md
@@ -1,87 +1,38 @@
 # Locale Batch State
 
-Keep batch state small and machine-readable. Use one committed or shared plan file for intended work and one local status file for volatile run state.
+Use small machine-readable state so orchestration can resume without chat history. Keep volatile state in `artifacts/`; shared/committed state must omit machine-local paths.
 
-## Batch Plan
+## Batch plan
 
-Suggested path for an intentional plan:
+Suggested local path: `artifacts/locale-batches/<batch>.json`.
 
-`artifacts/locale-batches/<batch-name>.json`
+Required fields:
 
-`artifacts/` is normally local-only. If a plan must be reviewed in PR, place it under `docs/` and remove machine-local paths.
+- `batch`, `repo`, `branchPattern`, `mergePolicy`, `draftPrs`
+- `locales[]`: `code`, `name`, `worktree`, `branch`, `pr`, `phase`
+- `heldLocales[]` when the user pauses future work
 
-Example:
+## LocaleStatus
 
-```json
-{
-  "batch": "2026-05-locale-parity",
-  "repo": "Humanizr/Humanizer",
-  "branchPattern": "feat-{locale}",
-  "mergePolicy": "squash_when_green_clean_approved",
-  "draftPrs": false,
-  "locales": [
-    {
-      "code": "cy",
-      "name": "Welsh",
-      "worktree": "../Humanizer-locale-cy",
-      "branch": "feat-cy",
-      "pr": 1770,
-      "phase": "babysit"
-    }
-  ],
-  "heldLocales": ["eu", "so", "as", "or", "tk", "kok"]
-}
-```
+Suggested local path: `artifacts/locale-batch-status.json`. The object is keyed by locale code. Each entry should use these fields when known:
 
-## Live Status
+- identity: `name`, `worktree`, `branch`, `pr`, `prUrl`, `head`
+- workflow: `phase`, `blocker`
+- review/CI: `reviewDecision`, `unresolvedThreads`, `checks`, `mergeable`, `mergeStateStatus`, `isDraft`
+- completion: `merged`, `mergedAt`, `mergeCommit`, `worktreeCleaned`
+- validation: compact map of command names to `not-run`, `pass`, `fail`, or `not-applicable`
 
-Suggested local path:
-
-`artifacts/locale-batch-status.json`
-
-Example:
-
-```json
-{
-  "cy": {
-    "name": "Welsh",
-    "worktree": "../Humanizer-locale-cy",
-    "branch": "feat-cy",
-    "pr": 1770,
-    "head": "4bca9264",
-    "phase": "babysit",
-    "reviewDecision": "APPROVED",
-    "checks": "pending",
-    "unresolvedThreads": 0,
-    "mergeable": "UNKNOWN",
-    "merged": false,
-    "mergeCommit": null,
-    "worktreeCleaned": false,
-    "blocker": null
-  }
-}
-```
+Agents should report one `LocaleStatus` entry. Include detailed logs only for failures.
 
 ## Phases
 
-- `planned` — not started.
-- `worktree` — worktree/branch exists, no implementation yet.
-- `implement` — locale orchestrator is building parity.
-- `review-fix` — PR has actionable review feedback.
-- `ci-fix` — checks failed and need diagnosis/fix.
-- `babysit` — PR is open; parent or child is polling gates.
-- `ready-to-merge` — zero unresolved threads, checks green, mergeable, acceptable review.
-- `merged` — PR merged; cleanup still may be pending.
-- `cleaned` — worktree/branches removed where safe.
-- `held` — intentionally paused by user or dependency.
-- `blocked` — requires user decision or shared strategy.
+`planned`, `worktree`, `implement`, `review-fix`, `ci-fix`, `babysit`, `ready-to-merge`, `merged`, `cleaned`, `held`, `blocked`.
 
-## Shared Change Coordination
+## Shared changes
 
-If two or more locales need the same generator/runtime/schema change:
+When two or more locales need the same generator/runtime/schema change:
 
-1. Mark affected locales `held` with the same `blocker` key.
-2. Create a separate shared worktree/branch/PR.
-3. Land the shared PR first.
-4. Rebase held locale branches on latest main.
-5. Resume locales with duplicated shared changes removed.
+1. Mark affected locales `held` with the same `blocker`.
+2. Create and land one shared worktree/branch/PR.
+3. Rebase held locale branches on latest main.
+4. Resume locales with duplicated shared edits removed.

--- a/.agents/skills/add-locale-batch/references/batch-state.md
+++ b/.agents/skills/add-locale-batch/references/batch-state.md
@@ -1,0 +1,87 @@
+# Locale Batch State
+
+Keep batch state small and machine-readable. Use one committed or shared plan file for intended work and one local status file for volatile run state.
+
+## Batch Plan
+
+Suggested path for an intentional plan:
+
+`artifacts/locale-batches/<batch-name>.json`
+
+`artifacts/` is normally local-only. If a plan must be reviewed in PR, place it under `docs/` and remove machine-local paths.
+
+Example:
+
+```json
+{
+  "batch": "2026-05-locale-parity",
+  "repo": "Humanizr/Humanizer",
+  "branchPattern": "feat-{locale}",
+  "mergePolicy": "squash_when_green_clean_approved",
+  "draftPrs": false,
+  "locales": [
+    {
+      "code": "cy",
+      "name": "Welsh",
+      "worktree": "../Humanizer-locale-cy",
+      "branch": "feat-cy",
+      "pr": 1770,
+      "phase": "babysit"
+    }
+  ],
+  "heldLocales": ["eu", "so", "as", "or", "tk", "kok"]
+}
+```
+
+## Live Status
+
+Suggested local path:
+
+`artifacts/locale-batch-status.json`
+
+Example:
+
+```json
+{
+  "cy": {
+    "name": "Welsh",
+    "worktree": "../Humanizer-locale-cy",
+    "branch": "feat-cy",
+    "pr": 1770,
+    "head": "4bca9264",
+    "phase": "babysit",
+    "reviewDecision": "APPROVED",
+    "checks": "pending",
+    "unresolvedThreads": 0,
+    "mergeable": "UNKNOWN",
+    "merged": false,
+    "mergeCommit": null,
+    "worktreeCleaned": false,
+    "blocker": null
+  }
+}
+```
+
+## Phases
+
+- `planned` — not started.
+- `worktree` — worktree/branch exists, no implementation yet.
+- `implement` — locale orchestrator is building parity.
+- `review-fix` — PR has actionable review feedback.
+- `ci-fix` — checks failed and need diagnosis/fix.
+- `babysit` — PR is open; parent or child is polling gates.
+- `ready-to-merge` — zero unresolved threads, checks green, mergeable, acceptable review.
+- `merged` — PR merged; cleanup still may be pending.
+- `cleaned` — worktree/branches removed where safe.
+- `held` — intentionally paused by user or dependency.
+- `blocked` — requires user decision or shared strategy.
+
+## Shared Change Coordination
+
+If two or more locales need the same generator/runtime/schema change:
+
+1. Mark affected locales `held` with the same `blocker` key.
+2. Create a separate shared worktree/branch/PR.
+3. Land the shared PR first.
+4. Rebase held locale branches on latest main.
+5. Resume locales with duplicated shared changes removed.

--- a/.agents/skills/add-locale-batch/references/locale-orchestrator-contract.md
+++ b/.agents/skills/add-locale-batch/references/locale-orchestrator-contract.md
@@ -1,0 +1,75 @@
+# Locale Orchestrator Contract
+
+A locale orchestrator owns exactly one locale worktree and branch. It implements or finishes locale parity using `$add-locale` and reports compact status to the parent.
+
+## Required Startup
+
+1. Confirm current directory is the assigned worktree.
+2. Confirm current branch is the assigned branch.
+3. Read repo instructions and `$add-locale`.
+4. Read `.agents/skills/add-locale/references/goal-template.md`.
+5. Set a locale-specific goal from the template using the assigned culture code/name and worktree/PR context.
+
+## Scope Boundary
+
+Allowed:
+
+- Assigned locale YAML/tests/docs/matrix entries.
+- Shared generator/runtime/schema changes only when explicitly assigned by the parent or when the agent stops and gets approval for a shared strategy.
+- PR description updates, review-thread resolution, CI diagnosis, and branch pushes for its assigned PR.
+
+Forbidden:
+
+- Editing the main checkout.
+- Editing sibling worktrees.
+- Creating draft PRs unless policy changes.
+- Committing artifacts with full local filesystem paths.
+- Declaring review comments or routine CI failures as blockers without an attempted diagnosis/fix.
+
+## Required JSON Status
+
+Report this shape on progress and final output:
+
+```json
+{
+  "locale": "cy",
+  "name": "Welsh",
+  "worktree": "../Humanizer-locale-cy",
+  "branch": "feat-cy",
+  "pr": 1770,
+  "head": "4bca9264",
+  "phase": "babysit",
+  "validation": {
+    "sourceGeneratorsNet10": "pass",
+    "humanizerNet8": "pass",
+    "humanizerNet10": "pass",
+    "humanizerNet11": "pass",
+    "pack": "pass",
+    "format": "pass"
+  },
+  "review": {
+    "decision": "APPROVED",
+    "unresolvedThreads": 0
+  },
+  "checks": "pending",
+  "mergeable": "UNKNOWN",
+  "merged": false,
+  "mergeCommit": null,
+  "worktreeCleaned": false,
+  "blocker": null
+}
+```
+
+Use `"not-run"`, `"pass"`, `"fail"`, or `"not-applicable"` for validation entries. Include detailed logs only for failures.
+
+## Stop Conditions
+
+Stop and report to the parent when:
+
+- The work needs a shared generator/runtime/schema strategy also needed by another active locale.
+- A rebase or merge conflict risks discarding another locale/shared change.
+- GitHub permissions prevent push, review-thread resolution, PR creation, or merge.
+- CI fails repeatedly for infrastructure reasons after reasonable retry/diagnosis.
+- The user policy changes.
+
+Do not stop merely because there are review comments or code-related CI failures; address them.

--- a/.agents/skills/add-locale-batch/references/locale-orchestrator-contract.md
+++ b/.agents/skills/add-locale-batch/references/locale-orchestrator-contract.md
@@ -1,75 +1,41 @@
 # Locale Orchestrator Contract
 
-A locale orchestrator owns exactly one locale worktree and branch. It implements or finishes locale parity using `$add-locale` and reports compact status to the parent.
+A locale orchestrator owns one locale worktree, branch, and PR. It implements or finishes locale parity with `$add-locale` and reports compact status to the parent.
 
-## Required Startup
+## Startup
 
-1. Confirm current directory is the assigned worktree.
-2. Confirm current branch is the assigned branch.
-3. Read repo instructions and `$add-locale`.
-4. Read `.agents/skills/add-locale/references/goal-template.md`.
-5. Set a locale-specific goal from the template using the assigned culture code/name and worktree/PR context.
+1. Confirm CWD is the assigned worktree and HEAD is the assigned branch.
+2. Read repo instructions and `$add-locale`.
+3. Read `.agents/skills/add-locale/references/goal-template.md`.
+4. Set a locale-specific goal using the assigned culture code/name and worktree/PR context.
 
-## Scope Boundary
+## Scope
 
 Allowed:
 
 - Assigned locale YAML/tests/docs/matrix entries.
-- Shared generator/runtime/schema changes only when explicitly assigned by the parent or when the agent stops and gets approval for a shared strategy.
-- PR description updates, review-thread resolution, CI diagnosis, and branch pushes for its assigned PR.
+- Assigned PR description, pushes, review-thread resolution, CI diagnosis, merge cleanup.
+- Shared generator/runtime/schema edits only after parent approval or explicit assignment.
 
 Forbidden:
 
-- Editing the main checkout.
-- Editing sibling worktrees.
-- Creating draft PRs unless policy changes.
-- Committing artifacts with full local filesystem paths.
-- Declaring review comments or routine CI failures as blockers without an attempted diagnosis/fix.
+- Editing main or sibling worktrees.
+- Draft PRs unless policy changes.
+- Committed full local paths.
+- Treating routine review comments or code-related CI failures as blockers without diagnosis/fix.
 
-## Required JSON Status
+## Reporting
 
-Report this shape on progress and final output:
+Report one `LocaleStatus` entry as defined in `batch-state.md`. Keep output JSON-first; include failed logs only, not passing test output.
 
-```json
-{
-  "locale": "cy",
-  "name": "Welsh",
-  "worktree": "../Humanizer-locale-cy",
-  "branch": "feat-cy",
-  "pr": 1770,
-  "head": "4bca9264",
-  "phase": "babysit",
-  "validation": {
-    "sourceGeneratorsNet10": "pass",
-    "humanizerNet8": "pass",
-    "humanizerNet10": "pass",
-    "humanizerNet11": "pass",
-    "pack": "pass",
-    "format": "pass"
-  },
-  "review": {
-    "decision": "APPROVED",
-    "unresolvedThreads": 0
-  },
-  "checks": "pending",
-  "mergeable": "UNKNOWN",
-  "merged": false,
-  "mergeCommit": null,
-  "worktreeCleaned": false,
-  "blocker": null
-}
-```
+## Stop and report
 
-Use `"not-run"`, `"pass"`, `"fail"`, or `"not-applicable"` for validation entries. Include detailed logs only for failures.
+Stop for parent coordination when:
 
-## Stop Conditions
+- Work needs a shared generator/runtime/schema strategy also needed by another active locale.
+- Rebase/conflict resolution risks discarding another locale/shared change.
+- GitHub permissions block push, PR creation, thread resolution, or merge.
+- CI is repeatedly infrastructure-failing after diagnosis/retry.
+- User policy changes.
 
-Stop and report to the parent when:
-
-- The work needs a shared generator/runtime/schema strategy also needed by another active locale.
-- A rebase or merge conflict risks discarding another locale/shared change.
-- GitHub permissions prevent push, review-thread resolution, PR creation, or merge.
-- CI fails repeatedly for infrastructure reasons after reasonable retry/diagnosis.
-- The user policy changes.
-
-Do not stop merely because there are review comments or code-related CI failures; address them.
+Do not stop merely because review comments or branch-caused CI failures exist; address them.

--- a/.agents/skills/add-locale-batch/references/pr-gates.md
+++ b/.agents/skills/add-locale-batch/references/pr-gates.md
@@ -1,0 +1,61 @@
+# PR Gates and Central Polling
+
+The parent orchestrator should poll PR state centrally whenever possible. This keeps implementation agents from spending tokens narrating pending CI.
+
+## Required Merge Gate
+
+A locale PR may be squash-merged only when all are true:
+
+- PR is open and not draft.
+- Review state is approved or otherwise acceptable under repo policy.
+- There are zero unresolved, non-outdated review threads.
+- Required checks are passing.
+- PR is mergeable/clean.
+- The current branch head is the validated head.
+- Babysit has found no fresh review comments or failing checks.
+
+## Compact `gh` Checks
+
+Use compact queries instead of verbose logs:
+
+```bash
+gh pr view <pr> --repo Humanizr/Humanizer \
+  --json number,url,state,isDraft,headRefName,headRefOid,reviewDecision,mergeStateStatus,mergeable,mergedAt
+```
+
+Unresolved non-outdated threads:
+
+```bash
+gh api graphql \
+  -f owner=Humanizr -f name=Humanizer -F number=<pr> \
+  -f query='query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { reviewThreads(first:100) { nodes { isResolved isOutdated } } } } }' \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == false)] | length'
+```
+
+Checks:
+
+```bash
+gh pr checks <pr> --repo Humanizr/Humanizer --watch=false
+```
+
+## When to Wake a Locale Agent
+
+Wake or steer the locale orchestrator only for actionable deltas:
+
+- New unresolved review thread.
+- Failed required check.
+- Rebase needed after a merged dependency.
+- PR description/scope mismatch.
+- Merge and cleanup authorization after gates are green.
+
+## Cleanup After Merge
+
+After squash merge:
+
+1. Record PR URL and merge commit.
+2. Remove the locale worktree.
+3. Delete the local branch if it is merged or no longer needed.
+4. Prune/delete remote branch when GitHub did not already delete it.
+5. Mark status `cleaned`.
+
+Never remove a worktree that still has uncommitted intentional changes.

--- a/.agents/skills/add-locale-batch/references/pr-gates.md
+++ b/.agents/skills/add-locale-batch/references/pr-gates.md
@@ -1,61 +1,31 @@
 # PR Gates and Central Polling
 
-The parent orchestrator should poll PR state centrally whenever possible. This keeps implementation agents from spending tokens narrating pending CI.
+Poll PR state centrally so implementation agents do not spend tokens narrating pending CI.
 
-## Required Merge Gate
-
-A locale PR may be squash-merged only when all are true:
-
-- PR is open and not draft.
-- Review state is approved or otherwise acceptable under repo policy.
-- There are zero unresolved, non-outdated review threads.
-- Required checks are passing.
-- PR is mergeable/clean.
-- The current branch head is the validated head.
-- Babysit has found no fresh review comments or failing checks.
-
-## Compact `gh` Checks
-
-Use compact queries instead of verbose logs:
+Preferred refresh:
 
 ```bash
-gh pr view <pr> --repo Humanizr/Humanizer \
-  --json number,url,state,isDraft,headRefName,headRefOid,reviewDecision,mergeStateStatus,mergeable,mergedAt
+python3 .agents/skills/add-locale-batch/scripts/locale_batch_status.py --status artifacts/locale-batch-status.json --repo Humanizr/Humanizer --write
 ```
 
-Unresolved non-outdated threads:
+Fallback: use equivalent `gh pr view`, review-thread GraphQL count, and `gh pr checks` queries.
 
-```bash
-gh api graphql \
-  -f owner=Humanizr -f name=Humanizer -F number=<pr> \
-  -f query='query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { reviewThreads(first:100) { nodes { isResolved isOutdated } } } } }' \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == false)] | length'
-```
+## Merge gate
 
-Checks:
+Squash only when: open, non-draft; review acceptable; 0 unresolved non-outdated threads; checks green; mergeable/clean; validated head equals PR head; babysit clean.
 
-```bash
-gh pr checks <pr> --repo Humanizr/Humanizer --watch=false
-```
-
-## When to Wake a Locale Agent
-
-Wake or steer the locale orchestrator only for actionable deltas:
+## Wake child agent only for deltas
 
 - New unresolved review thread.
 - Failed required check.
-- Rebase needed after a merged dependency.
+- Rebase after merged dependency.
 - PR description/scope mismatch.
-- Merge and cleanup authorization after gates are green.
+- Green/clean merge + cleanup authorization.
 
-## Cleanup After Merge
-
-After squash merge:
+## Cleanup after merge
 
 1. Record PR URL and merge commit.
-2. Remove the locale worktree.
-3. Delete the local branch if it is merged or no longer needed.
-4. Prune/delete remote branch when GitHub did not already delete it.
+2. Remove the locale worktree only if it has no uncommitted intentional changes.
+3. Delete the safe local branch.
+4. Prune/delete remote branch if GitHub did not.
 5. Mark status `cleaned`.
-
-Never remove a worktree that still has uncommitted intentional changes.

--- a/.agents/skills/add-locale-batch/scripts/locale_batch_status.py
+++ b/.agents/skills/add-locale-batch/scripts/locale_batch_status.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Refresh compact GitHub PR state for a Humanizer locale batch status file.
+
+Input status shape is a JSON object keyed by locale code. Entries with a `pr`
+number are updated with PR metadata, unresolved review-thread count, and compact
+check state. The script prints the updated JSON and optionally writes it back.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def run_json(args: list[str]) -> Any:
+    completed = subprocess.run(args, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if completed.returncode != 0:
+        raise RuntimeError(f"command failed: {' '.join(args)}\n{completed.stderr.strip()}")
+    return json.loads(completed.stdout or "null")
+
+
+def run_text(args: list[str]) -> str:
+    completed = subprocess.run(args, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if completed.returncode != 0:
+        return completed.stdout + completed.stderr
+    return completed.stdout
+
+
+def unresolved_threads(repo: str, pr: int) -> int:
+    owner, name = repo.split("/", 1)
+    query = (
+        "query($owner:String!, $name:String!, $number:Int!) { "
+        "repository(owner:$owner, name:$name) { "
+        "pullRequest(number:$number) { "
+        "reviewThreads(first:100) { nodes { isResolved isOutdated } } "
+        "} } }"
+    )
+    data = run_json([
+        "gh", "api", "graphql",
+        "-f", f"owner={owner}",
+        "-f", f"name={name}",
+        "-F", f"number={pr}",
+        "-f", f"query={query}",
+    ])
+    nodes = data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+    return sum(1 for node in nodes if not node["isResolved"] and not node["isOutdated"])
+
+
+def checks_state(repo: str, pr: int) -> str:
+    output = run_text(["gh", "pr", "checks", str(pr), "--repo", repo, "--watch=false"])
+    states: list[str] = []
+    for line in output.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            states.append(parts[1].strip().lower())
+    if not states:
+        return "unknown"
+    if any(state in {"fail", "failing", "failure", "cancelled", "timed_out"} for state in states):
+        return "failed"
+    if any(state in {"pending", "queued", "in_progress", "waiting"} for state in states):
+        return "pending"
+    if all(state in {"pass", "passing", "success", "skipping", "skipped"} for state in states):
+        return "green"
+    return "mixed"
+
+
+def refresh_entry(repo: str, entry: dict[str, Any]) -> dict[str, Any]:
+    pr = entry.get("pr")
+    if not pr:
+        return entry
+
+    view = run_json([
+        "gh", "pr", "view", str(pr), "--repo", repo,
+        "--json", "number,url,state,isDraft,headRefName,headRefOid,reviewDecision,mergeStateStatus,mergeable,mergedAt",
+    ])
+
+    entry.update({
+        "pr": view["number"],
+        "prUrl": view["url"],
+        "head": view.get("headRefOid"),
+        "branch": entry.get("branch") or view.get("headRefName"),
+        "reviewDecision": view.get("reviewDecision"),
+        "mergeable": view.get("mergeable"),
+        "mergeStateStatus": view.get("mergeStateStatus"),
+        "isDraft": view.get("isDraft"),
+        "merged": view.get("state") == "MERGED",
+        "mergedAt": view.get("mergedAt"),
+        "unresolvedThreads": unresolved_threads(repo, int(pr)),
+        "checks": checks_state(repo, int(pr)),
+    })
+    if entry["merged"] and entry.get("phase") != "cleaned":
+        entry["phase"] = "merged"
+    return entry
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--status", required=True, help="Path to locale-batch-status.json")
+    parser.add_argument("--repo", default="Humanizr/Humanizer", help="GitHub repo, owner/name")
+    parser.add_argument("--write", action="store_true", help="Write refreshed JSON back to --status")
+    args = parser.parse_args()
+
+    path = Path(args.status)
+    status = json.loads(path.read_text())
+    for entry in status.values():
+        if isinstance(entry, dict):
+            refresh_entry(args.repo, entry)
+
+    rendered = json.dumps(status, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.write:
+        path.write_text(rendered)
+    sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/add-locale-batch/scripts/locale_batch_status.py
+++ b/.agents/skills/add-locale-batch/scripts/locale_batch_status.py
@@ -11,18 +11,34 @@ from pathlib import Path
 from typing import Any
 
 
-def run_json(args: list[str]) -> Any:
-    completed = subprocess.run(args, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+GH_TIMEOUT_SECONDS = 30
+
+
+def run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        completed = subprocess.run(
+            args,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"command timed out after {GH_TIMEOUT_SECONDS}s: {' '.join(args)}") from exc
+
     if completed.returncode != 0:
-        raise RuntimeError(f"command failed: {' '.join(args)}\n{completed.stderr.strip()}")
-    return json.loads(completed.stdout or "null")
+        output = (completed.stdout + completed.stderr).strip()
+        raise RuntimeError(f"command failed: {' '.join(args)}\n{output}")
+
+    return completed
+
+
+def run_json(args: list[str]) -> Any:
+    return json.loads(run_gh(args).stdout or "null")
 
 
 def run_text(args: list[str]) -> str:
-    completed = subprocess.run(args, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    if completed.returncode != 0:
-        return completed.stdout + completed.stderr
-    return completed.stdout
+    return run_gh(args).stdout
 
 
 def unresolved_threads(repo: str, pr: int) -> int:

--- a/.agents/skills/add-locale-batch/scripts/locale_batch_status.py
+++ b/.agents/skills/add-locale-batch/scripts/locale_batch_status.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-"""Refresh compact GitHub PR state for a Humanizer locale batch status file.
-
-Input status shape is a JSON object keyed by locale code. Entries with a `pr`
-number are updated with PR metadata, unresolved review-thread count, and compact
-check state. The script prints the updated JSON and optionally writes it back.
-"""
+"""Refresh compact GitHub PR state in a locale batch status JSON file."""
 
 from __future__ import annotations
 
@@ -99,9 +94,9 @@ def refresh_entry(repo: str, entry: dict[str, Any]) -> dict[str, Any]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--status", required=True, help="Path to locale-batch-status.json")
-    parser.add_argument("--repo", default="Humanizr/Humanizer", help="GitHub repo, owner/name")
-    parser.add_argument("--write", action="store_true", help="Write refreshed JSON back to --status")
+    parser.add_argument("--status", required=True)
+    parser.add_argument("--repo", default="Humanizr/Humanizer")
+    parser.add_argument("--write", action="store_true")
     args = parser.parse_args()
 
     path = Path(args.status)


### PR DESCRIPTION
## Summary\n- add a new `add-locale-batch` orchestration skill for multi-locale Humanizer parity batches\n- add references for batch state, locale-orchestrator contracts, PR gates, and cleanup\n- add a compact `locale_batch_status.py` helper for centralized PR polling\n\n## Validation\n- `PYTHONDONTWRITEBYTECODE=1 python3 .agents/skills/add-locale-batch/scripts/locale_batch_status.py --status <sample-status> --repo Humanizr/Humanizer`\n- `python3 -m py_compile .agents/skills/add-locale-batch/scripts/locale_batch_status.py`\n- verified no committed full local filesystem paths under `.agents/skills/add-locale-batch`