### PR TITLE
feat: MVP TimeSpan dehumanize for compact duration strings (#691)

### DIFF
--- a/src/Humanizer/TimeSpanDehumanizeColonFormat.cs
+++ b/src/Humanizer/TimeSpanDehumanizeColonFormat.cs
@@ -1,0 +1,17 @@
+namespace Humanizer;
+
+/// <summary>
+/// Controls how colon-separated duration strings are interpreted.
+/// </summary>
+public enum TimeSpanDehumanizeColonFormat
+{
+    /// <summary>
+    /// Two-part values are hours and minutes; three-part values are hours, minutes, and seconds.
+    /// </summary>
+    HoursMinutes = 0,
+
+    /// <summary>
+    /// Two-part values are minutes and seconds; three-part values remain hours, minutes, and seconds.
+    /// </summary>
+    MinutesSeconds = 1,
+}

--- a/src/Humanizer/TimeSpanDehumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeExtensions.cs
@@ -195,7 +195,8 @@ public static class TimeSpanDehumanizeExtensions
         if (parts.Length == 3
             && TryParseInvariantInt(parts[0], out var hours)
             && TryParseInvariantInt(parts[1], out var minutes)
-            && TryParseInvariantDouble(parts[2], out var seconds))
+            && TryParseInvariantDouble(parts[2], out var seconds)
+            && hours >= 0 && minutes >= 0 && seconds >= 0)
         {
             result = TimeSpan.FromHours(hours) + TimeSpan.FromMinutes(minutes) + TimeSpan.FromSeconds(seconds);
             return true;
@@ -205,14 +206,16 @@ public static class TimeSpanDehumanizeExtensions
         {
             if (colonFormat == TimeSpanDehumanizeColonFormat.MinutesSeconds
                 && TryParseInvariantInt(parts[0], out var minutesOnly)
-                && TryParseInvariantDouble(parts[1], out var secondsOnly))
+                && TryParseInvariantDouble(parts[1], out var secondsOnly)
+                && minutesOnly >= 0 && secondsOnly >= 0)
             {
                 result = TimeSpan.FromMinutes(minutesOnly) + TimeSpan.FromSeconds(secondsOnly);
                 return true;
             }
 
             if (TryParseInvariantInt(parts[0], out var hoursOnly)
-                && TryParseInvariantDouble(parts[1], out var minutesOnlyFromHours))
+                && TryParseInvariantDouble(parts[1], out var minutesOnlyFromHours)
+                && hoursOnly >= 0 && minutesOnlyFromHours >= 0)
             {
                 result = TimeSpan.FromHours(hoursOnly) + TimeSpan.FromMinutes(minutesOnlyFromHours);
                 return true;

--- a/src/Humanizer/TimeSpanDehumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeExtensions.cs
@@ -1,5 +1,3 @@
-using System.Globalization;
-
 namespace Humanizer;
 
 /// <summary>
@@ -48,9 +46,17 @@ public static class TimeSpanDehumanizeExtensions
         var text = input.Trim();
         options ??= TimeSpanDehumanizeOptions.Default;
 
-        return TryParseUnitTokens(text, out result)
-               || TryParseColonDuration(text, options.ColonFormat, out result)
-               || TimeSpan.TryParse(text, CultureInfo.InvariantCulture, out result);
+        try
+        {
+            return TryParseUnitTokens(text, out result)
+                   || TryParseColonDuration(text, options.ColonFormat, out result)
+                   || TimeSpan.TryParse(text, CultureInfo.InvariantCulture, out result);
+        }
+        catch (OverflowException)
+        {
+            result = default;
+            return false;
+        }
     }
 
     static bool TryParseUnitTokens(string input, out TimeSpan result)

