### PR TITLE
feat: add English ToDecimalNumber word parsing (#1739)

### DIFF
--- a/src/Humanizer.SourceGenerators/Common/ProfileDefinitions.cs
+++ b/src/Humanizer.SourceGenerators/Common/ProfileDefinitions.cs
@@ -87,6 +87,8 @@ public sealed partial class HumanizerSourceGenerator
         bool allowTerminalOrdinalToken,
         bool useHundredMultiplier,
         bool allowInvariantIntegerInput,
+        ImmutableArray<string> decimalMarkerTokens,
+        bool allowInvariantDecimalInput,
         long? teenBaseValue,
         long? hundredSuffixValue,
         long? unitTokenMinValue,
@@ -119,6 +121,8 @@ public sealed partial class HumanizerSourceGenerator
         public bool AllowTerminalOrdinalToken { get; } = allowTerminalOrdinalToken;
         public bool UseHundredMultiplier { get; } = useHundredMultiplier;
         public bool AllowInvariantIntegerInput { get; } = allowInvariantIntegerInput;
+        public ImmutableArray<string> DecimalMarkerTokens { get; } = decimalMarkerTokens;
+        public bool AllowInvariantDecimalInput { get; } = allowInvariantDecimalInput;
         public long? TeenBaseValue { get; } = teenBaseValue;
         public long? HundredSuffixValue { get; } = hundredSuffixValue;
         public long? UnitTokenMinValue { get; } = unitTokenMinValue;

--- a/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/WordsToNumberEngineContractFactory.cs
+++ b/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/WordsToNumberEngineContractFactory.cs
@@ -215,6 +215,8 @@ public sealed partial class HumanizerSourceGenerator
                 RuleAssignment("AllowTerminalOrdinalToken", CreateBooleanLiteral(GetBoolean(root, "allowTerminalOrdinalToken"))),
                 RuleAssignment("UseHundredMultiplier", CreateBooleanLiteral(GetBoolean(root, "useHundredMultiplier"))),
                 RuleAssignment("AllowInvariantIntegerInput", CreateBooleanLiteral(GetBoolean(root, "allowInvariantIntegerInput"))),
+                RuleAssignment("DecimalMarkerTokens", CreateOptionalStringArrayExpression(root, "decimalMarkerTokens")),
+                RuleAssignment("AllowInvariantDecimalInput", CreateBooleanLiteral(GetBoolean(root, "allowInvariantDecimalInput"))),
                 RuleAssignment("TeenBaseValue", CreateOptionalInt64Literal(root, "teenBaseValue", "10")),
                 RuleAssignment("HundredSuffixValue", CreateOptionalInt64Literal(root, "hundredSuffixValue", "100")),
                 RuleAssignment("UnitTokenMinValue", CreateOptionalInt64Literal(root, "unitTokenMinValue", "1")),

--- a/src/Humanizer.SourceGenerators/Generators/TokenMapWordsToNumberInput.cs
+++ b/src/Humanizer.SourceGenerators/Generators/TokenMapWordsToNumberInput.cs
@@ -114,6 +114,8 @@ public sealed partial class HumanizerSourceGenerator
             var allowTerminalOrdinalToken = ReadBoolean(localeCode, localeElement, "allowTerminalOrdinalToken", diagnostics, ref hasErrors);
             var useHundredMultiplier = ReadBoolean(localeCode, localeElement, "useHundredMultiplier", diagnostics, ref hasErrors);
             var allowInvariantIntegerInput = ReadBoolean(localeCode, localeElement, "allowInvariantIntegerInput", diagnostics, ref hasErrors);
+            var decimalMarkerTokens = ReadStringArray(localeCode, localeElement, "decimalMarkerTokens", diagnostics, ref hasErrors);
+            var allowInvariantDecimalInput = ReadBoolean(localeCode, localeElement, "allowInvariantDecimalInput", diagnostics, ref hasErrors);
             var teenBaseValue = ReadLong(localeCode, localeElement, "teenBaseValue", diagnostics, ref hasErrors);
             var hundredSuffixValue = ReadLong(localeCode, localeElement, "hundredSuffixValue", diagnostics, ref hasErrors);
             var unitTokenMinValue = ReadLong(localeCode, localeElement, "unitTokenMinValue", diagnostics, ref hasErrors);
@@ -152,6 +154,8 @@ public sealed partial class HumanizerSourceGenerator
                 allowTerminalOrdinalToken,
                 useHundredMultiplier,
                 allowInvariantIntegerInput,
+                decimalMarkerTokens,
+                allowInvariantDecimalInput,
                 teenBaseValue,
                 hundredSuffixValue,
                 unitTokenMinValue,
@@ -218,6 +222,8 @@ public sealed partial class HumanizerSourceGenerator
                 AppendTrueBooleanValue(builder, "            ", "AllowTerminalOrdinalToken", locale.AllowTerminalOrdinalToken);
                 AppendTrueBooleanValue(builder, "            ", "UseHundredMultiplier", locale.UseHundredMultiplier);
                 AppendTrueBooleanValue(builder, "            ", "AllowInvariantIntegerInput", locale.AllowInvariantIntegerInput);
+                AppendStringArray(builder, "            ", "DecimalMarkerTokens", locale.DecimalMarkerTokens);
+                AppendTrueBooleanValue(builder, "            ", "AllowInvariantDecimalInput", locale.AllowInvariantDecimalInput);
 
                 AppendLongValue(builder, "            ", "TeenBaseValue", locale.TeenBaseValue, defaultValue: 10);
                 AppendLongValue(builder, "            ", "HundredSuffixValue", locale.HundredSuffixValue, defaultValue: 100);

--- a/src/Humanizer/Configuration/Configurator.cs
+++ b/src/Humanizer/Configuration/Configurator.cs
@@ -26,6 +26,12 @@ public static class Configurator
     private static LocaliserRegistry<IWordsToNumberConverter> WordsToNumberConverters { get; } = new WordsToNumberConverterRegistry();
 
     /// <summary>
+    /// A registry of converters that transform decimal number words into numeric values for the active locale.
+    /// </summary>
+    private static LocaliserRegistry<IWordsToDecimalNumberConverter> WordsToDecimalNumberConverters { get; } =
+        new WordsToDecimalNumberConverterRegistry();
+
+    /// <summary>
     /// A registry of ordinalizers used to localise Ordinalize method
     /// </summary>
     public static LocaliserRegistry<IOrdinalizer> Ordinalizers { get; } = new OrdinalizerRegistry();
@@ -65,6 +71,9 @@ public static class Configurator
 
     internal static IWordsToNumberConverter GetWordsToNumberConverter(CultureInfo culture) =>
         WordsToNumberConverters.ResolveForCulture(culture);
+
+    internal static IWordsToDecimalNumberConverter GetWordsToDecimalNumberConverter(CultureInfo culture) =>
+        WordsToDecimalNumberConverters.ResolveForCulture(culture);
 
 
 

--- a/src/Humanizer/Configuration/WordsToDecimalNumberConverterRegistry.cs
+++ b/src/Humanizer/Configuration/WordsToDecimalNumberConverterRegistry.cs
@@ -1,0 +1,13 @@
+namespace Humanizer;
+
+internal class WordsToDecimalNumberConverterRegistry : LocaliserRegistry<IWordsToDecimalNumberConverter>
+{
+    public WordsToDecimalNumberConverterRegistry()
+        : base(_ => UnsupportedWordsToDecimalNumberConverter.Instance)
+    {
+        Register(
+            "en",
+            static _ => new TokenMapWordsToDecimalNumberConverter(
+                (TokenMapWordsToNumberConverter)TokenMapWordsToNumberConverters.En));
+    }
+}

--- a/src/Humanizer/Configuration/WordsToDecimalNumberConverterRegistry.cs
+++ b/src/Humanizer/Configuration/WordsToDecimalNumberConverterRegistry.cs
@@ -4,10 +4,8 @@ internal class WordsToDecimalNumberConverterRegistry : LocaliserRegistry<IWordsT
 {
     public WordsToDecimalNumberConverterRegistry()
         : base(_ => UnsupportedWordsToDecimalNumberConverter.Instance)
-    {
-        Register(
+        => Register(
             "en",
             static _ => new TokenMapWordsToDecimalNumberConverter(
                 (TokenMapWordsToNumberConverter)TokenMapWordsToNumberConverters.En));
-    }
 }

--- a/src/Humanizer/Locales/en.yml
+++ b/src/Humanizer/Locales/en.yml
@@ -421,6 +421,9 @@ surfaces:
       allowTerminalOrdinalToken: true
       useHundredMultiplier: true
       allowInvariantIntegerInput: true
+      decimalMarkerTokens:
+        - 'point'
+      allowInvariantDecimalInput: true
 
   ordinal:
     numeric:

--- a/src/Humanizer/Localisation/WordsToNumber/GenderlessWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/GenderlessWordsToDecimalNumberConverter.cs
@@ -1,0 +1,17 @@
+namespace Humanizer;
+
+/// <summary>
+/// Provides the common contract for words-to-decimal-number converters that do not vary by
+/// grammatical gender.
+/// </summary>
+internal abstract class GenderlessWordsToDecimalNumberConverter : IWordsToDecimalNumberConverter
+{
+    /// <inheritdoc />
+    public abstract decimal Convert(string words);
+
+    /// <inheritdoc />
+    public abstract bool TryConvert(string words, out decimal parsedValue);
+
+    /// <inheritdoc />
+    public abstract bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+}

--- a/src/Humanizer/Localisation/WordsToNumber/IWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/IWordsToDecimalNumberConverter.cs
@@ -1,0 +1,32 @@
+namespace Humanizer;
+
+/// <summary>
+/// Converts localized decimal number words into numeric values.
+/// </summary>
+public interface IWordsToDecimalNumberConverter
+{
+    /// <summary>
+    /// Attempts to convert <paramref name="words"/> into a decimal value.
+    /// </summary>
+    /// <param name="words">The localized decimal number phrase to convert.</param>
+    /// <param name="parsedValue">When this method returns, contains the parsed decimal value.</param>
+    /// <returns><c>true</c> if the phrase was parsed successfully; otherwise, <c>false</c>.</returns>
+    bool TryConvert(string words, out decimal parsedValue);
+
+    /// <summary>
+    /// Attempts to convert <paramref name="words"/> into a decimal value and reports the first
+    /// unrecognized token when parsing fails.
+    /// </summary>
+    /// <param name="words">The localized decimal number phrase to convert.</param>
+    /// <param name="parsedValue">When this method returns, contains the parsed decimal value.</param>
+    /// <param name="unrecognizedNumber">When parsing fails, the first unrecognized token.</param>
+    /// <returns><c>true</c> if the phrase was parsed successfully; otherwise, <c>false</c>.</returns>
+    bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+
+    /// <summary>
+    /// Converts <paramref name="words"/> into a decimal value.
+    /// </summary>
+    /// <param name="words">The localized decimal number phrase to convert.</param>
+    /// <returns>The parsed decimal value.</returns>
+    decimal Convert(string words);
+}

--- a/src/Humanizer/Localisation/WordsToNumber/TokenMapWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/TokenMapWordsToDecimalNumberConverter.cs
@@ -1,0 +1,30 @@
+namespace Humanizer;
+
+/// <summary>
+/// Parses localized decimal number words using token-map rules from
+/// <see cref="TokenMapWordsToNumberConverter"/>.
+/// </summary>
+internal sealed class TokenMapWordsToDecimalNumberConverter(TokenMapWordsToNumberConverter converter)
+    : GenderlessWordsToDecimalNumberConverter
+{
+    readonly TokenMapWordsToNumberConverter converter = converter;
+
+    /// <inheritdoc />
+    public override decimal Convert(string words)
+    {
+        if (!TryConvert(words, out var parsedValue, out var unrecognizedWord))
+        {
+            throw new ArgumentException($"Unrecognized number word: {unrecognizedWord}");
+        }
+
+        return parsedValue;
+    }
+
+    /// <inheritdoc />
+    public override bool TryConvert(string words, out decimal parsedValue) =>
+        converter.TryConvertDecimal(words, out parsedValue, out _);
+
+    /// <inheritdoc />
+    public override bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber) =>
+        converter.TryConvertDecimal(words, out parsedValue, out unrecognizedNumber);
+}

--- a/src/Humanizer/Localisation/WordsToNumber/TokenMapWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/TokenMapWordsToNumberConverter.cs
@@ -294,7 +294,7 @@ internal class TokenMapWordsToNumberConverter(TokenMapWordsToNumberRules rules) 
             }
         }
 
