### PR TITLE
fix: make TimeSpan humanization counts overflow-safe

### DIFF
--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -213,7 +213,7 @@ public static class TimeSpanHumanizeExtensions
     {
         if (isTimeUnitToGetTheMaximumTimeUnit)
         {
-            return (int)totalTimeNumberOfUnits;
+            return (int)Math.Max(-int.MaxValue, Math.Min(totalTimeNumberOfUnits, int.MaxValue));
         }
 
         return timeNumberOfUnits;

--- a/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
@@ -467,4 +467,14 @@ public class TimeSpanHumanizeTests
         var actual = timeSpan.Humanize(precision: precision, culture: new(culture), maxUnit: TimeUnit.Year, toWords: true);
         Assert.Equal(expected: expected, actual);
     }
+
+    [Theory]
+    [InlineData(TimeUnit.Millisecond, "2147483647 milliseconds")]
+    [InlineData(TimeUnit.Second, "2147483647 seconds")]
+    [InlineData(TimeUnit.Minute, "2147483647 minutes")]
+    public void LargeTimeSpansSaturateCounts(TimeUnit unit, string expected)
+    {
+        Assert.Equal(expected, TimeSpan.MaxValue.Humanize(maxUnit: unit, minUnit: unit));
+        Assert.Equal(expected, TimeSpan.MinValue.Humanize(maxUnit: unit, minUnit: unit));
+    }
 }


### PR DESCRIPTION
## Summary

Very large negative `TimeSpan` values now humanize deterministically instead of throwing when milliseconds, seconds, or minutes are selected as the maximum unit. Counts outside the existing formatter's `int` range saturate at `int.MaxValue`, preserving the public formatter API and matching large positive spans across supported runtimes. Focused regressions cover `TimeSpan.MaxValue` and `TimeSpan.MinValue` for every unit that can overflow.

Related: #1791 (earlier contributor implementation of the same saturation contract).

Fixes #1728.

## Validation

- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 57,024 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 57,024 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 57,024 passed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temporary-path>` — succeeded without warnings or errors
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — no changes required

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or OSS
- [x] There are very few or no comments
- [x] XML documentation was reviewed; no public API changed
- [x] The PR is based on the latest `main`
- [x] The fixed issue is linked with `Fixes #1728`
- [x] Readme impact was reviewed; no documentation change is needed
- [x] Required builds and tests pass
