### PR TITLE
Rebase: Add UseScaleWord format to auto-select scale based on locale (#1675)

### DIFF
--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -494,6 +494,16 @@ public static class MetricNumeralExtensions
             {
                 return UnitPrefixes[symbol].LongScaleWord;
             }
+            
+            if (formatValue.HasFlag(MetricNumeralFormats.UseScaleWord))
+            {
+                var culture = CultureInfo.CurrentUICulture;
+                var isLongScale = LongScaleCultures.Contains(culture.Name)
+                               || LongScaleCultures.Contains(culture.TwoLetterISOLanguageName);
+                return isLongScale
+                    ? UnitPrefixes[symbol].LongScaleWord
+                    : UnitPrefixes[symbol].ShortScaleWord;
+            }
         }
 
         return symbol.ToString();
@@ -536,4 +546,25 @@ public static class MetricNumeralExtensions
         public string ShortScaleWord { get; } = shortScaleWord;
         public readonly string LongScaleWord => longScaleWord ?? ShortScaleWord;
     }
+
+    /// <summary>
+    /// A set of culture codes that use the <a href="https://en.wikipedia.org/wiki/Long_and_short_scales">long scale</a> system.
+    /// In the long scale, <c>1E9</c> is a <c>milliard</c> and <c>1E12</c> is a <c>billion</c>.
+    /// Cultures not in this set are assumed to use the short scale, where <c>1E9</c> is a <c>billion</c>.
+    /// Used by <see cref="MetricNumeralFormats.UseScaleWord"/> to automatically select the correct scale word
+    /// based on <see cref="System.Globalization.CultureInfo.CurrentUICulture"/>.
+    /// </summary>
+    static readonly HashSet<string> LongScaleCultures =
+    [
+        "de", "de-DE",  // German
+        "fr", "fr-FR",  // French
+        "it", "it-IT",  // Italian
+        "es", "es-ES",  // Spanish
+        "pt", "pt-PT",  // Portuguese
+        "nl", "nl-NL",  // Dutch
+        "ru", "ru-RU",  // Russian
+        "pl", "pl-PL",  // Polish
+        "tr", "tr-TR"   // Turkish
+                        // Short scale cultures (not listed): en, en-US, en-GB, zh, ja, etc.
+    ];
 }

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -494,7 +494,7 @@ public static class MetricNumeralExtensions
             {
                 return UnitPrefixes[symbol].LongScaleWord;
             }