-        decimal scale = 0.1m;
+        var scale = 0.1m;
         foreach (var token in WordsToNumberTokenizer.Enumerate(fractionPart))
         {
             var tokenText = token.ToString();

--- a/src/Humanizer/Localisation/WordsToNumber/TokenMapWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/TokenMapWordsToNumberConverter.cs
@@ -52,13 +52,6 @@ internal class TokenMapWordsToNumberConverter(TokenMapWordsToNumberRules rules) 
             return true;
         }
 
-        if (rules.AllowInvariantIntegerInput &&
-            long.TryParse(words.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out parsedValue))
-        {
-            unrecognizedWord = null;
-            return true;
-        }
-
         TryPrepareNormalizedPhrase(words, out var normalized, out var negative, out unrecognizedWord);
 
         if (TryParseOrdinal(normalized, out var value) ||
@@ -304,6 +297,12 @@ internal class TokenMapWordsToNumberConverter(TokenMapWordsToNumberRules rules) 
             }
 
             if (!rules.CardinalMap.TryGetValue(tokenText, out var digit) || digit is < 0 or > 9)
+            {
+                unrecognizedWord = tokenText;
+                return false;
+            }
+
+            if (scale == 0m)
             {
                 unrecognizedWord = tokenText;
                 return false;

--- a/src/Humanizer/Localisation/WordsToNumber/TokenMapWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/TokenMapWordsToNumberConverter.cs
@@ -52,8 +52,103 @@ internal class TokenMapWordsToNumberConverter(TokenMapWordsToNumberRules rules) 
             return true;
         }
 
