### PR TITLE
fix: saturate large TimeSpan humanize counts to int range (#1728)

### DIFF
--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -213,17 +213,50 @@ public static class TimeSpanHumanizeExtensions
     {
         if (isTimeUnitToGetTheMaximumTimeUnit)
         {
-            return (int)totalTimeNumberOfUnits;
+            return SaturateToIntCount(totalTimeNumberOfUnits);
         }
 
         return timeNumberOfUnits;
     }
 
+    static int SaturateToIntCount(double value)
+    {
+        if (double.IsNaN(value) || double.IsPositiveInfinity(value))
+        {
+            return int.MaxValue;
+        }
+
+        if (double.IsNegativeInfinity(value))
+        {
+            return int.MinValue;
+        }
+
+        if (value >= int.MaxValue)
+        {
+            return int.MaxValue;
+        }
+
+        if (value <= int.MinValue)
+        {
+            return int.MinValue;
+        }
+
+        return (int)value;
+    }
+
     static string? BuildFormatTimePart(IFormatter cultureFormatter, TimeUnit timeUnitType, int amountOfTimeUnits, bool toWords = false) =>
         // Always use positive units to account for negative timespans
         amountOfTimeUnits != 0
-            ? cultureFormatter.TimeSpanHumanize(timeUnitType, Math.Abs(amountOfTimeUnits), toWords)
+            ? cultureFormatter.TimeSpanHumanize(timeUnitType, GetAbsoluteCount(amountOfTimeUnits), toWords)
             : null;
+
+    static int GetAbsoluteCount(int count) =>
+        count switch
+        {
+            int.MinValue => int.MaxValue,
+            < 0 => -count,
+            _ => count,
+        };
 
     static string HumanizeSinglePart(TimeSpan timeSpan, CultureInfo? culture, TimeUnit maxUnit, TimeUnit minUnit, bool toWords)
     {

--- a/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
@@ -467,4 +467,22 @@ public class TimeSpanHumanizeTests
         var actual = timeSpan.Humanize(precision: precision, culture: new(culture), maxUnit: TimeUnit.Year, toWords: true);
         Assert.Equal(expected: expected, actual);
     }
+
+    [Fact]
+    public void MaxValue_DoesNotThrow_WhenHumanizingInSeconds()
+    {
+        var result = TimeSpan.MaxValue.Humanize(maxUnit: TimeUnit.Second, minUnit: TimeUnit.Second);
+
+        Assert.NotEmpty(result);
+        Assert.Contains("second", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MinValue_DoesNotThrow_WhenHumanizingInMilliseconds()
+    {
+        var result = TimeSpan.MinValue.Humanize(maxUnit: TimeUnit.Millisecond, minUnit: TimeUnit.Millisecond);
+
+        Assert.NotEmpty(result);
+        Assert.Contains("millisecond", result, StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
## Summary
- Clamp oversized TimeSpan unit counts to the `int` range before formatting
- Avoid `Math.Abs(int.MinValue)` when humanizing extreme `TimeSpan` values
- Add regression tests for `TimeSpan.MaxValue` and `TimeSpan.MinValue`

Fixes #1728

## Test plan
- [ ] CI passes
- [ ] `TimeSpan.MaxValue.Humanize(maxUnit: Second, minUnit: Second)` no longer throws
- [ ] Existing `TimeSpanHumanizeTests` remain green