### PR TITLE
test: cover Pascalize for underscore-separated digit segments (#1668)

### DIFF
--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -121,6 +121,7 @@ public class InflectorTests
     [InlineData("customer-first-name", "CustomerFirstName")]
     [InlineData("_customer-first-name", "CustomerFirstName")]
     [InlineData(" customer__first--name", "CustomerFirstName")]
+    [InlineData("admin_area_level_1_long_name", "AdminAreaLevel1LongName")]
     public void Pascalize(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Pascalize());
 


### PR DESCRIPTION
## Summary
- Add a regression test ensuring `admin_area_level_1_long_name`.Pascalize() produces `AdminAreaLevel1LongName`
- Guards the behavior restored in #1684 against future regressions

Addresses #1668

## Test plan
- [ ] CI passes (`InflectorTests.Pascalize`)