### PR TITLE
fix: singularize -ive verbs like arrives to arrive (#1674)

### DIFF
--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -73,6 +73,8 @@ public static class Vocabularies
         _default.AddIrregular("sex", "sexes");
         _default.AddIrregular("glove", "gloves");
         _default.AddIrregular("move", "moves");
+        _default.AddIrregular("arrive", "arrives");
+        _default.AddIrregular("archive", "archives");
         _default.AddIrregular("goose", "geese");
         _default.AddIrregular("wave", "waves");
         _default.AddIrregular("foot", "feet");

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -71,6 +71,15 @@ public class InflectorTests
     public void SingularizeSingleLetter(string input) =>
         Assert.Equal(input, input.Singularize());
 
+    /// <summary>
+    /// https://github.com/Humanizr/Humanizer/issues/1674
+    /// </summary>
+    [Theory]
+    [InlineData("arrive", "arrives")]
+    [InlineData("archive", "archives")]
+    public void SingularizeIveVerbsEndingInEs(string singular, string plural) =>
+        Assert.Equal(singular, plural.Singularize());
+
     //Uppercases individual words and removes some characters
     [Theory]
     [InlineData("some title", "Some Title")]


### PR DESCRIPTION
## Summary
- Register `arrive`/`arrives` and `archive`/`archives` as irregular singular/plural pairs.
- Prevents the generic `(...ves -> ...fe)` rule from rewriting `arrives` to `arrife`.

Fixes #1674

## Test plan
- [x] Added `SingularizeIveVerbsEndingInEs` regression tests
- [ ] CI green on `main`