### PR TITLE
fix: restore runtime enum humanization

### DIFF
--- a/src/Humanizer/EnumHumanizeExtensions.cs
+++ b/src/Humanizer/EnumHumanizeExtensions.cs
@@ -39,9 +39,10 @@ public static class EnumHumanizeExtensions
                 .MakeGenericMethod(input.GetType())
                 .Invoke(null, [input])!;
         }
-        catch (TargetInvocationException exception)
+        catch (TargetInvocationException exception) when (exception.InnerException is not null)
         {
-            throw exception.InnerException!;
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+            throw;
         }
     }
 

--- a/src/Humanizer/EnumHumanizeExtensions.cs
+++ b/src/Humanizer/EnumHumanizeExtensions.cs
@@ -5,6 +5,59 @@ namespace Humanizer;
 /// </summary>
 public static class EnumHumanizeExtensions
 {
+#if NET6_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The method is only used by Humanize which already has RequiresUnreferencedCode")]
+    [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "The method is only used by Humanize which already has RequiresUnreferencedCode")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "The method is only used by Humanize which already has RequiresDynamicCode")]
+#endif
+    static MethodInfo GetGenericHumanizeMethodInfo() =>
+        typeof(EnumHumanizeExtensions)
+            .GetMethods()
+            .Single(method =>
+                method.Name == nameof(Humanize) &&
+                method.IsGenericMethodDefinition &&
+                method.GetParameters().Length == 1 &&
+                method.GetGenericArguments().Length == 1);
+
+    static readonly Lazy<MethodInfo> GenericHumanizeMethod = new(GetGenericHumanizeMethodInfo);
+
+    /// <summary>
+    /// Converts an enum value to a human-readable string when the concrete enum type is only known at runtime.
+    /// </summary>
+    /// <param name="input">The enum value to be humanized.</param>
+    /// <returns>A human-readable string representation of the enum value.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(EnumHumanizeExtensions))]
+#endif
+    public static string Humanize(this Enum input)
+    {
+        try
+        {
+            return (string)GenericHumanizeMethod.Value
+                .MakeGenericMethod(input.GetType())
+                .Invoke(null, [input])!;
+        }
+        catch (TargetInvocationException exception)
+        {
+            throw exception.InnerException!;
+        }
+    }
+
+    /// <summary>
+    /// Converts an enum value to a human-readable string with the specified letter casing when the concrete enum type is only known at runtime.
+    /// </summary>
+    /// <param name="input">The enum value to be humanized.</param>
+    /// <param name="casing">The desired letter casing to apply to the humanized enum value.</param>
+    /// <returns>A human-readable string representation of the enum value with the specified casing applied.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+#endif
+    public static string Humanize(this Enum input, LetterCasing casing) =>
+        input.Humanize().ApplyCase(casing);
+
     /// <summary>
     /// Converts an enum value to a human-readable string by intelligently formatting the enum member name
     /// and respecting any <see cref="System.ComponentModel.DescriptionAttribute"/> applied to the member.

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -266,6 +266,13 @@ namespace Humanizer
     }
     public static class EnumHumanizeExtensions
     {
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods, typeof(Humanizer.EnumHumanizeExtensions))]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing) { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input)
             where T :  struct, System.Enum { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing)

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -266,6 +266,13 @@ namespace Humanizer
     }
     public static class EnumHumanizeExtensions
     {
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods, typeof(Humanizer.EnumHumanizeExtensions))]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing) { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input)
             where T :  struct, System.Enum { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing)

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -265,6 +265,13 @@ namespace Humanizer
     }
     public static class EnumHumanizeExtensions
     {
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods, typeof(Humanizer.EnumHumanizeExtensions))]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing) { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input)
             where T :  struct, System.Enum { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing)

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -241,6 +241,8 @@ namespace Humanizer
     }
     public static class EnumHumanizeExtensions
     {
+        public static string Humanize(this System.Enum input) { }
+        public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing) { }
         public static string Humanize<T>(this T input)
             where T :  struct, System.Enum { }
         public static string Humanize<T>(this T input, Humanizer.LetterCasing casing)

--- a/tests/Humanizer.Tests/EnumHumanizeTests.cs
+++ b/tests/Humanizer.Tests/EnumHumanizeTests.cs
@@ -23,6 +23,19 @@ public class EnumHumanizeTests
         Assert.Equal(EnumTestsResources.MemberWithoutDescriptionAttributeSentence, EnumUnderTest.MemberWithoutDescriptionAttribute.Humanize());
 
     [Fact]
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+    public void CanHumanizeWhenEnumTypeIsKnownAtRuntimeOnly()
+    {
+        Enum value = EnumUnderTest.MemberWithoutDescriptionAttribute;
+
+        Assert.Equal(EnumTestsResources.MemberWithoutDescriptionAttributeSentence, value.Humanize());
+        Assert.Equal(
+            EnumTestsResources.MemberWithoutDescriptionAttributeTitle,
+            value.Humanize(LetterCasing.Title));
+    }
+
+    [Fact]
     public void CanApplyTitleCasingOnEnumHumanization() =>
         Assert.Equal(
             EnumTestsResources.MemberWithoutDescriptionAttributeTitle,

--- a/tests/Humanizer.Tests/EnumHumanizeTests.cs
+++ b/tests/Humanizer.Tests/EnumHumanizeTests.cs
@@ -36,6 +36,18 @@ public class EnumHumanizeTests
     }
 
     [Fact]
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+    public void RuntimeEnumHumanizationPreservesInnerExceptionStack()
+    {
+        Enum value = (EnumUnderTest)int.MaxValue;
+
+        var exception = Assert.Throws<KeyNotFoundException>(() => value.Humanize());
+
+        Assert.Contains("Humanize[T]", exception.StackTrace);
+    }
+
+    [Fact]
     public void CanApplyTitleCasingOnEnumHumanization() =>
         Assert.Equal(
             EnumTestsResources.MemberWithoutDescriptionAttributeTitle,


### PR DESCRIPTION
## Summary

Runtime-typed enum values can call `Humanize()` again, restoring source and binary compatibility for callers whose concrete enum type is not known at compile time. The runtime overloads delegate to the existing generic implementation and expose the required trimming/AOT annotations.

Fixes #1653

## Validation

- `net8.0`: 57,022/57,022 tests passed through `dotnet test`
- `net10.0`: clean build with 0 warnings/errors; 57,022/57,022 tests passed through the compiled Microsoft.Testing.Platform application
- `net11.0`: clean build with 0 warnings/errors; 57,022/57,022 tests passed through the compiled Microsoft.Testing.Platform application
- Release pack succeeded for all targets and produced `Humanizer.3.5.0-preview.65.ga8181c81b5.nupkg`
- Full solution formatting passed with 0/2,430 files changed; the post-rebase changed-file analyzer and whitespace checks also passed with 0 files changed
- Public API approvals updated for .NET 8, .NET 10, .NET 11, and .NET Framework 4.8

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No copied third-party code requires disclosure
- [x] There are very few or no comments
- [x] XML documentation is added for the restored public APIs
- [x] The branch is rebased on the latest `main`
- [x] The fixed issue is linked with closing syntax
- [x] README changes are not required because this restores the previous API
- [x] Repository build, test, pack, API approval, and formatting checks were run
