### PR TITLE
fix: use CurrentCulture for default locale resolution (#1562)

### DIFF
--- a/src/Humanizer/Configuration/Configurator.cs
+++ b/src/Humanizer/Configuration/Configurator.cs
@@ -47,7 +47,7 @@ public static class Configurator
     public static LocaliserRegistry<ITimeOnlyToClockNotationConverter> TimeOnlyToClockNotationConverters { get; } = new TimeOnlyToClockNotationConvertersRegistry();
 #endif
 
-    internal static ICollectionFormatter CollectionFormatter => CollectionFormatters.ResolveForUiCulture();
+    internal static ICollectionFormatter CollectionFormatter => CollectionFormatters.ResolveForCulture(null);
 
     /// <summary>
     /// The formatter to be used
@@ -71,20 +71,20 @@ public static class Configurator
     /// <summary>
     /// The ordinalizer to be used
     /// </summary>
-    internal static IOrdinalizer Ordinalizer => Ordinalizers.ResolveForUiCulture();
+    internal static IOrdinalizer Ordinalizer => Ordinalizers.ResolveForCulture(null);
 
     /// <summary>
     /// The ordinalizer to be used
     /// </summary>
-    internal static IDateToOrdinalWordConverter DateToOrdinalWordsConverter => DateToOrdinalWordsConverters.ResolveForUiCulture();
+    internal static IDateToOrdinalWordConverter DateToOrdinalWordsConverter => DateToOrdinalWordsConverters.ResolveForCulture(null);
 
 #if NET6_0_OR_GREATER
     /// <summary>
     /// The ordinalizer to be used
     /// </summary>
-    internal static IDateOnlyToOrdinalWordConverter DateOnlyToOrdinalWordsConverter => DateOnlyToOrdinalWordsConverters.ResolveForUiCulture();
+    internal static IDateOnlyToOrdinalWordConverter DateOnlyToOrdinalWordsConverter => DateOnlyToOrdinalWordsConverters.ResolveForCulture(null);
 
-    internal static ITimeOnlyToClockNotationConverter TimeOnlyToClockNotationConverter => TimeOnlyToClockNotationConverters.ResolveForUiCulture();
+    internal static ITimeOnlyToClockNotationConverter TimeOnlyToClockNotationConverter => TimeOnlyToClockNotationConverters.ResolveForCulture(null);
 #endif
 
     /// <summary>

--- a/src/Humanizer/Configuration/LocaliserRegistry.cs
+++ b/src/Humanizer/Configuration/LocaliserRegistry.cs
@@ -28,15 +28,15 @@ public class LocaliserRegistry<TLocaliser>
     /// Gets the localiser for the current thread's UI culture
     /// </summary>
     public TLocaliser ResolveForUiCulture() =>
-        ResolveForCulture(null);
+        ResolveForCulture(CultureInfo.CurrentUICulture);
 
     /// <summary>
     /// Gets the localiser for the specified culture
     /// </summary>
-    /// <param name="culture">The culture to retrieve localiser for. If not specified, current thread's UI culture is used.</param>
+    /// <param name="culture">The culture to retrieve localiser for. If not specified, current thread's culture is used.</param>
     public TLocaliser ResolveForCulture(CultureInfo? culture)
     {
-        var cultureInfo = culture ?? CultureInfo.CurrentUICulture;
+        var cultureInfo = culture ?? CultureInfo.CurrentCulture;
         var cultureName = cultureInfo.Name;
 
         // Use ConcurrentDictionary with culture name (string) as key to avoid CultureInfo equality checks

--- a/src/Humanizer/HeadingExtensions.cs
+++ b/src/Humanizer/HeadingExtensions.cs
@@ -40,7 +40,7 @@ public static class HeadingExtensions
     {
         var val = (int)(heading / 22.5 + .5);
         var headingsIndex = val % 16;
-        return HeadingTableCatalog.Resolve(culture ?? CultureInfo.CurrentUICulture)
+        return HeadingTableCatalog.Resolve(culture ?? CultureInfo.CurrentCulture)
             .GetHeading(style, headingsIndex);
     }
 

--- a/src/Humanizer/OrdinalizeExtensions.cs
+++ b/src/Humanizer/OrdinalizeExtensions.cs
@@ -34,10 +34,10 @@ public static class OrdinalizeExtensions
     /// Turns a number into an ordinal string used to denote the position in an ordered sequence such as 1st, 2nd, 3rd, 4th.
     /// </summary>
     /// <param name="numberString">The number, in string, to be ordinalized</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     public static string Ordinalize(this string numberString, CultureInfo culture)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(ParseOrdinalNumber(numberString, resolvedCulture), NormalizeOrdinalNumberString(numberString));
     }
 
@@ -52,12 +52,12 @@ public static class OrdinalizeExtensions
     /// </code>
     /// </example>
     /// <param name="numberString">The number to be ordinalized</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
     /// <returns>The number ordinalized</returns>
     public static string Ordinalize(this string numberString, CultureInfo culture, WordForm wordForm)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(ParseOrdinalNumber(numberString, resolvedCulture), NormalizeOrdinalNumberString(numberString), wordForm);
     }
 
@@ -99,10 +99,10 @@ public static class OrdinalizeExtensions
     /// </summary>
     /// <param name="numberString">The number, in string, to be ordinalized</param>
     /// <param name="gender">The grammatical gender to use for output words</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     public static string Ordinalize(this string numberString, GrammaticalGender gender, CultureInfo culture)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(ParseOrdinalNumber(numberString, resolvedCulture), NormalizeOrdinalNumberString(numberString), gender);
     }
 