-            
+
             if (formatValue.HasFlag(MetricNumeralFormats.UseScaleWord))
             {
                 var culture = CultureInfo.CurrentUICulture;

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -556,15 +556,27 @@ public static class MetricNumeralExtensions
     /// </summary>
     static readonly HashSet<string> LongScaleCultures =
     [
-        "de", "de-DE",  // German
-        "fr", "fr-FR",  // French
-        "it", "it-IT",  // Italian
-        "es", "es-ES",  // Spanish
-        "pt", "pt-PT",  // Portuguese
-        "nl", "nl-NL",  // Dutch
-        "ru", "ru-RU",  // Russian
-        "pl", "pl-PL",  // Polish
-        "tr", "tr-TR"   // Turkish
-                        // Short scale cultures (not listed): en, en-US, en-GB, zh, ja, etc.
+        "de", "de-DE", "de-AT", "de-CH",  // German
+        "fr", "fr-FR", "fr-BE", "fr-CH",  // French
+        "it", "it-IT", "it-CH",            // Italian
+        "es", "es-ES",                     // Spanish
+        "pt", "pt-PT",                     // Portuguese (NOT pt-BR - Brazil uses short scale)
+        "nl", "nl-NL", "nl-BE",            // Dutch
+        "ru", "ru-RU",                     // Russian
+        "pl", "pl-PL",                     // Polish
+        "tr", "tr-TR",                     // Turkish
+        "cs", "cs-CZ",                     // Czech (miliarda for 1E9)
+        "sk", "sk-SK",                     // Slovak
+        "hr", "hr-HR",                     // Croatian
+        "ro", "ro-RO",                     // Romanian
+        "sl", "sl-SI",                     // Slovenian
+        "uk", "uk-UA",                     // Ukrainian
+        "he", "he-IL",                     // Hebrew (מיליארד for 1E9)
+        "ar", "ar-SA",                     // Arabic
+        "hu", "hu-HU",                     // Hungarian
+        "fi", "fi-FI",                     // Finnish
+        "nb", "nb-NO",                     // Norwegian
+        "sv", "sv-SE",                     // Swedish
+        "da", "da-DK",                     // Danish
     ];
 }

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -498,6 +498,11 @@ public static class MetricNumeralExtensions
             if (formatValue.HasFlag(MetricNumeralFormats.UseScaleWord))
             {
                 var culture = CultureInfo.CurrentUICulture;
+                if (ShortScaleCultureExceptions.Contains(culture.Name))
+                {
+                    return UnitPrefixes[symbol].ShortScaleWord;
+                }
+
                 var isLongScale = LongScaleCultures.Contains(culture.Name)
                                || LongScaleCultures.Contains(culture.TwoLetterISOLanguageName);
                 return isLongScale
@@ -559,8 +564,8 @@ public static class MetricNumeralExtensions
         "de", "de-DE", "de-AT", "de-CH",  // German
         "fr", "fr-FR", "fr-BE", "fr-CH",  // French
         "it", "it-IT", "it-CH",            // Italian
-        "es", "es-ES",                     // Spanish
-        "pt", "pt-PT",                     // Portuguese (NOT pt-BR - Brazil uses short scale)
+        "es-ES",                     // Spanish (Spain); Latin American es-* uses short scale
+        "pt-PT",                     // Portuguese (Portugal); pt-BR uses short scale
         "nl", "nl-NL", "nl-BE",            // Dutch
         "ru", "ru-RU",                     // Russian
         "pl", "pl-PL",                     // Polish
@@ -578,5 +583,14 @@ public static class MetricNumeralExtensions
         "nb", "nb-NO",                     // Norwegian
         "sv", "sv-SE",                     // Swedish
         "da", "da-DK",                     // Danish
+    ];
+
+    /// <summary>
+    /// Cultures that explicitly use short scale even when their two-letter language code
+    /// appears in <see cref="LongScaleCultures"/> for other regions.
+    /// </summary>
+    static readonly HashSet<string> ShortScaleCultureExceptions =
+    [
+        "pt-BR", // Brazil
     ];
 }

--- a/src/Humanizer/MetricNumeralFormats.cs
+++ b/src/Humanizer/MetricNumeralFormats.cs
@@ -24,5 +24,12 @@ public enum MetricNumeralFormats
     /// <summary>
     /// Include a space after the numeral.
     /// </summary>
-    WithSpace = 8
+    WithSpace = 8,
+
+    /// <summary>
+    /// Automatically select between <a href="https://en.wikipedia.org/wiki/Long_and_short_scales">long and short scale words</a>
+    /// based on <see cref="System.Globalization.CultureInfo.CurrentUICulture"/>.
+    /// For example, <c>1E9</c> renders as <c>billion</c> in <c>en-US</c> and <c>milliard</c> in <c>de-DE</c>.
+    /// </summary>
+    UseScaleWord = 16
 }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -806,6 +806,7 @@ namespace Humanizer
         UseName = 2,
         UseShortScaleWord = 4,
         WithSpace = 8,
+        UseScaleWord = 16,
     }
     public class NoMatchFoundException : System.Exception
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -806,6 +806,7 @@ namespace Humanizer
         UseName = 2,
         UseShortScaleWord = 4,
         WithSpace = 8,
+        UseScaleWord = 16,
     }
     public class NoMatchFoundException : System.Exception
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -805,6 +805,7 @@ namespace Humanizer
         UseName = 2,
         UseShortScaleWord = 4,
         WithSpace = 8,
+        UseScaleWord = 16,
     }
     public class NoMatchFoundException : System.Exception
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -585,6 +585,7 @@ namespace Humanizer
         UseName = 2,
         UseShortScaleWord = 4,
         WithSpace = 8,
