### PR TITLE
fix: restore Enum.Humanize for runtime-known enum types (#1653)

### DIFF
--- a/src/Humanizer/EnumHumanizeExtensions.cs
+++ b/src/Humanizer/EnumHumanizeExtensions.cs
@@ -5,6 +5,32 @@ namespace Humanizer;
 /// </summary>
 public static class EnumHumanizeExtensions
 {
+    static readonly MethodInfo GenericHumanizeMethod = typeof(EnumHumanizeExtensions)
+        .GetMethods()
+        .Single(method =>
+            method.Name == nameof(Humanize) &&
+            method.IsGenericMethodDefinition &&
+            method.GetParameters().Length == 1 &&
+            method.GetGenericArguments().Length == 1);
+
+    /// <summary>
+    /// Converts an enum value to a human-readable string when the concrete enum type is only known at runtime.
+    /// </summary>
+    /// <param name="input">The enum value to be humanized.</param>
+    /// <returns>A human-readable string representation of the enum value.</returns>
+    public static string Humanize(this Enum input) =>
+        (string)GenericHumanizeMethod
+            .MakeGenericMethod(input.GetType())
+            .Invoke(null, [input])!;
+
+    /// <summary>
+    /// Converts an enum value to a human-readable string with the specified letter casing when the concrete enum type is only known at runtime.
+    /// </summary>
+    /// <param name="input">The enum value to be humanized.</param>
+    /// <param name="casing">The desired letter casing to apply to the humanized enum value.</param>
+    /// <returns>A human-readable string representation of the enum value with the specified casing applied.</returns>
+    public static string Humanize(this Enum input, LetterCasing casing) =>
+        input.Humanize().ApplyCase(casing);
     /// <summary>
     /// Converts an enum value to a human-readable string by intelligently formatting the enum member name
     /// and respecting any <see cref="System.ComponentModel.DescriptionAttribute"/> applied to the member.

--- a/src/Humanizer/EnumHumanizeExtensions.cs
+++ b/src/Humanizer/EnumHumanizeExtensions.cs
@@ -18,10 +18,23 @@ public static class EnumHumanizeExtensions
     /// </summary>
     /// <param name="input">The enum value to be humanized.</param>
     /// <returns>A human-readable string representation of the enum value.</returns>
-    public static string Humanize(this Enum input) =>
-        (string)GenericHumanizeMethod
-            .MakeGenericMethod(input.GetType())
-            .Invoke(null, [input])!;
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+#endif
+    public static string Humanize(this Enum input)
+    {
+        try
+        {
+            return (string)GenericHumanizeMethod
+                .MakeGenericMethod(input.GetType())
+                .Invoke(null, [input])!;
+        }
+        catch (TargetInvocationException exception)
+        {
+            throw exception.InnerException!;
+        }
+    }
 
     /// <summary>
     /// Converts an enum value to a human-readable string with the specified letter casing when the concrete enum type is only known at runtime.
@@ -31,6 +44,7 @@ public static class EnumHumanizeExtensions
     /// <returns>A human-readable string representation of the enum value with the specified casing applied.</returns>
     public static string Humanize(this Enum input, LetterCasing casing) =>
         input.Humanize().ApplyCase(casing);
+
     /// <summary>
     /// Converts an enum value to a human-readable string by intelligently formatting the enum member name
     /// and respecting any <see cref="System.ComponentModel.DescriptionAttribute"/> applied to the member.

--- a/src/Humanizer/EnumHumanizeExtensions.cs
+++ b/src/Humanizer/EnumHumanizeExtensions.cs
@@ -5,13 +5,21 @@ namespace Humanizer;
 /// </summary>
 public static class EnumHumanizeExtensions
 {
-    static readonly MethodInfo GenericHumanizeMethod = typeof(EnumHumanizeExtensions)
-        .GetMethods()
-        .Single(method =>
-            method.Name == nameof(Humanize) &&
-            method.IsGenericMethodDefinition &&
-            method.GetParameters().Length == 1 &&
-            method.GetGenericArguments().Length == 1);
+#if NET6_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The method is only used by Humanize which already has RequiresUnreferencedCode")]
+    [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "The method is only used by Humanize which already has RequiresUnreferencedCode")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "The method is only used by Humanize which already has RequiresDynamicCode")]
+#endif
+    static MethodInfo GetGenericHumanizeMethodInfo() =>
+        typeof(EnumHumanizeExtensions)
+            .GetMethods()
+            .Single(method =>
+                method.Name == nameof(Humanize) &&
+                method.IsGenericMethodDefinition &&
+                method.GetParameters().Length == 1 &&
+                method.GetGenericArguments().Length == 1);
+
+    static readonly Lazy<MethodInfo> GenericHumanizeMethod = new(GetGenericHumanizeMethodInfo);
 
     /// <summary>
     /// Converts an enum value to a human-readable string when the concrete enum type is only known at runtime.
@@ -21,12 +29,13 @@ public static class EnumHumanizeExtensions
 #if NET6_0_OR_GREATER
     [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
     [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(EnumHumanizeExtensions))]
 #endif
     public static string Humanize(this Enum input)
     {
         try
         {
-            return (string)GenericHumanizeMethod
+            return (string)GenericHumanizeMethod.Value
                 .MakeGenericMethod(input.GetType())
                 .Invoke(null, [input])!;
         }
@@ -42,6 +51,10 @@ public static class EnumHumanizeExtensions
     /// <param name="input">The enum value to be humanized.</param>
     /// <param name="casing">The desired letter casing to apply to the humanized enum value.</param>
     /// <returns>A human-readable string representation of the enum value with the specified casing applied.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+#endif
     public static string Humanize(this Enum input, LetterCasing casing) =>
         input.Humanize().ApplyCase(casing);
 

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -260,6 +260,13 @@ namespace Humanizer
     }
     public static class EnumHumanizeExtensions
     {
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods, typeof(Humanizer.EnumHumanizeExtensions))]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing) { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input)
             where T :  struct, System.Enum { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing)

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -260,6 +260,13 @@ namespace Humanizer
     }
     public static class EnumHumanizeExtensions
     {
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods, typeof(Humanizer.EnumHumanizeExtensions))]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing) { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input)
             where T :  struct, System.Enum { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing)

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -259,6 +259,13 @@ namespace Humanizer
     }
     public static class EnumHumanizeExtensions
     {
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods, typeof(Humanizer.EnumHumanizeExtensions))]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing) { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input)
             where T :  struct, System.Enum { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing)

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -235,6 +235,8 @@ namespace Humanizer
     }
     public static class EnumHumanizeExtensions
     {
+        public static string Humanize(this System.Enum input) { }
+        public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing) { }
         public static string Humanize<T>(this T input)
             where T :  struct, System.Enum { }
         public static string Humanize<T>(this T input, Humanizer.LetterCasing casing)

