### PR TITLE
docs: fix broken links in docs index and cross-references (#1659)

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -191,6 +191,6 @@ Configurator.CollectionFormatters.Register("my-culture",
 
 ## Related Topics
 
-- [Custom Vocabularies](custom-vocabularies.md) - Detailed pluralization customization
+- [Custom Vocabularies](../readme.md#adding-words) - Detailed pluralization customization
 - [Localization](localization.md) - Multi-language support
-- [Configuration](configuration.md) - Global configuration options
+- [Configuration](../readme.md#mix-this-into-your-framework-to-simplify-your-life) - Global configuration options

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,63 +9,69 @@ Humanizer meets all your .NET needs for manipulating and displaying strings, enu
 
 ## Core Features
 
+Detailed examples for most features live in the [project README](../readme.md#features). Topic-specific guides that ship in this folder are linked below.
+
 ### String Manipulation
+
 - [String Humanization](string-humanization.md) - Transform computerized strings to human-readable text
 - [String Dehumanization](string-dehumanization.md) - Convert back to PascalCase
-- [String Transformations](string-transformations.md) - Apply custom transformations with IStringTransformer
 - [String Truncation](string-truncation.md) - Intelligent truncation strategies
+- [String Transformations](../readme.md#transform-string) - Apply custom transformations with `IStringTransformer`
 
 ### Enumerations
-- [Enum Humanization](enum-humanization.md) - Make enums readable
-- [Enum Dehumanization](enum-dehumanization.md) - Parse strings back to enums
+
+- [Enum Humanization](../readme.md#humanize-enums) - Make enums readable
+- [Enum Dehumanization](../readme.md#dehumanize-enums) - Parse strings back to enums
 
 ### Date and Time
-- [DateTime Humanization](datetime-humanization.md) - Relative time ("2 hours ago", "tomorrow")
-- [TimeSpan Humanization](timespan-humanization.md) - Human-readable durations
-- [Fluent Date API](fluent-date.md) - Readable date/time construction and manipulation
-- [DateTime to Ordinal Words](datetime-ordinal-words.md) - "1st of January 2020"
-- [TimeOnly to Clock Notation](timeonly-clock-notation.md) - "half past two" (.NET 6+)
+
+- [DateTime Humanization](../readme.md#humanize-datetime) - Relative time ("2 hours ago", "tomorrow")
+- [TimeSpan Humanization](../readme.md#humanize-timespan) - Human-readable durations
+- [Fluent Date API](../readme.md#fluent-date) - Readable date/time construction and manipulation
+- [DateTime to Ordinal Words](../readme.md#datetime-to-ordinal-words) - "1st of January 2020"
+- [TimeOnly to Clock Notation](../readme.md#timeonly-to-clock-notation) - "half past two" (.NET 6+)
 
 ### Numbers
-- [Number to Words](number-to-words.md) - "123" → "one hundred twenty-three"
-- [Number to Ordinal Words](number-to-ordinal-words.md) - "1" → "first"
-- [Words to Number](words-to-number.md) - "forty-two" → 42
-- [Ordinalization](ordinalization.md) - "1" → "1st"
-- [Roman Numerals](roman-numerals.md) - Convert to/from Roman numerals
-- [Metric Numerals](metric-numerals.md) - "1230" → "1.23k"
-- [Number to Numbers](number-to-numbers.md) - Fluent API for large numbers
-- [Tupleize](tupleize.md) - "2" → "double"
+
+- [Number to Words](../readme.md#number-to-words) - "123" → "one hundred twenty-three"
+- [Number to Ordinal Words](../readme.md#number-to-ordinal-words) - "1" → "first"
+- [Words to Number](../readme.md#words-to-number-conversion) - "forty-two" → 42
+- [Ordinalization](../readme.md#ordinalize) - "1" → "1st"
+- [Roman Numerals](../readme.md#roman-numerals) - Convert to/from Roman numerals
+- [Metric Numerals](../readme.md#metric-numerals) - "1230" → "1.23k"
+- [Number to Numbers](../readme.md#number-to-numbers) - Fluent API for large numbers
+- [Tupleize](../readme.md#tupleize) - "2" → "double"
 
 ### Collections
-- [Collection Humanization](collection-humanization.md) - Turn lists into "item1, item2, and item3"
-- [ToQuantity](to-quantity.md) - "5 cases", "1 man", "2 men"
+
+- [Collection Humanization](../readme.md#humanize-collections) - Turn lists into "item1, item2, and item3"
+- [ToQuantity](../readme.md#toquantity) - "5 cases", "1 man", "2 men"
 
 ### Word Manipulation
-- [Pluralization](pluralization.md) - Handle singular/plural forms
-- [Singularization](singularization.md) - Convert plurals to singular
-- [Inflector Methods](inflector-methods.md) - Pascalize, Camelize, Underscore, Kebaberize, etc.
+
+- [Pluralization](../readme.md#pluralize) - Handle singular/plural forms
+- [Singularization](../readme.md#singularize) - Convert plurals to singular
+- [Inflector Methods](../readme.md#inflector-methods) - Pascalize, Camelize, Underscore, Kebaberize, etc.
 
 ### Specialized Features
-- [ByteSize](bytesize.md) - Human-readable byte sizes
-- [Heading](heading.md) - Convert headings to text
-- [Time Unit Symbols](time-unit-symbols.md) - "ms", "s", "min", etc.
+
+- [ByteSize](../readme.md#bytesize) - Human-readable byte sizes
+- [Heading](../readme.md#heading-to-words) - Convert headings to text
+- [Time Unit Symbols](../readme.md#time-unit-to-symbol) - "ms", "s", "min", etc.
 
 ## Advanced Topics
 
 - [Localization](localization.md) - Multi-language support, YAML locale data, and inheritance
-- [Custom Vocabularies](custom-vocabularies.md) - Add custom pluralization rules
+- [Adding a Locale](adding-a-locale.md) - Contributor workflow for new locales
+- [Locale YAML How-To](locale-yaml-how-to.md) - Practical YAML authoring guide
+- [Locale YAML Reference](locale-yaml-reference.md) - Schema reference for locale files
 - [Extensibility](extensibility.md) - Implement custom transformers and truncators
-- [Configuration](configuration.md) - Customize Humanizer behavior
 
 ## Migration Guides
 
 - [Migrating from 2.14.1 to 3.0.8](migration-v3.md) - Comprehensive breaking changes, patch-line fixes, and known regressions
 - [Namespace migration details](v3-namespace-migration.md) - Namespace-only migration guidance and analyzer usage
 
-## API Reference
-
-- [Complete API Reference](api-reference.md) - Full API documentation
-
 ## Contributing
 
-- [Contributing Guide](../CONTRIBUTING.md) - How to contribute to Humanizer
+- [Contributing Guide](../.github/CONTRIBUTING.md) - How to contribute to Humanizer

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,4 +47,4 @@ DateTime.UtcNow.AddHours(-2).Humanize(); // Returns "2 hours ago"
 - [Quick Start Guide](quick-start.md)
 - [Migration from 2.14.1 to 3.0.8](migration-v3.md)
 - [String Humanization](string-humanization.md)
-- [DateTime Humanization](datetime-humanization.md)
+- [DateTime Humanization](../readme.md#humanize-datetime)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -173,7 +173,7 @@ $"You have {singleItem} {"item".ToQuantity(singleItem)}";
 Explore the documentation for detailed information on each feature:
 
 - [String Humanization](string-humanization.md)
-- [DateTime Humanization](datetime-humanization.md)
-- [Number Conversions](number-to-words.md)
-- [Pluralization](pluralization.md)
+- [DateTime Humanization](../readme.md#humanize-datetime)
+- [Number Conversions](../readme.md#number-to-words)
+- [Pluralization](../readme.md#pluralize)
 - [All Features](index.md)

--- a/docs/string-dehumanization.md
+++ b/docs/string-dehumanization.md
@@ -39,4 +39,4 @@ If the input is already in PascalCase (contains no spaces), it is returned uncha
 ## Related Topics
 
 - [String Humanization](string-humanization.md)
-- [Inflector Methods](inflector-methods.md) - Pascalize, Camelize
+- [Inflector Methods](../readme.md#inflector-methods) - Pascalize, Camelize

--- a/docs/string-humanization.md
+++ b/docs/string-humanization.md
@@ -136,5 +136,5 @@ In version 3.0, `Humanize` and `Titleize` now preserve input strings that contai
 ## Related Topics
 
 - [String Dehumanization](string-dehumanization.md) - Convert back to PascalCase
-- [String Transformations](string-transformations.md) - Custom transformations
-- [Inflector Methods](inflector-methods.md) - Titleize, Pascalize, Camelize, etc.
+- [String Transformations](../readme.md#transform-string) - Custom transformations
+- [Inflector Methods](../readme.md#inflector-methods) - Titleize, Pascalize, Camelize, etc.

--- a/docs/string-truncation.md
+++ b/docs/string-truncation.md
@@ -178,4 +178,4 @@ var notification = comment.Truncate(40);
 ## Related Topics
 
 - [String Humanization](string-humanization.md)
-- [String Transformations](string-transformations.md)
+- [String Transformations](../readme.md#transform-string)


### PR DESCRIPTION
## Summary
- Rewrites `docs/index.md` so every link resolves on GitHub (either to a file in `docs/` or to README feature anchors)
- Fixes the same class of broken cross-links in `quick-start.md`, `installation.md`, `string-*.md`, and `extensibility.md`

Fixes #1659.

Many topic pages referenced from the index were removed during the v3 docs consolidation; feature examples now live primarily in `readme.md`. This PR keeps the docs hub useful without reintroducing duplicate pages.

## Test plan
- [x] Verified all remaining `docs/*.md` internal links target files that exist in the repo
- [ ] CI (Azure Humanizer-CI + GitHub checks)