@@ -120,12 +120,12 @@ public static class OrdinalizeExtensions
     /// </example>
     /// <param name="numberString">The number to be ordinalized</param>
     /// <param name="gender">The grammatical gender to use for output words</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
     /// <returns>The number ordinalized</returns>
     public static string Ordinalize(this string numberString, GrammaticalGender gender, CultureInfo culture, WordForm wordForm)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(ParseOrdinalNumber(numberString, resolvedCulture), NormalizeOrdinalNumberString(numberString), gender, wordForm);
     }
 
@@ -156,10 +156,10 @@ public static class OrdinalizeExtensions
     /// Turns a number into an ordinal number used to denote the position in an ordered sequence such as 1st, 2nd, 3rd, 4th.
     /// </summary>
     /// <param name="number">The number to be ordinalized</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     public static string Ordinalize(this int number, CultureInfo culture)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)));
     }
 
@@ -174,12 +174,12 @@ public static class OrdinalizeExtensions
     /// </code>
     /// </example>
     /// <param name="number">The number to be ordinalized</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
     /// <returns>The number ordinalized</returns>
     public static string Ordinalize(this int number, CultureInfo culture, WordForm wordForm)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)), wordForm);
     }
 
@@ -221,10 +221,10 @@ public static class OrdinalizeExtensions
     /// </summary>
     /// <param name="number">The number to be ordinalized</param>
     /// <param name="gender">The grammatical gender to use for output words</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     public static string Ordinalize(this int number, GrammaticalGender gender, CultureInfo culture)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)), gender);
     }
 
@@ -242,12 +242,12 @@ public static class OrdinalizeExtensions
     /// </example>
     /// <param name="number">The number to be ordinalized</param>
     /// <param name="gender">The grammatical gender to use for output words</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
     /// <returns>The number ordinalized</returns>
     public static string Ordinalize(this int number, GrammaticalGender gender, CultureInfo culture, WordForm wordForm)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)), gender, wordForm);
     }
 

--- a/tests/Humanizer.Tests/HeadingTests.cs
+++ b/tests/Humanizer.Tests/HeadingTests.cs
@@ -196,7 +196,7 @@ public class HeadingTests
             CultureInfo.CurrentCulture = new CultureInfo("en-US");
             CultureInfo.CurrentUICulture = new CultureInfo("de-DE");
 
-            Assert.Equal("North", 0d.ToHeading(HeadingStyle.Full));
+            Assert.Equal("north", 0d.ToHeading(HeadingStyle.Full));
         }
         finally
         {

--- a/tests/Humanizer.Tests/HeadingTests.cs
+++ b/tests/Humanizer.Tests/HeadingTests.cs
@@ -186,7 +186,7 @@ public class HeadingTests
         Assert.Equal(expected, heading.FromAbbreviatedHeading(new(culture)));
 
     [Fact]
-    public void ToHeadingUsesCurrentUiCultureWhenCultureIsOmitted()
+    public void ToHeadingUsesCurrentCultureWhenCultureIsOmitted()
     {
         var originalCulture = CultureInfo.CurrentCulture;
         var originalUiCulture = CultureInfo.CurrentUICulture;
@@ -196,7 +196,7 @@ public class HeadingTests
             CultureInfo.CurrentCulture = new CultureInfo("en-US");
             CultureInfo.CurrentUICulture = new CultureInfo("de-DE");
 
-            Assert.Equal("Nord", 0d.ToHeading(HeadingStyle.Full));
+            Assert.Equal("North", 0d.ToHeading(HeadingStyle.Full));
         }
         finally
         {

--- a/tests/Humanizer.Tests/Localisation/LocaliserRegistryTests.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaliserRegistryTests.cs
@@ -14,14 +14,29 @@ public class LocaliserRegistryTests
     }
 
     [Fact]
-    public void ResolveForCultureNullUsesCurrentUiCulture()
+    public void ResolveForCultureNullUsesCurrentCulture()
     {
         var registry = new LocaliserRegistry<string>(culture => $"default:{culture.Name}");
         registry.Register("fr", culture => $"fr:{culture.Name}");
 
         using var _ = new DistinctCultureSwap(new("en-US"), new("fr-CH"));
 
-        Assert.Equal("fr:fr-CH", registry.ResolveForCulture(null));
+        Assert.Equal("default:en-US", registry.ResolveForCulture(null));
+    }
+
+    [Fact]
+    public void ResolveForCultureNullUsesCurrentCultureWhenDistinctFromUiCulture()
+    {
+        var registry = new LocaliserRegistry<string>(culture => $"default:{culture.Name}");
+        registry.Register("en-GB", culture => $"en-GB:{culture.Name}");
+
+        using var _ = new DistinctCultureSwap(new("en-GB"), new("en-US"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.Equal("en-GB:en-GB", registry.ResolveForCulture(null));
+            Assert.Equal("default:en-US", registry.ResolveForUiCulture());
+        });
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Resolve null-culture lookups from `CurrentCulture` instead of `CurrentUICulture` in `LocaliserRegistry`
- Keep `ResolveForUiCulture()` explicitly bound to `CurrentUICulture`
- Update default Humanizer services (ordinalizers, date-to-ordinal converters, collection formatters, headings) to use culture-based resolution
- Align `Ordinalize` overloads and heading helpers with the same default

Fixes #1562

## Test plan
- [ ] CI passes (`LocaliserRegistryTests`, `HeadingTests`, existing localization suites)
- [ ] When `CurrentCulture` and `CurrentUICulture` differ, formatting uses `CurrentCulture`