+        if (rules.AllowInvariantIntegerInput &&
+            long.TryParse(words.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out parsedValue))
+        {
+            unrecognizedWord = null;
+            return true;
+        }
+
+        TryPrepareNormalizedPhrase(words, out var normalized, out var negative, out unrecognizedWord);
+
+        if (TryParseOrdinal(normalized, out var value) ||
+            TryParseCardinal(normalized, negative, out value, out unrecognizedWord))
+        {
+            parsedValue = value;
+            if (negative && parsedValue != long.MinValue)
+            {
+                parsedValue = -parsedValue;
+            }
+
+            unrecognizedWord = null;
+            return true;
+        }
+
+        parsedValue = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to convert a spelled-out decimal phrase into a <see cref="decimal"/> value.
+    /// </summary>
+    /// <param name="words">The localized decimal number phrase.</param>
+    /// <param name="parsedValue">When this method returns, contains the parsed decimal value.</param>
+    /// <param name="unrecognizedWord">When parsing fails, the first unrecognized token.</param>
+    /// <returns><c>true</c> if parsing succeeded; otherwise, <c>false</c>.</returns>
+    internal bool TryConvertDecimal(string words, out decimal parsedValue, out string? unrecognizedWord)
+    {
+        parsedValue = default;
+        unrecognizedWord = null;
+
+        if (rules.DecimalMarkerTokens.Length == 0)
+        {
+            unrecognizedWord = words;
+            return false;
+        }
+
+        TryPrepareNormalizedPhrase(words, out var normalized, out var negative, out unrecognizedWord);
+
+        if (!TrySplitOnDecimalMarker(normalized, out var integerPart, out var fractionPart, out unrecognizedWord))
+        {
+            return false;
+        }
+
+        long integerValue = 0;
+        if (integerPart.Length > 0 &&
+            !TryParseCardinal(integerPart, false, out integerValue, out unrecognizedWord))
+        {
+            return false;
+        }
+
+        if (!TryParseDecimalFraction(fractionPart, out var fractionValue, out unrecognizedWord))
+        {
+            return false;
+        }
+
+        try
+        {
+            parsedValue = decimal.Add(integerValue, fractionValue);
+        }
+        catch (OverflowException)
+        {
+            unrecognizedWord = words;
+            return false;
+        }
+
+        if (negative)
+        {
+            parsedValue = -parsedValue;
+        }
+
+        unrecognizedWord = null;
+        return true;
+    }
+
+    void TryPrepareNormalizedPhrase(
+        string words,
+        out string normalized,
+        out bool negative,
+        out string? unrecognizedWord)
+    {
+        unrecognizedWord = null;
+
+        if (string.IsNullOrWhiteSpace(words))
+        {
+            throw new ArgumentException("Input words cannot be empty.");
+        }
+
         var normalizedSource = words.Trim();
-        var negative = false;
+        negative = false;
 
         foreach (var negativePrefix in rules.NegativePrefixes)
         {
@@ -67,7 +162,7 @@ internal class TokenMapWordsToNumberConverter(TokenMapWordsToNumberRules rules) 
             break;
         }
 
-        var normalized = TokenMapWordsToNumberNormalizer.Normalize(normalizedSource, rules.NormalizationProfile);
+        normalized = TokenMapWordsToNumberNormalizer.Normalize(normalizedSource, rules.NormalizationProfile);
 
         if (!negative)
         {
@@ -110,21 +205,129 @@ internal class TokenMapWordsToNumberConverter(TokenMapWordsToNumberRules rules) 
             }
         }
 
