### PR TITLE
feat: word-phrase TimeSpan dehumanize + Humanize round-trip (#691)

### DIFF
--- a/src/Humanizer/TimeSpanDehumanizeColonFormat.cs
+++ b/src/Humanizer/TimeSpanDehumanizeColonFormat.cs
@@ -1,0 +1,17 @@
+namespace Humanizer;
+
+/// <summary>
+/// Controls how colon-separated duration strings are interpreted.
+/// </summary>
+public enum TimeSpanDehumanizeColonFormat
+{
+    /// <summary>
+    /// Two-part values are hours and minutes; three-part values are hours, minutes, and seconds.
+    /// </summary>
+    HoursMinutes = 0,
+
+    /// <summary>
+    /// Two-part values are minutes and seconds; three-part values remain hours, minutes, and seconds.
+    /// </summary>
+    MinutesSeconds = 1,
+}

--- a/src/Humanizer/TimeSpanDehumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeExtensions.cs
@@ -195,7 +195,8 @@ public static class TimeSpanDehumanizeExtensions
         if (parts.Length == 3
             && TryParseInvariantInt(parts[0], out var hours)
             && TryParseInvariantInt(parts[1], out var minutes)
-            && TryParseInvariantDouble(parts[2], out var seconds))
+            && TryParseInvariantDouble(parts[2], out var seconds)
+            && hours >= 0 && minutes >= 0 && seconds >= 0)
         {
             result = TimeSpan.FromHours(hours) + TimeSpan.FromMinutes(minutes) + TimeSpan.FromSeconds(seconds);
             return true;
@@ -205,14 +206,16 @@ public static class TimeSpanDehumanizeExtensions
         {
             if (colonFormat == TimeSpanDehumanizeColonFormat.MinutesSeconds
                 && TryParseInvariantInt(parts[0], out var minutesOnly)
-                && TryParseInvariantDouble(parts[1], out var secondsOnly))
+                && TryParseInvariantDouble(parts[1], out var secondsOnly)
+                && minutesOnly >= 0 && secondsOnly >= 0)
             {
                 result = TimeSpan.FromMinutes(minutesOnly) + TimeSpan.FromSeconds(secondsOnly);
                 return true;
             }
 
             if (TryParseInvariantInt(parts[0], out var hoursOnly)
-                && TryParseInvariantDouble(parts[1], out var minutesOnlyFromHours))
+                && TryParseInvariantDouble(parts[1], out var minutesOnlyFromHours)
+                && hoursOnly >= 0 && minutesOnlyFromHours >= 0)
             {
                 result = TimeSpan.FromHours(hoursOnly) + TimeSpan.FromMinutes(minutesOnlyFromHours);
                 return true;

--- a/src/Humanizer/TimeSpanDehumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeExtensions.cs
@@ -67,10 +67,7 @@ public static class TimeSpanDehumanizeExtensions
 
         while (index < input.Length)
         {
-            while (index < input.Length && char.IsWhiteSpace(input[index]))
-            {
-                index++;
-            }
+            SkipTokenSeparators(input, ref index);
 
             if (index >= input.Length)
             {
@@ -93,10 +90,7 @@ public static class TimeSpanDehumanizeExtensions
                 return false;
             }
 
-            while (index < input.Length && char.IsWhiteSpace(input[index]))
-            {
-                index++;
-            }
+            SkipTokenSeparators(input, ref index);
 
             if (!TryReadUnit(input, ref index, out var unit))
             {
@@ -113,6 +107,48 @@ public static class TimeSpanDehumanizeExtensions
         }
 
         return parsedAny;
+    }
+
+    static void SkipTokenSeparators(string input, ref int index)
+    {
+        while (index < input.Length)
+        {
+            while (index < input.Length && char.IsWhiteSpace(input[index]))
+            {
+                index++;
+            }
+
+            if (index < input.Length && input[index] == ',')
+            {
+                index++;
+                continue;
+            }
+
+            if (TrySkipCaseInsensitiveWord(input, ref index, "and"))
+            {
+                continue;
+            }
+
+            break;
+        }
+    }
+
+    static bool TrySkipCaseInsensitiveWord(string input, ref int index, string word)
+    {
+        if (index + word.Length > input.Length
+            || !input.AsSpan(index, word.Length).Equals(word.AsSpan(), StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var after = index + word.Length;
+        if (after < input.Length && char.IsLetter(input[after]))
+        {
+            return false;
+        }
+
+        index = after;
+        return true;
     }
 
     static bool TryReadUnit(string input, ref int index, out ReadOnlyMemory<char> unit)

--- a/src/Humanizer/TimeSpanDehumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeExtensions.cs
@@ -232,9 +232,9 @@ public static class TimeSpanDehumanizeExtensions
             && TryParseInvariantInt(parts[0], out var hours)
             && TryParseInvariantInt(parts[1], out var minutes)
             && TryParseInvariantDouble(parts[2], out var seconds)
-            && hours >= 0 && minutes >= 0 && seconds >= 0)
+            && TryGetColonComponents(hours, minutes, seconds, out var hoursSign, out var hoursMagnitude, out var minutesMagnitude, out var secondsMagnitude))
         {
-            result = TimeSpan.FromHours(hours) + TimeSpan.FromMinutes(minutes) + TimeSpan.FromSeconds(seconds);
+            result = hoursSign * (TimeSpan.FromHours(hoursMagnitude) + TimeSpan.FromMinutes(minutesMagnitude) + TimeSpan.FromSeconds(secondsMagnitude));
             return true;
         }
 
@@ -243,22 +243,64 @@ public static class TimeSpanDehumanizeExtensions
             if (colonFormat == TimeSpanDehumanizeColonFormat.MinutesSeconds
                 && TryParseInvariantInt(parts[0], out var minutesOnly)
                 && TryParseInvariantDouble(parts[1], out var secondsOnly)
-                && minutesOnly >= 0 && secondsOnly >= 0)
+                && TryGetColonComponents(minutesOnly, secondsOnly, out var minutesSign, out var minutesMagnitude, out var secondsMagnitude))
             {
-                result = TimeSpan.FromMinutes(minutesOnly) + TimeSpan.FromSeconds(secondsOnly);
+                result = minutesSign * (TimeSpan.FromMinutes(minutesMagnitude) + TimeSpan.FromSeconds(secondsMagnitude));
                 return true;
             }
 
             if (TryParseInvariantInt(parts[0], out var hoursOnly)
                 && TryParseInvariantDouble(parts[1], out var minutesOnlyFromHours)
-                && hoursOnly >= 0 && minutesOnlyFromHours >= 0)
+                && TryGetColonComponents(hoursOnly, minutesOnlyFromHours, out var hoursSign, out var hoursMagnitude, out var minutesMagnitude))
             {
-                result = TimeSpan.FromHours(hoursOnly) + TimeSpan.FromMinutes(minutesOnlyFromHours);
+                result = hoursSign * (TimeSpan.FromHours(hoursMagnitude) + TimeSpan.FromMinutes(minutesMagnitude));
                 return true;
             }
         }
 
         return false;
