### PR TITLE
fix: ToMetric uses rounded value for metric tier selection (#1695)

### DIFF
--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -422,20 +422,29 @@ public static class MetricNumeralExtensions
     /// <returns>A number in a Metric representation</returns>
     static string BuildRepresentation(double input, MetricNumeralFormats? formats, int? decimals)
     {
-        var value = decimals.HasValue ? Math.Round(input, decimals.Value) : input;
-        var exponent = (int)Math.Floor(Math.Log10(Math.Abs(value)) / 3);
+        var exponent = (int)Math.Floor(Math.Log10(Math.Abs(input)) / 3);
 
         if (!exponent.Equals(0))
         {
-            return BuildMetricRepresentation(value, exponent, formats, decimals);
+            return BuildMetricRepresentation(input, exponent, formats, decimals);
         }
 
         var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
-        var representation = decimals.HasValue
-            ? value.ToString(nfi)
-            : input.ToString(nfi);
-        var space = (formats & MetricNumeralFormats.WithSpace) == MetricNumeralFormats.WithSpace ? " " : string.Empty;
-        return representation + space;
+        if (decimals.HasValue)
+        {
+            var rounded = Math.Round(input, decimals.Value);
+            if (Math.Abs(rounded) >= 1000)
+            {
+                return BuildMetricRepresentation(rounded, 1, formats, decimals);
+            }
+
+            var space = (formats & MetricNumeralFormats.WithSpace) == MetricNumeralFormats.WithSpace ? " " : string.Empty;
+            return rounded.ToString(nfi) + space;
+        }
+
+        var representation = input.ToString(nfi);
+        var trailingSpace = (formats & MetricNumeralFormats.WithSpace) == MetricNumeralFormats.WithSpace ? " " : string.Empty;
+        return representation + trailingSpace;
     }
 
     /// <summary>

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -422,18 +422,17 @@ public static class MetricNumeralExtensions
     /// <returns>A number in a Metric representation</returns>
     static string BuildRepresentation(double input, MetricNumeralFormats? formats, int? decimals)
     {
-        var exponent = (int)Math.Floor(Math.Log10(Math.Abs(input)) / 3);
+        var value = decimals.HasValue ? Math.Round(input, decimals.Value) : input;
+        var exponent = (int)Math.Floor(Math.Log10(Math.Abs(value)) / 3);
 
         if (!exponent.Equals(0))
         {
-            return BuildMetricRepresentation(input, exponent, formats, decimals);
+            return BuildMetricRepresentation(value, exponent, formats, decimals);
         }
 
         var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
         var representation = decimals.HasValue
-            ? Math
-                .Round(input, decimals.Value)
-                .ToString(nfi)
+            ? value.ToString(nfi)
             : input.ToString(nfi);
         var space = (formats & MetricNumeralFormats.WithSpace) == MetricNumeralFormats.WithSpace ? " " : string.Empty;
         return representation + space;

--- a/tests/Humanizer.Tests/MetricNumeralTests.cs
+++ b/tests/Humanizer.Tests/MetricNumeralTests.cs
@@ -212,6 +212,7 @@ public class MetricNumeralTests
     [InlineData("1 milli", 1E-3, MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseName, null)]
     [InlineData("1 thousandth", 1E-3, MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseShortScaleWord, null)]
     [InlineData("1 thousandth", 1E-3, MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseLongScaleWord, null)]
+    [InlineData("1k", 999.9, null, 0)]
     public void ToMetric(string expected, double input, MetricNumeralFormats? format, int? decimals) =>
         Assert.Equal(expected, input.ToMetric(format, decimals));
 


### PR DESCRIPTION
## Summary
- When `decimals` is specified, compute the metric exponent from the **rounded** value before choosing a prefix.
- Fixes cases like `999.9.ToMetric(decimals: 0)` returning `"1k"` instead of `"1000"`.

Fixes #1695

## Test plan
- [x] Added `ToMetric` regression case for `999.9` with `decimals: 0`
- [ ] CI green on `main`