-        if (TryParseOrdinal(normalized, out var value) ||
-            TryParseCardinal(normalized, negative, out value, out unrecognizedWord))
+        return;
+    }
+
+    bool TrySplitOnDecimalMarker(
+        string normalized,
+        out string integerPart,
+        out string fractionPart,
+        out string? unrecognizedWord)
+    {
+        integerPart = string.Empty;
+        fractionPart = string.Empty;
+        unrecognizedWord = null;
+
+        var markerIndex = -1;
+        string? matchedMarker = null;
+
+        foreach (var marker in rules.DecimalMarkerTokens)
         {
-            parsedValue = value;
-            if (negative && parsedValue != long.MinValue)
+            if (marker.Length == 0)
             {
-                parsedValue = -parsedValue;
+                continue;
             }
 
-            unrecognizedWord = null;
-            return true;
+            var index = 0;
+            while (index <= normalized.Length)
+            {
+                var found = normalized.IndexOf(marker, index, StringComparison.Ordinal);
+                if (found < 0)
+                {
+                    break;
+                }
+
+                var hasLeadingBoundary = found == 0 || normalized[found - 1] == ' ';
+                var end = found + marker.Length;
+                var hasTrailingBoundary = end == normalized.Length || normalized[end] == ' ';
+                if (hasLeadingBoundary && hasTrailingBoundary)
+                {
+                    markerIndex = found;
+                    matchedMarker = marker;
+                    break;
+                }
+
+                index = found + marker.Length;
+            }
+
+            if (matchedMarker is not null)
+            {
+                break;
+            }
         }
 
-        parsedValue = default;
-        return false;
+        if (matchedMarker is null)
+        {
+            unrecognizedWord = normalized;
+            return false;
+        }
+
+        integerPart = normalized[..markerIndex].Trim();
+        fractionPart = normalized[(markerIndex + matchedMarker.Length)..].Trim();
+        if (fractionPart.Length == 0)
+        {
+            unrecognizedWord = normalized;
+            return false;
+        }
+
+        return true;
+    }
+
+    bool TryParseDecimalFraction(string fractionPart, out decimal fractionValue, out string? unrecognizedWord)
+    {
+        fractionValue = default;
+        unrecognizedWord = null;
+
+        if (rules.AllowInvariantDecimalInput)
+        {
+            var compactFraction = fractionPart.Replace(" ", string.Empty);
+            if (compactFraction.Length > 0 &&
+                compactFraction.All(static c => c is >= '0' and <= '9') &&
+                decimal.TryParse(
+                    "0." + compactFraction,
+                    NumberStyles.Number,
+                    CultureInfo.InvariantCulture,
+                    out var invariantFraction))
+            {
+                fractionValue = invariantFraction;
+                return true;
+            }
+        }
+
+        decimal scale = 0.1m;
+        foreach (var token in WordsToNumberTokenizer.Enumerate(fractionPart))
+        {
+            var tokenText = token.ToString();
+            if (ShouldIgnore(tokenText))
+            {
+                continue;
+            }
+
+            if (!rules.CardinalMap.TryGetValue(tokenText, out var digit) || digit is < 0 or > 9)
+            {
+                unrecognizedWord = tokenText;
+                return false;
+            }
+
+            try
+            {
+                fractionValue += digit * scale;
+                scale /= 10m;
+            }
+            catch (OverflowException)
+            {
+                unrecognizedWord = fractionPart;
+                return false;
+            }
+        }
+
+        if (scale == 0.1m)
+        {
+            unrecognizedWord = fractionPart;
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -1238,6 +1441,10 @@ internal sealed class TokenMapWordsToNumberRules
     /// </summary>
     public string[] IgnoredTokens { get; init; } = [];
     /// <summary>
+    /// Gets the tokens that split integer and fractional parts of a decimal number phrase.
+    /// </summary>
+    public string[] DecimalMarkerTokens { get; init; } = [];
+    /// <summary>
     /// Gets the leading prefixes that should be trimmed from each token.
     /// </summary>
     public string[] LeadingTokenPrefixesToTrim { get; init; } = [];
@@ -1273,6 +1480,10 @@ internal sealed class TokenMapWordsToNumberRules
     /// Gets a value indicating whether invariant integer input is accepted directly.
     /// </summary>
     public bool AllowInvariantIntegerInput { get; init; }
+    /// <summary>
+    /// Gets a value indicating whether invariant decimal input is accepted in the fractional part.
+    /// </summary>
+    public bool AllowInvariantDecimalInput { get; init; }
     /// <summary>
     /// Gets the base value used when a unit token forms a teen compound.
     /// </summary>

--- a/src/Humanizer/Localisation/WordsToNumber/UnsupportedWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/UnsupportedWordsToDecimalNumberConverter.cs
@@ -1,0 +1,32 @@
+namespace Humanizer;
+
+/// <summary>
+/// Fallback converter used when a locale does not support decimal word parsing.
+/// </summary>
+internal sealed class UnsupportedWordsToDecimalNumberConverter : GenderlessWordsToDecimalNumberConverter
+{
+    public static UnsupportedWordsToDecimalNumberConverter Instance { get; } = new();
+
+    UnsupportedWordsToDecimalNumberConverter()
+    {
+    }
+
+    /// <inheritdoc />
+    public override decimal Convert(string words) =>
+        throw new NotSupportedException("Decimal word parsing is not supported for the requested culture.");
+
+    /// <inheritdoc />
+    public override bool TryConvert(string words, out decimal parsedValue)
+    {
+        parsedValue = default;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public override bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber)
+    {
+        parsedValue = default;
+        unrecognizedNumber = words;
+        return false;
+    }
+}

--- a/src/Humanizer/Localisation/WordsToNumber/UnsupportedWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/UnsupportedWordsToDecimalNumberConverter.cs
@@ -5,7 +5,10 @@ namespace Humanizer;
 /// </summary>
 internal sealed class UnsupportedWordsToDecimalNumberConverter : GenderlessWordsToDecimalNumberConverter
 {
-    public static UnsupportedWordsToDecimalNumberConverter Instance { get; } = new();
+    /// <summary>
+    /// Gets the shared fallback converter instance.
+    /// </summary>
+    internal static UnsupportedWordsToDecimalNumberConverter Instance { get; } = new();
 
     UnsupportedWordsToDecimalNumberConverter()
     {

--- a/src/Humanizer/WordsToDecimalNumberExtension.cs
+++ b/src/Humanizer/WordsToDecimalNumberExtension.cs
@@ -1,0 +1,41 @@
+namespace Humanizer;
+
+/// <summary>
+/// Converts localized decimal number words back into numeric values.
+/// </summary>
+public static class WordsToDecimalNumberExtension
+{
+    /// <summary>
+    /// Converts a spelled-out decimal number string to its numeric representation.
+    /// </summary>
+    /// <param name="words">The spelled-out decimal number.</param>
+    /// <param name="culture">The culture to use for parsing.</param>
+    /// <returns>The decimal value represented by <paramref name="words"/>.</returns>
+    public static decimal ToDecimalNumber(this string words, CultureInfo culture) =>
+        Configurator.GetWordsToDecimalNumberConverter(culture).Convert(words);
+
+    /// <summary>
+    /// Attempts to convert a spelled-out decimal number string to its numeric representation.
+    /// </summary>
+    /// <param name="words">The spelled-out decimal number.</param>
+    /// <param name="parsedNumber">When this method returns, contains the parsed value if successful.</param>
+    /// <param name="culture">The culture to use for parsing.</param>
+    /// <returns><c>true</c> if the conversion was successful; otherwise, <c>false</c>.</returns>
+    public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, CultureInfo culture) =>
+        Configurator.GetWordsToDecimalNumberConverter(culture).TryConvert(words, out parsedNumber);
+
+    /// <summary>
+    /// Attempts to convert a spelled-out decimal number string and reports the first unrecognized word.
+    /// </summary>
+    /// <param name="words">The spelled-out decimal number.</param>
+    /// <param name="parsedNumber">When this method returns, contains the parsed value if successful.</param>
+    /// <param name="culture">The culture to use for parsing.</param>
+    /// <param name="unrecognizedWord">When parsing fails, the first unrecognized token.</param>
+    /// <returns><c>true</c> if the conversion was successful; otherwise, <c>false</c>.</returns>
+    public static bool TryToDecimalNumber(
+        this string words,
+        out decimal parsedNumber,
+        CultureInfo culture,
+        out string? unrecognizedWord) =>
+        Configurator.GetWordsToDecimalNumberConverter(culture).TryConvert(words, out parsedNumber, out unrecognizedWord);
+}

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.cs
@@ -328,6 +328,8 @@ surfaces:
   "allowTerminalOrdinalToken": true,
   "useHundredMultiplier": true,
   "allowInvariantIntegerInput": true,
+  "decimalMarkerTokens": [ "point" ],
+  "allowInvariantDecimalInput": true,
   "teenBaseValue": 11,
   "hundredSuffixValue": 101,
   "unitTokenMinValue": 2,
@@ -353,6 +355,8 @@ surfaces:
         Assert.Contains("AllowTerminalOrdinalToken = true", fullExpression);
         Assert.Contains("UseHundredMultiplier = true", fullExpression);
         Assert.Contains("AllowInvariantIntegerInput = true", fullExpression);
+        Assert.Contains("DecimalMarkerTokens = new string[] { \"point\" }", fullExpression);
+        Assert.Contains("AllowInvariantDecimalInput = true", fullExpression);
         Assert.Contains("TeenBaseValue = 11", fullExpression);
         Assert.Contains("HundredSuffixValue = 101", fullExpression);
         Assert.Contains("UnitTokenMinValue = 2", fullExpression);

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.cs
@@ -387,6 +387,8 @@ surfaces:
         Assert.Contains("AllowTerminalOrdinalToken = false", minimalExpression);
         Assert.Contains("UseHundredMultiplier = false", minimalExpression);
         Assert.Contains("AllowInvariantIntegerInput = false", minimalExpression);
+        Assert.Contains("DecimalMarkerTokens = Array.Empty<string>()", minimalExpression);
+        Assert.Contains("AllowInvariantDecimalInput = false", minimalExpression);
         Assert.Contains("TeenBaseValue = 10", minimalExpression);
         Assert.Contains("HundredSuffixValue = 100", minimalExpression);
         Assert.Contains("UnitTokenMinValue = 1", minimalExpression);

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -384,6 +384,12 @@ namespace Humanizer
         bool TryConvert(string words, out long parsedValue);
         bool TryConvert(string words, out long parsedValue, out string? unrecognizedNumber);
     }
+    public interface IWordsToDecimalNumberConverter
+    {
+        decimal Convert(string words);
+        bool TryConvert(string words, out decimal parsedValue);
+        bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+    }
     public class In
     {
         public In() { }
@@ -1956,5 +1962,11 @@ namespace Humanizer
         public static long ToNumber(this string words, System.Globalization.CultureInfo culture) { }
         public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture) { }
         public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
+    }
+    public static class WordsToDecimalNumberExtension
+    {
+        public static decimal ToDecimalNumber(this string words, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
     }
 }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -378,17 +378,17 @@ namespace Humanizer
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("value")]
         string? Truncate(string? value, int length, string? truncationString, Humanizer.TruncateFrom truncateFrom = 1);
     }