--- a/src/Humanizer/TimeSpanDehumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeExtensions.cs
@@ -1,0 +1,224 @@
+using System.Globalization;
+
+namespace Humanizer;
+
+/// <summary>
+/// Parses compact, human-friendly duration strings into <see cref="TimeSpan"/> values.
+/// </summary>
+public static class TimeSpanDehumanizeExtensions
+{
+    /// <summary>
+    /// Parses a duration string into a <see cref="TimeSpan"/>.
+    /// </summary>
+    /// <param name="input">The duration text to parse.</param>
+    /// <param name="options">Optional parsing options.</param>
+    /// <returns>The parsed duration.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="input"/> is null.</exception>
+    /// <exception cref="FormatException">Thrown when <paramref name="input"/> cannot be parsed.</exception>
+    public static TimeSpan DehumanizeTimeSpan(this string input, TimeSpanDehumanizeOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        if (!input.TryDehumanizeTimeSpan(out var result, options))
+        {
+            throw new FormatException($"Could not parse '{input}' as a duration.");
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts to parse a duration string into a <see cref="TimeSpan"/>.
+    /// </summary>
+    /// <param name="input">The duration text to parse.</param>
+    /// <param name="result">The parsed duration when successful.</param>
+    /// <param name="options">Optional parsing options.</param>
+    /// <returns><c>true</c> when parsing succeeds; otherwise <c>false</c>.</returns>
+    public static bool TryDehumanizeTimeSpan(
+        this string input,
+        out TimeSpan result,
+        TimeSpanDehumanizeOptions? options = null)
+    {
+        result = default;
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return false;
+        }
+
+        var text = input.Trim();
+        options ??= TimeSpanDehumanizeOptions.Default;
+
+        return TryParseUnitTokens(text, out result)
+               || TryParseColonDuration(text, options.ColonFormat, out result)
+               || TimeSpan.TryParse(text, CultureInfo.InvariantCulture, out result);
+    }
+
+    static bool TryParseUnitTokens(string input, out TimeSpan result)
+    {
+        result = default;
+        var index = 0;
+        var parsedAny = false;
+
+        while (index < input.Length)
+        {
+            while (index < input.Length && char.IsWhiteSpace(input[index]))
+            {
+                index++;
+            }
+
+            if (index >= input.Length)
+            {
+                break;
+            }
+
+            var numberStart = index;
+            while (index < input.Length && (char.IsDigit(input[index]) || input[index] is '.' or '-'))
+            {
+                index++;
+            }
+
+            if (numberStart == index
+                || !double.TryParse(
+                    input.AsSpan(numberStart, index - numberStart),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out var amount))
+            {
+                return false;
+            }
+
+            while (index < input.Length && char.IsWhiteSpace(input[index]))
+            {
+                index++;
+            }
+
+            if (!TryReadUnit(input, ref index, out var unit))
+            {
+                return false;
+            }
+
+            if (!TryConvertUnit(amount, unit, out var contribution))
+            {
+                return false;
+            }
+
+            result += contribution;
+            parsedAny = true;
+        }
+
+        return parsedAny;
+    }
+
+    static bool TryReadUnit(string input, ref int index, out ReadOnlyMemory<char> unit)
+    {
+        unit = default;
+        if (index >= input.Length || !char.IsLetter(input[index]))
+        {
+            return false;
+        }
+
+        var start = index;
+        while (index < input.Length && char.IsLetter(input[index]))
+        {
+            index++;
+        }
+
+        unit = input.AsMemory(start, index - start);
+        return true;
+    }
+
+    static bool TryConvertUnit(double amount, ReadOnlyMemory<char> unitMemory, out TimeSpan result)
+    {
+        result = default;
+        var unit = unitMemory.Span;
+
+        if (UnitEquals(unit, "ms") || UnitEquals(unit, "millis") || UnitEquals(unit, "millisecond") || UnitEquals(unit, "milliseconds"))
+        {
+            result = TimeSpan.FromMilliseconds(amount);
+            return true;
+        }
+
+        if (UnitEquals(unit, "s") || UnitEquals(unit, "sec") || UnitEquals(unit, "secs") || UnitEquals(unit, "second") || UnitEquals(unit, "seconds"))
+        {
+            result = TimeSpan.FromSeconds(amount);
+            return true;
+        }
+
+        if (UnitEquals(unit, "m") || UnitEquals(unit, "min") || UnitEquals(unit, "mins") || UnitEquals(unit, "minute") || UnitEquals(unit, "minutes"))
+        {
+            result = TimeSpan.FromMinutes(amount);
+            return true;
+        }
+
+        if (UnitEquals(unit, "h") || UnitEquals(unit, "hr") || UnitEquals(unit, "hrs") || UnitEquals(unit, "hour") || UnitEquals(unit, "hours"))
+        {
+            result = TimeSpan.FromHours(amount);
+            return true;
+        }
+
+        if (UnitEquals(unit, "d") || UnitEquals(unit, "day") || UnitEquals(unit, "days"))
+        {
+            result = TimeSpan.FromDays(amount);
+            return true;
+        }
+
+        if (UnitEquals(unit, "w") || UnitEquals(unit, "week") || UnitEquals(unit, "weeks"))
+        {
+            result = TimeSpan.FromDays(7 * amount);
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool UnitEquals(ReadOnlySpan<char> unit, string expected)
+    {
+        return unit.Length == expected.Length
+               && unit.Equals(expected.AsSpan(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    static bool TryParseColonDuration(string input, TimeSpanDehumanizeColonFormat colonFormat, out TimeSpan result)
+    {
+        result = default;
+        var parts = input.Split(':');
+        if (parts.Length is not (2 or 3) || parts.Any(string.IsNullOrWhiteSpace))
+        {
+            return false;
+        }
+
+        if (parts.Length == 3
+            && TryParseInvariantInt(parts[0], out var hours)
+            && TryParseInvariantInt(parts[1], out var minutes)
+            && TryParseInvariantDouble(parts[2], out var seconds))
+        {
+            result = TimeSpan.FromHours(hours) + TimeSpan.FromMinutes(minutes) + TimeSpan.FromSeconds(seconds);
+            return true;
+        }
+
+        if (parts.Length == 2)
+        {
+            if (colonFormat == TimeSpanDehumanizeColonFormat.MinutesSeconds
+                && TryParseInvariantInt(parts[0], out var minutesOnly)
+                && TryParseInvariantDouble(parts[1], out var secondsOnly))
+            {
+                result = TimeSpan.FromMinutes(minutesOnly) + TimeSpan.FromSeconds(secondsOnly);
+                return true;
+            }
+
+            if (TryParseInvariantInt(parts[0], out var hoursOnly)
+                && TryParseInvariantDouble(parts[1], out var minutesOnlyFromHours))
+            {
+                result = TimeSpan.FromHours(hoursOnly) + TimeSpan.FromMinutes(minutesOnlyFromHours);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool TryParseInvariantInt(string value, out int result) =>
+        int.TryParse(value.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+
+    static bool TryParseInvariantDouble(string value, out double result) =>
+        double.TryParse(value.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+}

--- a/src/Humanizer/TimeSpanDehumanizeOptions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeOptions.cs
@@ -1,0 +1,17 @@
+namespace Humanizer;
+
+/// <summary>
+/// Options for parsing human-friendly duration strings into <see cref="TimeSpan"/> values.
+/// </summary>
+public sealed class TimeSpanDehumanizeOptions
+{
+    /// <summary>
+    /// Gets the default options instance.
+    /// </summary>
+    public static TimeSpanDehumanizeOptions Default { get; } = new();
+
+    /// <summary>
+    /// Gets how colon-separated values such as <c>3:18</c> are interpreted.
+    /// </summary>
+    public TimeSpanDehumanizeColonFormat ColonFormat { get; init; } = TimeSpanDehumanizeColonFormat.HoursMinutes;
+}

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -1870,14 +1870,14 @@ namespace Humanizer
     }
     public static class TimeSpanDehumanizeExtensions
     {
-        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
-        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
     }
     public sealed class TimeSpanDehumanizeOptions
     {
-        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
-        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
         public TimeSpanDehumanizeOptions() { }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
     }
     public static class TimeSpanHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -1863,6 +1863,22 @@ namespace Humanizer
     {
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive = 0) { }
     }
+    public enum TimeSpanDehumanizeColonFormat
+    {
+        HoursMinutes = 0,
+        MinutesSeconds = 1,
+    }
+    public static class TimeSpanDehumanizeExtensions
+    {
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+    }
+    public sealed class TimeSpanDehumanizeOptions
+    {
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public TimeSpanDehumanizeOptions() { }
+    }
     public static class TimeSpanHumanizeExtensions
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -1870,14 +1870,14 @@ namespace Humanizer
     }
     public static class TimeSpanDehumanizeExtensions
     {
-        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
-        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
     }
     public sealed class TimeSpanDehumanizeOptions
     {
-        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
-        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
         public TimeSpanDehumanizeOptions() { }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
     }
     public static class TimeSpanHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -1863,6 +1863,22 @@ namespace Humanizer
     {
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive = 0) { }
     }
+    public enum TimeSpanDehumanizeColonFormat
+    {
+        HoursMinutes = 0,
+        MinutesSeconds = 1,
+    }
+    public static class TimeSpanDehumanizeExtensions
+    {
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+    }
+    public sealed class TimeSpanDehumanizeOptions
+    {
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public TimeSpanDehumanizeOptions() { }
+    }
     public static class TimeSpanHumanizeExtensions
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -1862,6 +1862,22 @@ namespace Humanizer
     {
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive = 0) { }
     }
+    public enum TimeSpanDehumanizeColonFormat
+    {
+        HoursMinutes = 0,
+        MinutesSeconds = 1,
+    }
+    public static class TimeSpanDehumanizeExtensions
+    {
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+    }
+    public sealed class TimeSpanDehumanizeOptions
+    {
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public TimeSpanDehumanizeOptions() { }
+    }
     public static class TimeSpanHumanizeExtensions
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -1869,14 +1869,14 @@ namespace Humanizer
     }
     public static class TimeSpanDehumanizeExtensions
     {
-        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
-        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
     }
     public sealed class TimeSpanDehumanizeOptions
     {
-        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
-        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
         public TimeSpanDehumanizeOptions() { }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
     }
     public static class TimeSpanHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -1198,6 +1198,22 @@ namespace Humanizer
         Future = 0,
         Past = 1,
     }
+    public enum TimeSpanDehumanizeColonFormat
+    {
+        HoursMinutes = 0,
+        MinutesSeconds = 1,
+    }
+    public static class TimeSpanDehumanizeExtensions
+    {
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+    }
+    public sealed class TimeSpanDehumanizeOptions
+    {
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public TimeSpanDehumanizeOptions() { }
+    }
     public static class TimeSpanHumanizeExtensions
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -1205,14 +1205,14 @@ namespace Humanizer
     }
     public static class TimeSpanDehumanizeExtensions
     {
-        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
-        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
     }
     public sealed class TimeSpanDehumanizeOptions
     {
-        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
-        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
         public TimeSpanDehumanizeOptions() { }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
     }
     public static class TimeSpanHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
@@ -55,11 +55,16 @@ public class TimeSpanDehumanizeTests
         Assert.Equal(new TimeSpan(0, 18, 1), "18:01".DehumanizeTimeSpan(options));
     }
 
-    [Theory]
-    [InlineData("10675200d")]
-    public void TryDehumanizeTimeSpanReturnsFalseForOverflowInput(string input)
+    [Fact]
+    public void TryDehumanizeTimeSpanReturnsFalseForOverflowInput()
     {
-        Assert.False(input.TryDehumanizeTimeSpan(out _));
+        Assert.False("10675200d".TryDehumanizeTimeSpan(out _));
+    }
+
+    [Fact]
+    public void DehumanizeTimeSpanParsesNegativeColonFormatViaTryParseFallback()
+    {
+        Assert.Equal(new TimeSpan(-3, -18, 0), "-3:18:00".DehumanizeTimeSpan());
     }
 
     [Theory]

--- a/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
@@ -1,3 +1,4 @@
+[UseCulture("en-US")]
 public class TimeSpanDehumanizeTests
 {
     static readonly TimeSpan ThreeHoursEighteenMinutes = new(3, 18, 0);
@@ -36,6 +37,8 @@ public class TimeSpanDehumanizeTests
         Assert.Equal(new TimeSpan(0, 12, 30), "12m 30s".DehumanizeTimeSpan());
     }
 
+    [Fact]
+    public void DehumanizeTimeSpanParsesThreeHoursEighteenMinutesFromColonFormats()
     {
         Assert.Equal(ThreeHoursEighteenMinutes, "3:18:00".DehumanizeTimeSpan());
         Assert.Equal(ThreeHoursEighteenMinutes, "3:18".DehumanizeTimeSpan());
@@ -50,6 +53,13 @@ public class TimeSpanDehumanizeTests
         };
 
         Assert.Equal(new TimeSpan(0, 18, 1), "18:01".DehumanizeTimeSpan(options));
+    }
+
+    [Theory]
+    [InlineData("10675200d")]
+    public void TryDehumanizeTimeSpanReturnsFalseForOverflowInput(string input)
+    {
+        Assert.False(input.TryDehumanizeTimeSpan(out _));
     }
 
     [Theory]

--- a/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
@@ -1,0 +1,76 @@
+public class TimeSpanDehumanizeTests
+{
+    static readonly TimeSpan ThreeHoursEighteenMinutes = new(3, 18, 0);
+
+    [Theory]
+    [InlineData("3h18m")]
+    [InlineData("3h 18m")]
+    [InlineData("3.3hrs")]
+    [InlineData("3:18:00")]
+    [InlineData("3:18")]
+    [InlineData("12m 30s")]
+    [InlineData("1000s")]
+    [InlineData("6d")]
+    public void TryDehumanizeTimeSpanParsesCompactFormats(string input)
+    {
+        Assert.True(input.TryDehumanizeTimeSpan(out var parsed));
+        Assert.True(parsed > TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void DehumanizeTimeSpanParsesThreeHoursEighteenMinutesFromCompactUnits()
+    {
+        Assert.Equal(ThreeHoursEighteenMinutes, "3h18m".DehumanizeTimeSpan());
+        Assert.Equal(ThreeHoursEighteenMinutes, "3h 18m".DehumanizeTimeSpan());
+    }
+
+    [Fact]
+    public void DehumanizeTimeSpanParsesFractionalHours()
+    {
+        Assert.Equal(ThreeHoursEighteenMinutes, "3.3hrs".DehumanizeTimeSpan());
+    }
+
+    [Fact]
+    public void DehumanizeTimeSpanParsesCompoundMinutesAndSeconds()
+    {
+        Assert.Equal(new TimeSpan(0, 12, 30), "12m 30s".DehumanizeTimeSpan());
+    }
+
+    {
+        Assert.Equal(ThreeHoursEighteenMinutes, "3:18:00".DehumanizeTimeSpan());
+        Assert.Equal(ThreeHoursEighteenMinutes, "3:18".DehumanizeTimeSpan());
+    }
+
+    [Fact]
+    public void DehumanizeTimeSpanParsesMinutesAndSecondsWhenConfigured()
+    {
+        var options = new TimeSpanDehumanizeOptions
+        {
+            ColonFormat = TimeSpanDehumanizeColonFormat.MinutesSeconds,
+        };
+
+        Assert.Equal(new TimeSpan(0, 18, 1), "18:01".DehumanizeTimeSpan(options));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("not-a-duration")]
+    [InlineData("3x")]
+    public void TryDehumanizeTimeSpanReturnsFalseForInvalidInput(string input)
+    {
+        Assert.False(input.TryDehumanizeTimeSpan(out _));
+    }
+
+    [Fact]
+    public void DehumanizeTimeSpanThrowsForInvalidInput()
+    {
+        Assert.Throws<FormatException>(() => "not-a-duration".DehumanizeTimeSpan());
+    }
+
+    [Fact]
+    public void DehumanizeTimeSpanThrowsForNullInput()
+    {
+        Assert.Throws<ArgumentNullException>(() => TimeSpanDehumanizeExtensions.DehumanizeTimeSpan(null!));
+    }
+}


### PR DESCRIPTION
Fixes #691 (MVP scope)

## What
Adds `DehumanizeTimeSpan` / `TryDehumanizeTimeSpan` for parsing compact English duration text into `TimeSpan`.

## Supported formats (MVP)
- Unit suffixes: `3h18m`, `3h 18m`, `3.3hrs`, `12m 30s`, `1000s`, `6d`
- Colon: `3:18:00`, `3:18` (hours:minutes)
- Colon with options: `18:01` as minutes:seconds via `TimeSpanDehumanizeColonFormat.MinutesSeconds`
- Falls back to `TimeSpan.TryParse` for standard invariant strings

## Out of scope (follow-ups)
- Word phrases (`three hours and eighteen minutes`)
- Locale-specific unit names
- Ambiguous calendar units (`months`)

## API
```cs
"3h18m".DehumanizeTimeSpan() // 03:18:00
"18:01".DehumanizeTimeSpan(new TimeSpanDehumanizeOptions { ColonFormat = MinutesSeconds })
```


Made with [Cursor](https://cursor.com)