+    }
+
+    static bool TryGetColonComponents(
+        int leading,
+        double trailing,
+        out int sign,
+        out int leadingMagnitude,
+        out double trailingMagnitude)
+    {
+        return TryGetColonComponents(
+            leading,
+            trailing,
+            0,
+            out sign,
+            out leadingMagnitude,
+            out trailingMagnitude,
+            out _);
+    }
+
+    static bool TryGetColonComponents(
+        int leading,
+        int middle,
+        double trailing,
+        out int sign,
+        out int leadingMagnitude,
+        out int middleMagnitude,
+        out double trailingMagnitude)
+    {
+        if (middle < 0 || trailing < 0)
+        {
+            sign = 0;
+            leadingMagnitude = 0;
+            middleMagnitude = 0;
+            trailingMagnitude = 0;
+            return false;
+        }
+
+        sign = leading < 0 ? -1 : 1;
+        leadingMagnitude = Math.Abs(leading);
+        middleMagnitude = middle;
+        trailingMagnitude = trailing;
+        return true;
     }
 
     static bool TryParseInvariantInt(string value, out int result) =>

--- a/src/Humanizer/TimeSpanDehumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeExtensions.cs
@@ -234,7 +234,7 @@ public static class TimeSpanDehumanizeExtensions
             && TryParseInvariantDouble(parts[2], out var seconds)
             && TryGetColonComponents(hours, minutes, seconds, out var hoursSign, out var hoursMagnitude, out var minutesMagnitude, out var secondsMagnitude))
         {
-            result = hoursSign * (TimeSpan.FromHours(hoursMagnitude) + TimeSpan.FromMinutes(minutesMagnitude) + TimeSpan.FromSeconds(secondsMagnitude));
+            result = (TimeSpan.FromHours(hoursMagnitude) + TimeSpan.FromMinutes(minutesMagnitude) + TimeSpan.FromSeconds(secondsMagnitude)) * hoursSign;
             return true;
         }
 
