### PR TITLE
fix(ci): update .NET 11 preview and benchmark dependencies

### DIFF
--- a/.github/patches/results-comparer-sharpcompress-0.50.1.patch
+++ b/.github/patches/results-comparer-sharpcompress-0.50.1.patch
@@ -1,0 +1,30 @@
+diff --git a/src/tools/ResultsComparer/Data.cs b/src/tools/ResultsComparer/Data.cs
+index a663f1e..576768d 100644
+--- a/src/tools/ResultsComparer/Data.cs
++++ b/src/tools/ResultsComparer/Data.cs
+@@ -7,3 +6,0 @@ using SharpCompress.Archives;
+-using SharpCompress.Archives.GZip;
+-using SharpCompress.Archives.Tar;
+-using SharpCompress.Archives.Zip;
+@@ -24 +21 @@ namespace ResultsComparer
+-            using ZipArchive mainArchive = ZipArchive.Open(mainZipStream);
++            using IArchive mainArchive = ArchiveFactory.OpenArchive(mainZipStream);
+@@ -27 +24 @@ namespace ResultsComparer
+-            foreach (ZipArchiveEntry mainArchiveEntry in mainArchive.Entries.Where(e => !e.IsDirectory))
++            foreach (IArchiveEntry mainArchiveEntry in mainArchive.Entries.Where(e => !e.IsDirectory))
+@@ -33 +30 @@ namespace ResultsComparer
+-                    using ZipArchive zipArchive = ZipArchive.Open(zipArchiveEntryCopy);
++                    using IArchive zipArchive = ArchiveFactory.OpenArchive(zipArchiveEntryCopy);
+@@ -45 +42 @@ namespace ResultsComparer
+-                    using GZipArchive gZipArchive = GZipArchive.Open(zipArchiveEntryCopy);
++                    using IArchive gZipArchive = ArchiveFactory.OpenArchive(zipArchiveEntryCopy);
+@@ -52 +49 @@ namespace ResultsComparer
+-                            using TarArchive tarArchive = TarArchive.Open(tarCopy);
++                            using IArchive tarArchive = ArchiveFactory.OpenArchive(tarCopy);
+diff --git a/src/tools/ResultsComparer/Directory.Packages.props b/src/tools/ResultsComparer/Directory.Packages.props
+index d910ce3..9641b2c 100644
+--- a/src/tools/ResultsComparer/Directory.Packages.props
++++ b/src/tools/ResultsComparer/Directory.Packages.props
+@@ -12 +12 @@
+-    <PackageVersion Include="SharpCompress" Version="0.31.0" />
++    <PackageVersion Include="SharpCompress" Version="0.50.1" />

--- a/.github/workflows/benchmarks-baseline-vs-current.yml
+++ b/.github/workflows/benchmarks-baseline-vs-current.yml
@@ -11,10 +11,12 @@ on:
 
   push:
     paths:
-      - '.github/workflows/benchmarks-baseline-vs-current.yml'        
+      - '.github/workflows/benchmarks-baseline-vs-current.yml'
+      - '.github/patches/results-comparer-sharpcompress-0.50.1.patch'
   pull_request:
     paths:
       - '.github/workflows/benchmarks-baseline-vs-current.yml'
+      - '.github/patches/results-comparer-sharpcompress-0.50.1.patch'
 
   schedule:
     - cron: '0 4 * * 1'  # Every Monday at 04:00 UTC
@@ -51,8 +53,7 @@ jobs:
       - name: Setup .NET 11 preview
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: preview
+          dotnet-version: '11.0.100-preview.6.26359.118'
 
       - name: Display run information
         run: |
@@ -112,6 +113,7 @@ jobs:
     needs: benchmark
     env:
       BASELINE_VERSION: ${{ inputs.baselineVersion || '3.0.10' }}
+      RESULTS_COMPARER_COMMIT: 3c1fc107bbcb472535cbe9d7520b41acc12debd0
     strategy:
       fail-fast: false
       matrix:
@@ -148,12 +150,15 @@ jobs:
       - name: Setup .NET 11 preview
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: preview
+          dotnet-version: '11.0.100-preview.6.26359.118'
       
       - name: Clone and Build ResultsComparer
         run: |
-          git clone --depth 1 https://github.com/dotnet/performance "$RUNNER_TEMP/performance"
+          git init "$RUNNER_TEMP/performance"
+          git -C "$RUNNER_TEMP/performance" remote add origin https://github.com/dotnet/performance
+          git -C "$RUNNER_TEMP/performance" fetch --depth 1 origin "$RESULTS_COMPARER_COMMIT"
+          git -C "$RUNNER_TEMP/performance" checkout --detach FETCH_HEAD
+          git -C "$RUNNER_TEMP/performance" apply --unidiff-zero "$GITHUB_WORKSPACE/.github/patches/results-comparer-sharpcompress-0.50.1.patch"
 
           {
             echo '<configuration>'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ docs/                           # Jekyll documentation site
 
 ## Key Config Files
 
-- `global.json` - .NET SDK version (11.0.100-preview.3)
+- `global.json` - .NET SDK version (11.0.100-preview.6.26359.118)
 - `Directory.Build.props` - Shared MSBuild properties (nullable, warnings-as-errors, analyzers)
 - `Directory.Packages.props` - Central package management (all NuGet versions)
 - `version.json` - Nerdbank.GitVersioning semver config

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,8 +39,7 @@ stages:
     - task: UseDotNet@2
       displayName: 'Use .NET 11 SDK'
       inputs:
-        includePreviewVersions: true
-        version: 11.x
+        version: 11.0.100-preview.6.26359.118
 
     - task: DotNetCoreCLI@2
       inputs:
@@ -115,8 +114,7 @@ stages:
     - task: UseDotNet@2
       displayName: 'Use .NET 11 SDK'
       inputs:
-        includePreviewVersions: true
-        version: 11.x
+        version: 11.0.100-preview.6.26359.118
 
     # Install the code signing tool
     - task: DotNetCoreCLI@2

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.3",
+    "version": "11.0.100-preview.6.26359.118",
     "rollForward": "latestFeature",
     "allowPrerelease": true
   },


### PR DESCRIPTION
Here is a checklist you should tick through before submitting a pull request:
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [ ] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures

## Summary

Scheduled CodeQL and benchmark comparison jobs can run again: build environments now install the available .NET 11 Preview 6 SDK, and ResultsComparer no longer restores vulnerable SharpCompress 0.31.0.

The benchmark workflow pins the tested `dotnet/performance` revision and applies a fail-closed compatibility patch for SharpCompress 0.50.1 before restore. The patch updates the archive API calls required by the newer package rather than suppressing the security warning.

## Validation

- Packed Humanizer in Release configuration without warnings.
- Passed all 56,559 tests on each of `net8.0`, `net10.0`, and `net11.0`.
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` formatted 0 files.
- Recreated the pinned ResultsComparer checkout, applied the committed patch, restored from the workflow's package sources, built with 0 warnings/errors, launched `--help`, and confirmed SharpCompress 0.50.1 with no vulnerable packages reported.