-    public interface IWordsToNumberConverter
-    {
-        long Convert(string words);
-        bool TryConvert(string words, out long parsedValue);
-        bool TryConvert(string words, out long parsedValue, out string? unrecognizedNumber);
-    }
     public interface IWordsToDecimalNumberConverter
     {
         decimal Convert(string words);
         bool TryConvert(string words, out decimal parsedValue);
         bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+    }
+    public interface IWordsToNumberConverter
+    {
+        long Convert(string words);
+        bool TryConvert(string words, out long parsedValue);
+        bool TryConvert(string words, out long parsedValue, out string? unrecognizedNumber);
     }
     public class In
     {
@@ -1957,16 +1957,16 @@ namespace Humanizer
         Abbreviation = 1,
         Eifeler = 2,
     }
-    public static class WordsToNumberExtension
-    {
-        public static long ToNumber(this string words, System.Globalization.CultureInfo culture) { }
-        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture) { }
-        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
-    }
     public static class WordsToDecimalNumberExtension
     {
         public static decimal ToDecimalNumber(this string words, System.Globalization.CultureInfo culture) { }
         public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture) { }
         public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
+    }
+    public static class WordsToNumberExtension
+    {
+        public static long ToNumber(this string words, System.Globalization.CultureInfo culture) { }
+        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture) { }
+        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
     }
 }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -384,6 +384,12 @@ namespace Humanizer
         bool TryConvert(string words, out long parsedValue);
         bool TryConvert(string words, out long parsedValue, out string? unrecognizedNumber);
     }