@@ -245,7 +245,7 @@ public static class TimeSpanDehumanizeExtensions
                 && TryParseInvariantDouble(parts[1], out var secondsOnly)
                 && TryGetColonComponents(minutesOnly, secondsOnly, out var minutesSign, out var minutesMagnitude, out var secondsMagnitude))
             {
-                result = minutesSign * (TimeSpan.FromMinutes(minutesMagnitude) + TimeSpan.FromSeconds(secondsMagnitude));
+                result = (TimeSpan.FromMinutes(minutesMagnitude) + TimeSpan.FromSeconds(secondsMagnitude)) * minutesSign;
                 return true;
             }
 
@@ -253,7 +253,7 @@ public static class TimeSpanDehumanizeExtensions
                 && TryParseInvariantDouble(parts[1], out var minutesOnlyFromHours)
                 && TryGetColonComponents(hoursOnly, minutesOnlyFromHours, out var hoursSign, out var hoursMagnitude, out var minutesMagnitude))
             {
-                result = hoursSign * (TimeSpan.FromHours(hoursMagnitude) + TimeSpan.FromMinutes(minutesMagnitude));
+                result = (TimeSpan.FromHours(hoursMagnitude) + TimeSpan.FromMinutes(minutesMagnitude)) * hoursSign;
                 return true;
             }
         }
@@ -268,14 +268,18 @@ public static class TimeSpanDehumanizeExtensions
         out int leadingMagnitude,
         out double trailingMagnitude)
     {
-        return TryGetColonComponents(
-            leading,
-            trailing,
-            0,
-            out sign,
-            out leadingMagnitude,
-            out trailingMagnitude,
-            out _);
+        if (trailing < 0)
+        {
+            sign = 0;
+            leadingMagnitude = 0;
+            trailingMagnitude = 0;
+            return false;
+        }
+
+        sign = leading < 0 ? -1 : 1;
+        leadingMagnitude = Math.Abs(leading);
+        trailingMagnitude = trailing;
+        return true;
     }
 
     static bool TryGetColonComponents(

--- a/src/Humanizer/TimeSpanDehumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeExtensions.cs
@@ -232,9 +232,9 @@ public static class TimeSpanDehumanizeExtensions
             && TryParseInvariantInt(parts[0], out var hours)
             && TryParseInvariantInt(parts[1], out var minutes)
             && TryParseInvariantDouble(parts[2], out var seconds)
-            && TryGetColonComponents(hours, minutes, seconds, out var hoursSign, out var hoursMagnitude, out var minutesMagnitude, out var secondsMagnitude))
+            && TryGetColonComponents(hours, minutes, seconds, out var hmsSign, out var hmsHours, out var hmsMinutes, out var hmsSeconds))
         {
-            result = (TimeSpan.FromHours(hoursMagnitude) + TimeSpan.FromMinutes(minutesMagnitude) + TimeSpan.FromSeconds(secondsMagnitude)) * hoursSign;
+            result = ApplySign(TimeSpan.FromHours(hmsHours) + TimeSpan.FromMinutes(hmsMinutes) + TimeSpan.FromSeconds(hmsSeconds), hmsSign);
             return true;
         }
 
@@ -243,23 +243,26 @@ public static class TimeSpanDehumanizeExtensions
             if (colonFormat == TimeSpanDehumanizeColonFormat.MinutesSeconds
                 && TryParseInvariantInt(parts[0], out var minutesOnly)
                 && TryParseInvariantDouble(parts[1], out var secondsOnly)
-                && TryGetColonComponents(minutesOnly, secondsOnly, out var minutesSign, out var minutesMagnitude, out var secondsMagnitude))
+                && TryGetColonComponents(minutesOnly, secondsOnly, out var msSign, out var msMinutes, out var msSeconds))
             {
-                result = (TimeSpan.FromMinutes(minutesMagnitude) + TimeSpan.FromSeconds(secondsMagnitude)) * minutesSign;
+                result = ApplySign(TimeSpan.FromMinutes(msMinutes) + TimeSpan.FromSeconds(msSeconds), msSign);
                 return true;
             }
 
             if (TryParseInvariantInt(parts[0], out var hoursOnly)
                 && TryParseInvariantDouble(parts[1], out var minutesOnlyFromHours)
-                && TryGetColonComponents(hoursOnly, minutesOnlyFromHours, out var hoursSign, out var hoursMagnitude, out var minutesMagnitude))
+                && TryGetColonComponents(hoursOnly, minutesOnlyFromHours, out var hmSign, out var hmHours, out var hmMinutes))
             {
-                result = (TimeSpan.FromHours(hoursMagnitude) + TimeSpan.FromMinutes(minutesMagnitude)) * hoursSign;
+                result = ApplySign(TimeSpan.FromHours(hmHours) + TimeSpan.FromMinutes(hmMinutes), hmSign);
                 return true;
             }
         }
 
         return false;
     }
