### PR TITLE
fix: preserve decimal points when titleizing

### DIFF
--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -9,7 +9,7 @@ namespace Humanizer;
 /// </summary>
 public static partial class StringHumanizeExtensions
 {
-    const string PascalCaseWordPartsPattern = @"(\p{Lu}?\p{Ll}+|[0-9]+\p{Ll}*|\p{Lu}+(?=\p{Lu}|[0-9]|\b)|\p{Lo}+)[,;]?";
+    const string PascalCaseWordPartsPattern = @"(\p{Lu}?\p{Ll}+|[0-9]+(?:\.[0-9]+)?\p{Ll}*|\p{Lu}+(?=\p{Lu}|[0-9]|\b)|\p{Lo}+)[,;]?";
 
 #if NET7_0_OR_GREATER
     [GeneratedRegex(PascalCaseWordPartsPattern, RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture)]

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -98,6 +98,7 @@ public class InflectorTests
     [InlineData("some-title: The beginning", "Some Title: The Beginning")]
     [InlineData("some_title:_the_beginning", "Some Title: the Beginning")]
     [InlineData("some title: The_beginning", "Some Title: The Beginning")]
+    [InlineData("thisIs3.5mmLong", "This Is 3.5mm Long")]
     public void Titleize(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Titleize());
 


### PR DESCRIPTION
## Summary

`Titleize()` now keeps the decimal point in inputs such as `thisIs3.5mmLong`, producing `This Is 3.5mm Long` instead of splitting the value into `3 5mm`.

This carries forward the focused decimal-token behavior contributed by @Ltwo3five in #1267. It intentionally does not normalize malformed repeated periods such as `3..5` into a different numeric value.

Fixes #1261.

## Validation

- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0`
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0`
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0`
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temporary-output>`
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`

## Checklist

- [x] Implementation is clean and follows the existing coding standards.
- [x] No code analysis warnings were introduced.
- [x] Proper regression coverage is included.
- [x] Contributor attribution is preserved in the commit.
- [x] No comments or public API documentation changes are required.
- [x] The branch is based on the latest `main`.
- [x] The fixed issue is linked with a closing reference.
- [x] No README change is required for this bug fix.
- [x] The supported test matrix and Release package build pass.