+    public interface IWordsToDecimalNumberConverter
+    {
+        decimal Convert(string words);
+        bool TryConvert(string words, out decimal parsedValue);
+        bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+    }
     public class In
     {
         public In() { }
@@ -1956,5 +1962,11 @@ namespace Humanizer
         public static long ToNumber(this string words, System.Globalization.CultureInfo culture) { }
         public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture) { }
         public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
+    }
+    public static class WordsToDecimalNumberExtension
+    {
+        public static decimal ToDecimalNumber(this string words, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
     }
 }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -378,17 +378,17 @@ namespace Humanizer
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("value")]
         string? Truncate(string? value, int length, string? truncationString, Humanizer.TruncateFrom truncateFrom = 1);
     }
-    public interface IWordsToNumberConverter
-    {
-        long Convert(string words);
-        bool TryConvert(string words, out long parsedValue);
-        bool TryConvert(string words, out long parsedValue, out string? unrecognizedNumber);
-    }
     public interface IWordsToDecimalNumberConverter
     {
         decimal Convert(string words);
         bool TryConvert(string words, out decimal parsedValue);
         bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+    }
+    public interface IWordsToNumberConverter
+    {
+        long Convert(string words);
+        bool TryConvert(string words, out long parsedValue);
+        bool TryConvert(string words, out long parsedValue, out string? unrecognizedNumber);
     }
     public class In
     {
@@ -1957,16 +1957,16 @@ namespace Humanizer
         Abbreviation = 1,
         Eifeler = 2,
     }
