### PR TITLE
fix: avoid singularizing unrelated -men words

### DIFF
--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -68,8 +68,12 @@ public static class Vocabularies
         _default.AddSingular("([b|r|c]ook|room|smooth)ies$", "$1ie");
 
         _default.AddIrregular("person", "people");
-        _default.AddIrregular("man", "men");
-        _default.AddSingular("^(specimen|pacmen)$", "$1");
+        _default.AddIrregular("man", "men", matchEnding: false);
+        _default.AddIrregular("spokesman", "spokesmen", matchEnding: false);
+        _default.AddIrregular("policeman", "policemen", matchEnding: false);
+        _default.AddIrregular("woman", "women", matchEnding: false);
+        _default.AddIrregular("freshman", "freshmen", matchEnding: false);
+        _default.AddIrregular("chairman", "chairmen", matchEnding: false);
         _default.AddIrregular("human", "humans");
         _default.AddIrregular("child", "children");
         _default.AddIrregular("sex", "sexes");

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -68,7 +68,11 @@ public static class Vocabularies
         _default.AddSingular("([b|r|c]ook|room|smooth)ies$", "$1ie");
 
         _default.AddIrregular("person", "people");
-        _default.AddIrregular("man", "men");
+        _default.AddIrregular("man", "men", matchEnding: false);
+        _default.AddIrregular("spokesman", "spokesmen");
+        _default.AddIrregular("woman", "women");
+        _default.AddIrregular("freshman", "freshmen");
+        _default.AddIrregular("chairman", "chairmen");
         _default.AddIrregular("human", "humans");
         _default.AddIrregular("child", "children");
         _default.AddIrregular("sex", "sexes");

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -68,11 +68,8 @@ public static class Vocabularies
         _default.AddSingular("([b|r|c]ook|room|smooth)ies$", "$1ie");
 
         _default.AddIrregular("person", "people");
-        _default.AddIrregular("man", "men", matchEnding: false);
-        _default.AddIrregular("spokesman", "spokesmen");
-        _default.AddIrregular("woman", "women");
-        _default.AddIrregular("freshman", "freshmen");
-        _default.AddIrregular("chairman", "chairmen");
+        _default.AddIrregular("man", "men");
+        _default.AddSingular("^(specimen|pacmen)$", "$1");
         _default.AddIrregular("human", "humans");
         _default.AddIrregular("child", "children");
         _default.AddIrregular("sex", "sexes");

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -68,12 +68,8 @@ public static class Vocabularies
         _default.AddSingular("([b|r|c]ook|room|smooth)ies$", "$1ie");
 
         _default.AddIrregular("person", "people");
-        _default.AddIrregular("man", "men", matchEnding: false);
-        _default.AddIrregular("spokesman", "spokesmen", matchEnding: false);
-        _default.AddIrregular("policeman", "policemen", matchEnding: false);
-        _default.AddIrregular("woman", "women", matchEnding: false);
-        _default.AddIrregular("freshman", "freshmen", matchEnding: false);
-        _default.AddIrregular("chairman", "chairmen", matchEnding: false);
+        _default.AddIrregular("man", "men");
+        _default.AddSingular("(abdomen|acumen|agnomen|albumen|bitumen|catechumen|cerumen|cognomen|cyclamen|dolmen|duramen|energumen|examen|flamen|flehmen|foramen|germen|gravamen|hegumen|hymen|limen|lumen|nomen|numen|pacmen|praenomen|prenomen|putamen|ramen|regimen|rumen|specimen|stamen|tegmen|tegumen|velamen|yamen|^amen|^omen)$", "$1");
         _default.AddIrregular("human", "humans");
         _default.AddIrregular("child", "children");
         _default.AddIrregular("sex", "sexes");

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -61,6 +61,13 @@ public class InflectorTests
         Assert.Equal(singular, plural.Singularize(skipSimpleWords: true));
 
     [Theory]
+    [InlineData("abdomen")]
+    [InlineData("acumen")]
+    [InlineData("dolmen")]
+    [InlineData("hymen")]
+    [InlineData("lumen")]
+    [InlineData("omen")]
+    [InlineData("ramen")]
     [InlineData("specimen")]
     [InlineData("Specimen")]
     [InlineData("Pacmen")]

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -254,6 +254,7 @@ class PluralTestSource : IEnumerable<object[]>
         yield return ["person", "people"];
 
         yield return ["spokesman", "spokesmen"];
+        yield return ["policeman", "policemen"];
         yield return ["man", "men"];
         yield return ["woman", "women"];
         yield return ["freshman", "freshmen"];

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -61,6 +61,16 @@ public class InflectorTests
         Assert.Equal(singular, plural.Singularize(skipSimpleWords: true));
 
     [Theory]
+    [InlineData("specimen")]
+    [InlineData("Specimen")]
+    [InlineData("Pacmen")]
+    public void SingularizeDoesNotRewriteUnrelatedWordsEndingInMen(string word)
+    {
+        Assert.Equal(word, word.Singularize());
+        Assert.Equal(word, word.Singularize(inputIsKnownToBePlural: false));
+    }
+
+    [Theory]
     [InlineData("arrives", "arrive")]
     [InlineData("drives", "drive")]
     [InlineData("curves", "curve")]

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -262,6 +262,8 @@ class PluralTestSource : IEnumerable<object[]>
 
         yield return ["spokesman", "spokesmen"];
         yield return ["policeman", "policemen"];
+        yield return ["businessman", "businessmen"];
+        yield return ["seaman", "seamen"];
         yield return ["man", "men"];
         yield return ["woman", "women"];
         yield return ["freshman", "freshmen"];


### PR DESCRIPTION
Singularizing unrelated words ending in `-men` no longer corrupts them: `specimen` stays `specimen`, and `Pacmen` stays `Pacmen`. The exact `man`/`men` irregular and Humanizer's existing supported compound forms continue to round-trip, including the unknown-plurality path used by `ToQuantity`. Regression coverage exercises casing and both singularization modes.

Fixes #1011.

Validation completed with the full Humanizer test suite on net8.0, net10.0, and net11.0; Release package creation; and repository-wide formatting verification.

Here is a checklist you should tick through before submitting a pull request:
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [x] Required net8.0, net10.0, and net11.0 tests, Release pack, and formatting verification completed successfully