+
+    static TimeSpan ApplySign(TimeSpan duration, int sign) =>
+        sign < 0 ? -duration : duration;
 
     static bool TryGetColonComponents(
         int leading,

--- a/src/Humanizer/TimeSpanDehumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeExtensions.cs
@@ -1,5 +1,3 @@
-using System.Globalization;
-
 namespace Humanizer;
 
 /// <summary>
@@ -48,9 +46,17 @@ public static class TimeSpanDehumanizeExtensions
         var text = input.Trim();
         options ??= TimeSpanDehumanizeOptions.Default;
 
-        return TryParseUnitTokens(text, out result)
-               || TryParseColonDuration(text, options.ColonFormat, out result)
-               || TimeSpan.TryParse(text, CultureInfo.InvariantCulture, out result);
+        try
+        {
+            return TryParseUnitTokens(text, out result)
+                   || TryParseColonDuration(text, options.ColonFormat, out result)
+                   || TimeSpan.TryParse(text, CultureInfo.InvariantCulture, out result);
+        }
+        catch (OverflowException)
+        {
+            result = default;
+            return false;
+        }
     }
 
     static bool TryParseUnitTokens(string input, out TimeSpan result)

--- a/src/Humanizer/TimeSpanDehumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeExtensions.cs
@@ -1,0 +1,224 @@
+using System.Globalization;
+
+namespace Humanizer;
+
+/// <summary>
+/// Parses compact, human-friendly duration strings into <see cref="TimeSpan"/> values.
+/// </summary>
+public static class TimeSpanDehumanizeExtensions
+{
+    /// <summary>
+    /// Parses a duration string into a <see cref="TimeSpan"/>.
+    /// </summary>
+    /// <param name="input">The duration text to parse.</param>
+    /// <param name="options">Optional parsing options.</param>
+    /// <returns>The parsed duration.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="input"/> is null.</exception>
+    /// <exception cref="FormatException">Thrown when <paramref name="input"/> cannot be parsed.</exception>
+    public static TimeSpan DehumanizeTimeSpan(this string input, TimeSpanDehumanizeOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        if (!input.TryDehumanizeTimeSpan(out var result, options))
+        {
+            throw new FormatException($"Could not parse '{input}' as a duration.");
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts to parse a duration string into a <see cref="TimeSpan"/>.
+    /// </summary>
+    /// <param name="input">The duration text to parse.</param>
+    /// <param name="result">The parsed duration when successful.</param>
+    /// <param name="options">Optional parsing options.</param>
+    /// <returns><c>true</c> when parsing succeeds; otherwise <c>false</c>.</returns>
+    public static bool TryDehumanizeTimeSpan(
+        this string input,
+        out TimeSpan result,
+        TimeSpanDehumanizeOptions? options = null)
+    {
+        result = default;
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return false;
+        }
+
+        var text = input.Trim();
+        options ??= TimeSpanDehumanizeOptions.Default;
+
+        return TryParseUnitTokens(text, out result)
+               || TryParseColonDuration(text, options.ColonFormat, out result)
+               || TimeSpan.TryParse(text, CultureInfo.InvariantCulture, out result);
+    }
+
+    static bool TryParseUnitTokens(string input, out TimeSpan result)
+    {
+        result = default;
+        var index = 0;
+        var parsedAny = false;
+
+        while (index < input.Length)
+        {
+            while (index < input.Length && char.IsWhiteSpace(input[index]))
+            {
+                index++;
+            }
+
+            if (index >= input.Length)
+            {
+                break;
+            }
+
+            var numberStart = index;
+            while (index < input.Length && (char.IsDigit(input[index]) || input[index] is '.' or '-'))
+            {
+                index++;
+            }
+
+            if (numberStart == index
+                || !double.TryParse(
+                    input.AsSpan(numberStart, index - numberStart),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out var amount))
+            {
+                return false;
+            }
+
+            while (index < input.Length && char.IsWhiteSpace(input[index]))
+            {
+                index++;
+            }
+
+            if (!TryReadUnit(input, ref index, out var unit))
+            {
+                return false;
+            }
+
+            if (!TryConvertUnit(amount, unit, out var contribution))
+            {
+                return false;
+            }
+
+            result += contribution;
+            parsedAny = true;
+        }
+
+        return parsedAny;
+    }
+
+    static bool TryReadUnit(string input, ref int index, out ReadOnlyMemory<char> unit)
+    {
+        unit = default;
+        if (index >= input.Length || !char.IsLetter(input[index]))
+        {
+            return false;
+        }
+
+        var start = index;
+        while (index < input.Length && char.IsLetter(input[index]))
+        {
+            index++;
+        }
+
+        unit = input.AsMemory(start, index - start);
+        return true;
+    }
+
+    static bool TryConvertUnit(double amount, ReadOnlyMemory<char> unitMemory, out TimeSpan result)
+    {
+        result = default;
+        var unit = unitMemory.Span;
+
+        if (UnitEquals(unit, "ms") || UnitEquals(unit, "millis") || UnitEquals(unit, "millisecond") || UnitEquals(unit, "milliseconds"))
+        {
+            result = TimeSpan.FromMilliseconds(amount);
+            return true;
+        }
+
+        if (UnitEquals(unit, "s") || UnitEquals(unit, "sec") || UnitEquals(unit, "secs") || UnitEquals(unit, "second") || UnitEquals(unit, "seconds"))
+        {
+            result = TimeSpan.FromSeconds(amount);
+            return true;
+        }
+
+        if (UnitEquals(unit, "m") || UnitEquals(unit, "min") || UnitEquals(unit, "mins") || UnitEquals(unit, "minute") || UnitEquals(unit, "minutes"))
+        {
+            result = TimeSpan.FromMinutes(amount);
+            return true;
+        }
+
+        if (UnitEquals(unit, "h") || UnitEquals(unit, "hr") || UnitEquals(unit, "hrs") || UnitEquals(unit, "hour") || UnitEquals(unit, "hours"))
+        {
+            result = TimeSpan.FromHours(amount);
+            return true;
+        }
+
+        if (UnitEquals(unit, "d") || UnitEquals(unit, "day") || UnitEquals(unit, "days"))
+        {
+            result = TimeSpan.FromDays(amount);
+            return true;
+        }
+
+        if (UnitEquals(unit, "w") || UnitEquals(unit, "week") || UnitEquals(unit, "weeks"))
+        {
+            result = TimeSpan.FromDays(7 * amount);
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool UnitEquals(ReadOnlySpan<char> unit, string expected)
+    {
+        return unit.Length == expected.Length
+               && unit.Equals(expected.AsSpan(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    static bool TryParseColonDuration(string input, TimeSpanDehumanizeColonFormat colonFormat, out TimeSpan result)
+    {
+        result = default;
+        var parts = input.Split(':');
+        if (parts.Length is not (2 or 3) || parts.Any(string.IsNullOrWhiteSpace))
+        {
+            return false;
+        }
+
+        if (parts.Length == 3
+            && TryParseInvariantInt(parts[0], out var hours)
+            && TryParseInvariantInt(parts[1], out var minutes)
+            && TryParseInvariantDouble(parts[2], out var seconds))
+        {
+            result = TimeSpan.FromHours(hours) + TimeSpan.FromMinutes(minutes) + TimeSpan.FromSeconds(seconds);
+            return true;
+        }
+
+        if (parts.Length == 2)
+        {
+            if (colonFormat == TimeSpanDehumanizeColonFormat.MinutesSeconds
+                && TryParseInvariantInt(parts[0], out var minutesOnly)
+                && TryParseInvariantDouble(parts[1], out var secondsOnly))
+            {
+                result = TimeSpan.FromMinutes(minutesOnly) + TimeSpan.FromSeconds(secondsOnly);
+                return true;
+            }
+
+            if (TryParseInvariantInt(parts[0], out var hoursOnly)
+                && TryParseInvariantDouble(parts[1], out var minutesOnlyFromHours))
+            {
+                result = TimeSpan.FromHours(hoursOnly) + TimeSpan.FromMinutes(minutesOnlyFromHours);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool TryParseInvariantInt(string value, out int result) =>
+        int.TryParse(value.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+
+    static bool TryParseInvariantDouble(string value, out double result) =>
+        double.TryParse(value.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+}

--- a/src/Humanizer/TimeSpanDehumanizeOptions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeOptions.cs
@@ -1,0 +1,17 @@
+namespace Humanizer;
+
+/// <summary>
+/// Options for parsing human-friendly duration strings into <see cref="TimeSpan"/> values.
+/// </summary>
+public sealed class TimeSpanDehumanizeOptions
+{
+    /// <summary>
+    /// Gets the default options instance.
+    /// </summary>
+    public static TimeSpanDehumanizeOptions Default { get; } = new();
+
+    /// <summary>
+    /// Gets how colon-separated values such as <c>3:18</c> are interpreted.
+    /// </summary>
+    public TimeSpanDehumanizeColonFormat ColonFormat { get; init; } = TimeSpanDehumanizeColonFormat.HoursMinutes;
+}

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -1870,14 +1870,14 @@ namespace Humanizer
     }
     public static class TimeSpanDehumanizeExtensions
     {
-        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
-        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
     }
     public sealed class TimeSpanDehumanizeOptions
     {
-        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
-        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
         public TimeSpanDehumanizeOptions() { }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
     }
     public static class TimeSpanHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -1863,6 +1863,22 @@ namespace Humanizer
     {
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive = 0) { }
     }
+    public enum TimeSpanDehumanizeColonFormat
+    {
+        HoursMinutes = 0,
+        MinutesSeconds = 1,
+    }
+    public static class TimeSpanDehumanizeExtensions
+    {
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+    }
+    public sealed class TimeSpanDehumanizeOptions
+    {
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public TimeSpanDehumanizeOptions() { }
+    }
     public static class TimeSpanHumanizeExtensions
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -1870,14 +1870,14 @@ namespace Humanizer
     }
     public static class TimeSpanDehumanizeExtensions
     {
-        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
-        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
     }
     public sealed class TimeSpanDehumanizeOptions
     {
-        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
-        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
         public TimeSpanDehumanizeOptions() { }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
     }
     public static class TimeSpanHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -1863,6 +1863,22 @@ namespace Humanizer
     {
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive = 0) { }
     }
+    public enum TimeSpanDehumanizeColonFormat
+    {
+        HoursMinutes = 0,
+        MinutesSeconds = 1,
+    }
+    public static class TimeSpanDehumanizeExtensions
+    {
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+    }
+    public sealed class TimeSpanDehumanizeOptions
+    {
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public TimeSpanDehumanizeOptions() { }
+    }
     public static class TimeSpanHumanizeExtensions
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -1862,6 +1862,22 @@ namespace Humanizer
     {
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive = 0) { }
     }
+    public enum TimeSpanDehumanizeColonFormat
+    {
+        HoursMinutes = 0,
+        MinutesSeconds = 1,
+    }
+    public static class TimeSpanDehumanizeExtensions
+    {
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+    }
+    public sealed class TimeSpanDehumanizeOptions
+    {
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public TimeSpanDehumanizeOptions() { }
+    }
     public static class TimeSpanHumanizeExtensions
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -1869,14 +1869,14 @@ namespace Humanizer
     }
     public static class TimeSpanDehumanizeExtensions
     {
-        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
-        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
     }
     public sealed class TimeSpanDehumanizeOptions
     {
-        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
-        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
         public TimeSpanDehumanizeOptions() { }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
     }
     public static class TimeSpanHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -1198,6 +1198,22 @@ namespace Humanizer
         Future = 0,
         Past = 1,
     }
+    public enum TimeSpanDehumanizeColonFormat
+    {
+        HoursMinutes = 0,
+        MinutesSeconds = 1,
+    }
+    public static class TimeSpanDehumanizeExtensions
+    {
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+    }
+    public sealed class TimeSpanDehumanizeOptions
+    {
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public TimeSpanDehumanizeOptions() { }
+    }
     public static class TimeSpanHumanizeExtensions
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -1205,14 +1205,14 @@ namespace Humanizer
     }
     public static class TimeSpanDehumanizeExtensions
     {
-        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
-        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = default) { }
+        public static System.TimeSpan DehumanizeTimeSpan(this string input, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
+        public static bool TryDehumanizeTimeSpan(this string input, out System.TimeSpan result, Humanizer.TimeSpanDehumanizeOptions? options = null) { }
     }
     public sealed class TimeSpanDehumanizeOptions
     {
-        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
-        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
         public TimeSpanDehumanizeOptions() { }
+        public Humanizer.TimeSpanDehumanizeColonFormat ColonFormat { get; init; }
+        public static Humanizer.TimeSpanDehumanizeOptions Default { get; }
     }
     public static class TimeSpanHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
@@ -55,11 +55,16 @@ public class TimeSpanDehumanizeTests
         Assert.Equal(new TimeSpan(0, 18, 1), "18:01".DehumanizeTimeSpan(options));
     }
 
-    [Theory]
-    [InlineData("10675200d")]
-    public void TryDehumanizeTimeSpanReturnsFalseForOverflowInput(string input)
+    [Fact]
+    public void TryDehumanizeTimeSpanReturnsFalseForOverflowInput()
     {
-        Assert.False(input.TryDehumanizeTimeSpan(out _));
+        Assert.False("10675200d".TryDehumanizeTimeSpan(out _));
+    }
+
+    [Fact]
+    public void DehumanizeTimeSpanParsesNegativeColonFormatViaTryParseFallback()
+    {
+        Assert.Equal(new TimeSpan(-3, -18, 0), "-3:18:00".DehumanizeTimeSpan());
     }
 
     [Theory]

--- a/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
@@ -1,3 +1,4 @@
+[UseCulture("en-US")]
 public class TimeSpanDehumanizeTests
 {
     static readonly TimeSpan ThreeHoursEighteenMinutes = new(3, 18, 0);
@@ -36,6 +37,8 @@ public class TimeSpanDehumanizeTests
         Assert.Equal(new TimeSpan(0, 12, 30), "12m 30s".DehumanizeTimeSpan());
     }
 
+    [Fact]
+    public void DehumanizeTimeSpanParsesThreeHoursEighteenMinutesFromColonFormats()
     {
         Assert.Equal(ThreeHoursEighteenMinutes, "3:18:00".DehumanizeTimeSpan());
         Assert.Equal(ThreeHoursEighteenMinutes, "3:18".DehumanizeTimeSpan());
@@ -50,6 +53,13 @@ public class TimeSpanDehumanizeTests
         };
 
         Assert.Equal(new TimeSpan(0, 18, 1), "18:01".DehumanizeTimeSpan(options));
+    }
+
+    [Theory]
+    [InlineData("10675200d")]
+    public void TryDehumanizeTimeSpanReturnsFalseForOverflowInput(string input)
+    {
+        Assert.False(input.TryDehumanizeTimeSpan(out _));
     }
 
     [Theory]

--- a/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
@@ -1,0 +1,76 @@
+public class TimeSpanDehumanizeTests
+{
+    static readonly TimeSpan ThreeHoursEighteenMinutes = new(3, 18, 0);
+
+    [Theory]
+    [InlineData("3h18m")]
+    [InlineData("3h 18m")]
+    [InlineData("3.3hrs")]
+    [InlineData("3:18:00")]
+    [InlineData("3:18")]
+    [InlineData("12m 30s")]
+    [InlineData("1000s")]
+    [InlineData("6d")]
+    public void TryDehumanizeTimeSpanParsesCompactFormats(string input)
+    {
+        Assert.True(input.TryDehumanizeTimeSpan(out var parsed));
+        Assert.True(parsed > TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void DehumanizeTimeSpanParsesThreeHoursEighteenMinutesFromCompactUnits()
+    {
+        Assert.Equal(ThreeHoursEighteenMinutes, "3h18m".DehumanizeTimeSpan());
+        Assert.Equal(ThreeHoursEighteenMinutes, "3h 18m".DehumanizeTimeSpan());
+    }
+
+    [Fact]
+    public void DehumanizeTimeSpanParsesFractionalHours()
+    {
+        Assert.Equal(ThreeHoursEighteenMinutes, "3.3hrs".DehumanizeTimeSpan());
+    }
+
+    [Fact]
+    public void DehumanizeTimeSpanParsesCompoundMinutesAndSeconds()
+    {
+        Assert.Equal(new TimeSpan(0, 12, 30), "12m 30s".DehumanizeTimeSpan());
+    }
+
+    {
+        Assert.Equal(ThreeHoursEighteenMinutes, "3:18:00".DehumanizeTimeSpan());
+        Assert.Equal(ThreeHoursEighteenMinutes, "3:18".DehumanizeTimeSpan());
+    }
+
+    [Fact]
+    public void DehumanizeTimeSpanParsesMinutesAndSecondsWhenConfigured()
+    {
+        var options = new TimeSpanDehumanizeOptions
+        {
+            ColonFormat = TimeSpanDehumanizeColonFormat.MinutesSeconds,
+        };
+
+        Assert.Equal(new TimeSpan(0, 18, 1), "18:01".DehumanizeTimeSpan(options));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("not-a-duration")]
+    [InlineData("3x")]
+    public void TryDehumanizeTimeSpanReturnsFalseForInvalidInput(string input)
+    {
+        Assert.False(input.TryDehumanizeTimeSpan(out _));
+    }
+
+    [Fact]
+    public void DehumanizeTimeSpanThrowsForInvalidInput()
+    {
+        Assert.Throws<FormatException>(() => "not-a-duration".DehumanizeTimeSpan());
+    }
+
+    [Fact]
+    public void DehumanizeTimeSpanThrowsForNullInput()
+    {
+        Assert.Throws<ArgumentNullException>(() => TimeSpanDehumanizeExtensions.DehumanizeTimeSpan(null!));
+    }
+}

--- a/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
@@ -56,6 +56,27 @@ public class TimeSpanDehumanizeTests
     }
 
     [Fact]
+    public void DehumanizeTimeSpanParsesThreeHoursEighteenMinutesFromWordPhrases()
+    {
+        Assert.Equal(ThreeHoursEighteenMinutes, "3 hours 18 minutes".DehumanizeTimeSpan());
+        Assert.Equal(ThreeHoursEighteenMinutes, "3 hours, 18 minutes".DehumanizeTimeSpan());
+        Assert.Equal(ThreeHoursEighteenMinutes, "3 hours and 18 minutes".DehumanizeTimeSpan());
+    }
+
+    [Theory]
+    [InlineData(0, 3, 18, 0, 2)]
+    [InlineData(0, 0, 12, 30, 2)]
+    [InlineData(0, 2, 0, 0, 1)]
+    [InlineData(14, 0, 0, 0, 1)]
+    public void DehumanizeTimeSpanRoundTripsHumanizeOutput(int days, int hours, int minutes, int seconds, int precision)
+    {
+        var original = new TimeSpan(days, hours, minutes, seconds);
+        var humanized = original.Humanize(precision: precision);
+
+        Assert.Equal(original, humanized.DehumanizeTimeSpan());
+    }
+
+    [Fact]
     public void TryDehumanizeTimeSpanReturnsFalseForOverflowInput()
     {
         Assert.False("10675200d".TryDehumanizeTimeSpan(out _));

--- a/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
@@ -56,6 +56,17 @@ public class TimeSpanDehumanizeTests
     }
 
     [Fact]
+    public void DehumanizeTimeSpanParsesNegativeMinutesAndSecondsWhenConfigured()
+    {
+        var options = new TimeSpanDehumanizeOptions
+        {
+            ColonFormat = TimeSpanDehumanizeColonFormat.MinutesSeconds,
+        };
+
+        Assert.Equal(new TimeSpan(0, -18, -1), "-18:01".DehumanizeTimeSpan(options));
+    }
+
+    [Fact]
     public void DehumanizeTimeSpanParsesThreeHoursEighteenMinutesFromWordPhrases()
     {
         Assert.Equal(ThreeHoursEighteenMinutes, "3 hours 18 minutes".DehumanizeTimeSpan());


### PR DESCRIPTION
## Summary

Extends **#1800** (MVP TimeSpan dehumanize) with English word-phrase parsing:

- Skip `,` and `and` separators between number-unit tokens (`3 hours, 18 minutes`, `3 hours and 18 minutes`)
- Round-trip tests against `TimeSpan.Humanize()` output for hours/minutes/seconds/weeks

## Depends on

- **#1800** — merge first (or review stacked; this branch includes MVP commits)

## Out of scope

- Localized phrases (fi-FI, etc.)
- Calendar-month units from `Humanize()` (`11 months, 30 days`)
- `toWords: true` output (`three hours`)

Part of #691.

Made with [Cursor](https://cursor.com)