-    public static class WordsToNumberExtension
-    {
-        public static long ToNumber(this string words, System.Globalization.CultureInfo culture) { }
-        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture) { }
-        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
-    }
     public static class WordsToDecimalNumberExtension
     {
         public static decimal ToDecimalNumber(this string words, System.Globalization.CultureInfo culture) { }
         public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture) { }
         public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
+    }
+    public static class WordsToNumberExtension
+    {
+        public static long ToNumber(this string words, System.Globalization.CultureInfo culture) { }
+        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture) { }
+        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
     }
 }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -383,6 +383,12 @@ namespace Humanizer
         bool TryConvert(string words, out long parsedValue);
         bool TryConvert(string words, out long parsedValue, out string? unrecognizedNumber);
     }
+    public interface IWordsToDecimalNumberConverter
+    {
+        decimal Convert(string words);
+        bool TryConvert(string words, out decimal parsedValue);
+        bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+    }
     public class In
     {
         public In() { }
@@ -1955,5 +1961,11 @@ namespace Humanizer
         public static long ToNumber(this string words, System.Globalization.CultureInfo culture) { }
         public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture) { }
         public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
+    }
+    public static class WordsToDecimalNumberExtension
+    {
+        public static decimal ToDecimalNumber(this string words, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
     }
 }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -377,17 +377,17 @@ namespace Humanizer
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("value")]
         string? Truncate(string? value, int length, string? truncationString, Humanizer.TruncateFrom truncateFrom = 1);
     }
-    public interface IWordsToNumberConverter
-    {
-        long Convert(string words);
-        bool TryConvert(string words, out long parsedValue);
-        bool TryConvert(string words, out long parsedValue, out string? unrecognizedNumber);
-    }
     public interface IWordsToDecimalNumberConverter
     {
         decimal Convert(string words);
         bool TryConvert(string words, out decimal parsedValue);
         bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+    }
+    public interface IWordsToNumberConverter
+    {
+        long Convert(string words);
+        bool TryConvert(string words, out long parsedValue);
+        bool TryConvert(string words, out long parsedValue, out string? unrecognizedNumber);
     }
     public class In
     {
@@ -1956,16 +1956,16 @@ namespace Humanizer
         Abbreviation = 1,
         Eifeler = 2,
     }
-    public static class WordsToNumberExtension
-    {
-        public static long ToNumber(this string words, System.Globalization.CultureInfo culture) { }
-        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture) { }
-        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
-    }
     public static class WordsToDecimalNumberExtension
     {
         public static decimal ToDecimalNumber(this string words, System.Globalization.CultureInfo culture) { }
         public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture) { }
         public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
+    }
+    public static class WordsToNumberExtension
+    {
+        public static long ToNumber(this string words, System.Globalization.CultureInfo culture) { }
+        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture) { }
+        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
     }
 }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -336,17 +336,17 @@ namespace Humanizer
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("value")]
         string? Truncate(string? value, int length, string? truncationString, Humanizer.TruncateFrom truncateFrom = 1);
     }
-    public interface IWordsToNumberConverter
-    {
-        long Convert(string words);
-        bool TryConvert(string words, out long parsedValue);
-        bool TryConvert(string words, out long parsedValue, out string? unrecognizedNumber);
-    }
     public interface IWordsToDecimalNumberConverter
     {
         decimal Convert(string words);
         bool TryConvert(string words, out decimal parsedValue);
         bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+    }
+    public interface IWordsToNumberConverter
+    {
+        long Convert(string words);
+        bool TryConvert(string words, out long parsedValue);
+        bool TryConvert(string words, out long parsedValue, out string? unrecognizedNumber);
     }
     public class In
     {
@@ -1292,16 +1292,16 @@ namespace Humanizer
         Abbreviation = 1,
         Eifeler = 2,
     }