--- a/tests/Humanizer.Tests/EnumHumanizeTests.cs
+++ b/tests/Humanizer.Tests/EnumHumanizeTests.cs
@@ -23,6 +23,8 @@ public class EnumHumanizeTests
         Assert.Equal(EnumTestsResources.MemberWithoutDescriptionAttributeSentence, EnumUnderTest.MemberWithoutDescriptionAttribute.Humanize());
 
     [Fact]
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
     public void CanHumanizeWhenEnumTypeIsKnownAtRuntimeOnly()
     {
         Enum value = EnumUnderTest.MemberWithoutDescriptionAttribute;

--- a/tests/Humanizer.Tests/EnumHumanizeTests.cs
+++ b/tests/Humanizer.Tests/EnumHumanizeTests.cs
@@ -23,6 +23,17 @@ public class EnumHumanizeTests
         Assert.Equal(EnumTestsResources.MemberWithoutDescriptionAttributeSentence, EnumUnderTest.MemberWithoutDescriptionAttribute.Humanize());
 
     [Fact]
+    public void CanHumanizeWhenEnumTypeIsKnownAtRuntimeOnly()
+    {
+        Enum value = EnumUnderTest.MemberWithoutDescriptionAttribute;
+
+        Assert.Equal(EnumTestsResources.MemberWithoutDescriptionAttributeSentence, value.Humanize());
+        Assert.Equal(
+            EnumTestsResources.MemberWithoutDescriptionAttributeTitle,
+            value.Humanize(LetterCasing.Title));
+    }
+
+    [Fact]
     public void CanApplyTitleCasingOnEnumHumanization() =>
         Assert.Equal(
             EnumTestsResources.MemberWithoutDescriptionAttributeTitle,


### PR DESCRIPTION
## Summary
- Add non-generic `Enum.Humanize()` / `Humanize(LetterCasing)` overloads
- Dispatch to the existing generic implementation via reflection so boxed enum values work again
- Add regression test for runtime-known enum values

Fixes #1653

## Test plan
- [ ] CI passes
- [ ] `Enum value = ...; value.Humanize()` works when concrete enum type is unknown at compile time