### PR TITLE
fix: preserve date precision at exact unit multiples

### DIFF
--- a/src/Humanizer/DateTimeHumanizeStrategy/DateTimeHumanizeAlgorithms.cs
+++ b/src/Humanizer/DateTimeHumanizeStrategy/DateTimeHumanizeAlgorithms.cs
@@ -75,8 +75,7 @@ static class DateTimeHumanizeAlgorithms
         if (days > 31 && days < 365 * precision)
         {
             var factor = Convert.ToInt32(Math.Floor((double)days / 30));
-            var maxMonths = Convert.ToInt32(Math.Ceiling((double)days / 30));
-            months = days >= 30 * (factor + precision) ? maxMonths : maxMonths - 1;
+            months = days >= 30 * (factor + precision) ? factor + 1 : factor;
         }
 
         // year calculation
@@ -88,8 +87,7 @@ static class DateTimeHumanizeAlgorithms
         if (days > 365)
         {
             var factor = Convert.ToInt32(Math.Floor((double)days / 365));
-            var maxMonths = Convert.ToInt32(Math.Ceiling((double)days / 365));
-            years = days >= 365 * (factor + precision) ? maxMonths : maxMonths - 1;
+            years = days >= 365 * (factor + precision) ? factor + 1 : factor;
         }
 
         // start computing result from larger units to smaller ones

--- a/tests/Humanizer.Tests/DateTimeHumanizePrecisionStrategyTests.cs
+++ b/tests/Humanizer.Tests/DateTimeHumanizePrecisionStrategyTests.cs
@@ -105,6 +105,12 @@ public class DateTimeHumanizePrecisionStrategyTests
     [InlineData(31, "one month ago")]
     [InlineData(43, "one month ago")]
     [InlineData(53, "2 months ago")]
+    [InlineData(89, "3 months ago")]
+    [InlineData(90, "3 months ago")]
+    [InlineData(91, "3 months ago")]
+    [InlineData(729, "2 years ago")]
+    [InlineData(730, "2 years ago")]
+    [InlineData(731, "2 years ago")]
     public void DaysAgo(int days, string expected) =>
         DateHumanize.Verify(expected, days, TimeUnit.Day, Tense.Past, DefaultPrecision);
 
@@ -117,6 +123,12 @@ public class DateTimeHumanizePrecisionStrategyTests
     [InlineData(31, "one month from now")]
     [InlineData(43, "one month from now")]
     [InlineData(53, "2 months from now")]
+    [InlineData(89, "3 months from now")]
+    [InlineData(90, "3 months from now")]
+    [InlineData(91, "3 months from now")]
+    [InlineData(729, "2 years from now")]
+    [InlineData(730, "2 years from now")]
+    [InlineData(731, "2 years from now")]
     public void DaysFromNow(int days, string expected) =>
         DateHumanize.Verify(expected, days, TimeUnit.Day, Tense.Future, DefaultPrecision);
 


### PR DESCRIPTION
With 0.75 precision, exact 30-day and 365-day multiples no longer round below their immediate neighbors: 90 days now humanizes as three months, and 730 days as two years. The calculation starts from the completed-unit count and adds one only when the existing fractional precision threshold is crossed, preserving non-boundary behavior. Regression coverage exercises past and future values immediately around both affected multiples.

Validated with all 57,036 tests on net8.0, net10.0, and net11.0, a warning-free Release package build, and full format verification.

Fixes #1018.
