### PR TITLE
test: cover pt-PT "um" in WordsToNumber (#1669)

### DIFF
--- a/tests/Humanizer.Tests/WordsToNumberTests.cs
+++ b/tests/Humanizer.Tests/WordsToNumberTests.cs
@@ -369,6 +369,7 @@ public class WordsToNumberTests_Portuguese
 {
     [Theory]
     [InlineData("zero", 0)]
+    [InlineData("um", 1)]
     [InlineData("menos cinco", -5)]
     [InlineData("vinte e um", 21)]
     [InlineData("cento e cinco", 105)]
@@ -386,6 +387,7 @@ public class WordsToNumberTests_Portuguese
 
     [Theory]
     [InlineData("zero", 0, null)]
+    [InlineData("um", 1, null)]
     [InlineData("menos cinco", -5, null)]
     [InlineData("vinte e um", 21, null)]
     [InlineData("cento e cinco", 105, null)]


### PR DESCRIPTION
## Summary

Adds regression coverage for `"um".ToNumber(pt-PT)` — the exact case reported in #1669.

No production change: `pt.yml` already maps `um → 1` via token-map parser; v3.0.10 users hitting `DefaultWordsToNumberConverter` likely need a build that includes generated pt registration.

Part of #1669.

Made with [Cursor](https://cursor.com)