+        UseScaleWord = 16,
     }
     public class NoMatchFoundException : System.Exception
     {

--- a/tests/Humanizer.Tests/MetricNumeralTests.cs
+++ b/tests/Humanizer.Tests/MetricNumeralTests.cs
@@ -222,4 +222,25 @@ public class MetricNumeralTests
     [InlineData(-1E-27)]
     public void ToMetricOnInvalid(double input) =>
         Assert.Throws<ArgumentOutOfRangeException>(() => input.ToMetric());
+
+    [Theory]
+    [InlineData(1E9, "1 billion")]
+    [InlineData(1E12, "1 trillion")]
+    public void ToMetric_UseScaleWord_ShortScale(double input, string expected) =>
+        Assert.Equal(expected, input.ToMetric(MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseScaleWord));
+
+    [UseCulture("de-DE")]
+    [Theory]
+    [InlineData(1E9, "1 milliard")]
+    [InlineData(1E12, "1 billion")]
+    public void ToMetric_UseScaleWord_LongScale_German(double input, string expected) =>
+        Assert.Equal(expected, input.ToMetric(MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseScaleWord));
+
+    [UseCulture("fr-FR")]
+    [Theory]
+    [InlineData(1E9, "1 milliard")]
+    [InlineData(1E12, "1 billion")]
+    public void ToMetric_UseScaleWord_LongScale_French(double input, string expected) =>
+        Assert.Equal(expected, input.ToMetric(MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseScaleWord));
+
 }

--- a/tests/Humanizer.Tests/MetricNumeralTests.cs
+++ b/tests/Humanizer.Tests/MetricNumeralTests.cs
@@ -243,4 +243,32 @@ public class MetricNumeralTests
     public void ToMetric_UseScaleWord_LongScale_French(double input, string expected) =>
         Assert.Equal(expected, input.ToMetric(MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseScaleWord));
 
+    [UseCulture("pt-BR")]
+    [Theory]
+    [InlineData(1E9, "1 billion")]
+    [InlineData(1E12, "1 trillion")]
+    public void ToMetric_UseScaleWord_ShortScale_Brazil(double input, string expected) =>
+        Assert.Equal(expected, input.ToMetric(MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseScaleWord));
+
+    [UseCulture("pt-PT")]
+    [Theory]
+    [InlineData(1E9, "1 milliard")]
+    [InlineData(1E12, "1 billion")]
+    public void ToMetric_UseScaleWord_LongScale_Portugal(double input, string expected) =>
+        Assert.Equal(expected, input.ToMetric(MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseScaleWord));
+
+    [UseCulture("es-MX")]
+    [Theory]
+    [InlineData(1E9, "1 billion")]
+    [InlineData(1E12, "1 trillion")]
+    public void ToMetric_UseScaleWord_ShortScale_LatinAmericanSpanish(double input, string expected) =>
+        Assert.Equal(expected, input.ToMetric(MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseScaleWord));
+
+    [UseCulture("es-ES")]
+    [Theory]
+    [InlineData(1E9, "1 milliard")]
+    [InlineData(1E12, "1 billion")]
+    public void ToMetric_UseScaleWord_LongScale_Spain(double input, string expected) =>
+        Assert.Equal(expected, input.ToMetric(MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseScaleWord));
+
 }


### PR DESCRIPTION
Rebased, conflict-free version of **#1697** (by @reabr) onto current `main` (`f9292aa9`).

Fixes #1675

## What
Adds `MetricNumeralFormats.UseScaleWord` to pick long vs short scale words from `CultureInfo.CurrentUICulture`.

## Changes vs #1697
- Resolved merge conflict in `MetricNumeralExtensions.cs` (`LongScaleCultures` placement)
- Added missing **DotNet11** ApiApprover enum entry

## Example
```cs
(1E9).ToMetric(MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseScaleWord)
// en-US → "1 billion"
// de-DE → "1 milliard"
```

## Note
Original authorship is @reabr's (#1697). This PR exists to unblock review/CI after the upstream branch went stale/conflicting. Happy to close in favor of an updated #1697 if the author rebases.


Made with [Cursor](https://cursor.com)