-    public static class WordsToNumberExtension
-    {
-        public static long ToNumber(this string words, System.Globalization.CultureInfo culture) { }
-        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture) { }
-        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
-    }
     public static class WordsToDecimalNumberExtension
     {
         public static decimal ToDecimalNumber(this string words, System.Globalization.CultureInfo culture) { }
         public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture) { }
         public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
+    }
+    public static class WordsToNumberExtension
+    {
+        public static long ToNumber(this string words, System.Globalization.CultureInfo culture) { }
+        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture) { }
+        public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
     }
 }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -342,6 +342,12 @@ namespace Humanizer
         bool TryConvert(string words, out long parsedValue);
         bool TryConvert(string words, out long parsedValue, out string? unrecognizedNumber);
     }
+    public interface IWordsToDecimalNumberConverter
+    {
+        decimal Convert(string words);
+        bool TryConvert(string words, out decimal parsedValue);
+        bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+    }
     public class In
     {
         public In() { }
@@ -1291,5 +1297,11 @@ namespace Humanizer
         public static long ToNumber(this string words, System.Globalization.CultureInfo culture) { }
         public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture) { }
         public static bool TryToNumber(this string words, out long parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
+    }
+    public static class WordsToDecimalNumberExtension
+    {
+        public static decimal ToDecimalNumber(this string words, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
     }
 }

--- a/tests/Humanizer.Tests/WordsToDecimalNumberTests.cs
+++ b/tests/Humanizer.Tests/WordsToDecimalNumberTests.cs
@@ -25,6 +25,19 @@ public class WordsToDecimalNumberTests_US
     }
 
     [Fact]
+    public void TryToDecimalNumberFailsWhenFractionExceedsDecimalPrecision()
+    {
+        var words = "zero point " + string.Join(' ', Enumerable.Repeat("one", 30));
+
+        Assert.False(words.TryToDecimalNumber(
+            out var parsedNumber,
+            CultureInfo.CurrentCulture,
+            out var unrecognizedWord));
+        Assert.Equal(0m, parsedNumber);
+        Assert.Equal("one", unrecognizedWord);
+    }
+
+    [Fact]
     public void IntegerToNumberDoesNotParseDecimalPhrases()
     {
         Assert.False("one point two".TryToNumber(out _, CultureInfo.CurrentCulture, out var unrecognizedWord));

--- a/tests/Humanizer.Tests/WordsToDecimalNumberTests.cs
+++ b/tests/Humanizer.Tests/WordsToDecimalNumberTests.cs
@@ -1,0 +1,33 @@
+namespace Humanizer.Tests;
+
+[UseCulture("en-US")]
+public class WordsToDecimalNumberTests_US
+{
+    [Theory]
+    [InlineData("one point two", 1.2)]
+    [InlineData("three point one four", 3.14)]
+    [InlineData("zero point five", 0.5)]
+    [InlineData("minus two point five", -2.5)]
+    [InlineData("one hundred point two five", 100.25)]
+    [InlineData("point five", 0.5)]
+    public void ParsesEnglishDecimalPhrases(string words, decimal expected) =>
+        Assert.Equal(expected, words.ToDecimalNumber(CultureInfo.CurrentCulture));
+
+    [Fact]
+    public void TryToDecimalNumberReportsUnrecognizedFractionToken()
+    {
+        Assert.False("three point mystery".TryToDecimalNumber(
+            out var parsedNumber,
+            CultureInfo.CurrentCulture,
+            out var unrecognizedWord));
+        Assert.Equal(0m, parsedNumber);
+        Assert.Equal("mystery", unrecognizedWord);
+    }
+
+    [Fact]
+    public void IntegerToNumberDoesNotParseDecimalPhrases()
+    {
+        Assert.False("one point two".TryToNumber(out _, CultureInfo.CurrentCulture, out var unrecognizedWord));
+        Assert.Equal("point", unrecognizedWord);
+    }
+}

--- a/tests/Humanizer.Tests/WordsToDecimalNumberTests.cs
+++ b/tests/Humanizer.Tests/WordsToDecimalNumberTests.cs
@@ -27,7 +27,7 @@ public class WordsToDecimalNumberTests_US
     [Fact]
     public void TryToDecimalNumberFailsWhenFractionExceedsDecimalPrecision()
     {
-        var words = "zero point " + string.Join(' ', Enumerable.Repeat("one", 30));
+        var words = "zero point " + string.Join(" ", Enumerable.Repeat("one", 30));
 
         Assert.False(words.TryToDecimalNumber(
             out var parsedNumber,


### PR DESCRIPTION
## Summary
- Adds `ToDecimalNumber` / `TryToDecimalNumber` as a separate API returning `decimal` (does not change existing `ToNumber` semantics).
- Introduces `IWordsToDecimalNumberConverter` with English registration via `decimalMarkerTokens: ['point']` in `en.yml`.
- Extends the token-map engine to split on decimal markers and parse fractional digits word-by-word.

## Test plan
- [ ] `"one point two"` → `1.2`
- [ ] `"three point one four"` → `3.14`
- [ ] `"one point two".TryToNumber(...)` still fails (integer API unchanged)
- [ ] Azure Humanizer-CI green

Fixes #1739 (English MVP; Hindi/Urdu deferred).