### PR TITLE
docs: align Dehumanize XML docs with current behavior (#1737)

### DIFF
--- a/src/Humanizer/StringDehumanizeExtensions.cs
+++ b/src/Humanizer/StringDehumanizeExtensions.cs
@@ -6,19 +6,19 @@ namespace Humanizer;
 public static class StringDehumanizeExtensions
 {
     /// <summary>
-    /// Converts a humanized string back to PascalCase format by removing spaces and capitalizing each word.
+    /// Converts a humanized string back to PascalCase format by splitting on spaces and capitalizing each word.
     /// </summary>
     /// <param name="input">The string to be dehumanized. Must not be null.</param>
     /// <returns>
-    /// A PascalCase string with all spaces removed and each word capitalized.
-    /// If the input is already in PascalCase (contains no spaces), it is returned unchanged.
+    /// A PascalCase string formed by joining pascalized words without separators.
+    /// If the input contains no non-whitespace characters, it is returned unchanged.
     /// </returns>
     /// <remarks>
     /// This method reverses the humanization process by:
-    /// 1. Splitting the input on spaces
+    /// 1. Splitting the input on spaces (empty entries are ignored)
     /// 2. Humanizing each word (to handle any edge cases)
     /// 3. Pascalizing each word (capitalizing first letter)
-    /// 4. Removing all spaces
+    /// 4. Concatenating the words without separators
     /// This is the inverse operation of <see cref="StringHumanizeExtensions.Humanize(string)"/>.
     /// </remarks>
     /// <example>

--- a/tests/Humanizer.Tests/StringDehumanizeTests.cs
+++ b/tests/Humanizer.Tests/StringDehumanizeTests.cs
@@ -21,6 +21,7 @@ public class StringDehumanizeTests
     [InlineData("OneYetTwo", "OneYetTwo")]
     [InlineData("OneNorTwo", "OneNorTwo")]
     [InlineData("WordSoTwo", "WordSoTwo")]
+    [InlineData("   ", "   ")]
     public void CanDehumanizeIntoAPascalCaseWord(string input, string expectedResult) =>
         Assert.Equal(expectedResult, input.Dehumanize());
 }


### PR DESCRIPTION
## Summary
- Update `Dehumanize` XML documentation to describe joining pascalized words without separators instead of claiming all spaces are removed globally
- Document that whitespace-only input is returned unchanged
- Add a test case for whitespace-only input to lock in current behavior

Fixes #1737

## Test plan
- [ ] CI passes (`StringDehumanizeTests`)