### PR TITLE
Preserve leading underscores in Camelize

### DIFF
--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -199,6 +199,23 @@ public static partial class InflectorExtensions
     /// </example>
     public static string Camelize(this string input)
     {
+        var leadingUnderscoreLength = 0;
+        while (leadingUnderscoreLength < input.Length && input[leadingUnderscoreLength] == '_')
+        {
+            leadingUnderscoreLength++;
+        }
+
+        if (leadingUnderscoreLength > 0)
+        {
+            var prefix = input[..leadingUnderscoreLength];
+            if (leadingUnderscoreLength == input.Length)
+            {
+                return prefix;
+            }
+
+            return prefix + Camelize(input[leadingUnderscoreLength..]);
+        }
+
         if (TryPascalizeAscii(input, lowerFirst: true, out var result))
         {
             return result;

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -142,6 +142,8 @@ public class InflectorTests
     [InlineData("customer name $", "customerName$")]
     [InlineData("customer   name", "customerName")]
     [InlineData("", "")]
+    [InlineData("_Name", "_name")]
+    [InlineData("__customer_name", "__customerName")]
     public void Camelize(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Camelize());
 


### PR DESCRIPTION
## Summary

- Restores v2-compatible behavior for strings that start with one or more underscores.
- `Camelize()` now keeps leading `_` characters and camelizes the remainder, so `_Name` becomes `_name` instead of `name`.
- Adds regression tests for single and multiple leading underscores.

Fixes #1736

## Test plan

- [ ] `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --filter FullyQualifiedName~Camelize`
- [ ] Verify `_Name` => `_name`, `_customer_name` => `_customerName`, and `__customer_name` => `__customerName`