### PR TITLE
fix: decompose negative time spans consistently

### DIFF
--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -155,58 +155,59 @@ public static class TimeSpanHumanizeExtensions
     static int GetTimeUnitNumericalValue(TimeUnit timeUnitToGet, TimeSpan timespan, TimeUnit maximumTimeUnit)
     {
         var isTimeUnitToGetTheMaximumTimeUnit = timeUnitToGet == maximumTimeUnit;
+        var absoluteDays = Math.Abs(timespan.Days);
         return timeUnitToGet switch
         {
             TimeUnit.Millisecond => GetNormalCaseTimeAsInteger(timespan.Milliseconds, timespan.TotalMilliseconds, isTimeUnitToGetTheMaximumTimeUnit),
             TimeUnit.Second => GetNormalCaseTimeAsInteger(timespan.Seconds, timespan.TotalSeconds, isTimeUnitToGetTheMaximumTimeUnit),
             TimeUnit.Minute => GetNormalCaseTimeAsInteger(timespan.Minutes, timespan.TotalMinutes, isTimeUnitToGetTheMaximumTimeUnit),
             TimeUnit.Hour => GetNormalCaseTimeAsInteger(timespan.Hours, timespan.TotalHours, isTimeUnitToGetTheMaximumTimeUnit),
-            TimeUnit.Day => GetSpecialCaseDaysAsInteger(timespan, maximumTimeUnit),
-            TimeUnit.Week => GetSpecialCaseWeeksAsInteger(timespan, isTimeUnitToGetTheMaximumTimeUnit),
-            TimeUnit.Month => GetSpecialCaseMonthAsInteger(timespan, isTimeUnitToGetTheMaximumTimeUnit),
-            TimeUnit.Year => GetSpecialCaseYearAsInteger(timespan),
+            TimeUnit.Day => GetSpecialCaseDaysAsInteger(absoluteDays, maximumTimeUnit),
+            TimeUnit.Week => GetSpecialCaseWeeksAsInteger(absoluteDays, isTimeUnitToGetTheMaximumTimeUnit),
+            TimeUnit.Month => GetSpecialCaseMonthAsInteger(absoluteDays, isTimeUnitToGetTheMaximumTimeUnit),
+            TimeUnit.Year => GetSpecialCaseYearAsInteger(absoluteDays),
             _ => 0
         };
     }
 
-    static int GetSpecialCaseMonthAsInteger(TimeSpan timespan, bool isTimeUnitToGetTheMaximumTimeUnit)
+    static int GetSpecialCaseMonthAsInteger(int days, bool isTimeUnitToGetTheMaximumTimeUnit)
     {
         if (isTimeUnitToGetTheMaximumTimeUnit)
         {
-            return (int)(timespan.Days / DaysInAMonth);
+            return (int)(days / DaysInAMonth);
         }
 
-        var remainingDays = timespan.Days % DaysInAYear;
+        var remainingDays = days % DaysInAYear;
         return (int)(remainingDays / DaysInAMonth);
     }
 
-    static int GetSpecialCaseYearAsInteger(TimeSpan timespan) =>
-        (int)(timespan.Days / DaysInAYear);
+    static int GetSpecialCaseYearAsInteger(int days) =>
+        (int)(days / DaysInAYear);
 
-    static int GetSpecialCaseWeeksAsInteger(TimeSpan timespan, bool isTimeUnitToGetTheMaximumTimeUnit)
+    static int GetSpecialCaseWeeksAsInteger(int days, bool isTimeUnitToGetTheMaximumTimeUnit)
     {
-        if (isTimeUnitToGetTheMaximumTimeUnit || timespan.Days < DaysInAMonth)
+        if (isTimeUnitToGetTheMaximumTimeUnit || days < DaysInAMonth)
         {
-            return timespan.Days / DaysInAWeek;
+            return days / DaysInAWeek;
         }
 
         return 0;
     }
 
-    static int GetSpecialCaseDaysAsInteger(TimeSpan timespan, TimeUnit maximumTimeUnit)
+    static int GetSpecialCaseDaysAsInteger(int days, TimeUnit maximumTimeUnit)
     {
         if (maximumTimeUnit == TimeUnit.Day)
         {
-            return timespan.Days;
+            return days;
         }
 
-        if (timespan.Days < DaysInAMonth || maximumTimeUnit == TimeUnit.Week)
+        if (days < DaysInAMonth || maximumTimeUnit == TimeUnit.Week)
         {
-            var remainingDays = timespan.Days % DaysInAWeek;
+            var remainingDays = days % DaysInAWeek;
             return remainingDays;
         }
 
-        return (int)(timespan.Days % DaysInAMonth);
+        return (int)(days % DaysInAMonth);
     }
 
     static int GetNormalCaseTimeAsInteger(int timeNumberOfUnits, double totalTimeNumberOfUnits, bool isTimeUnitToGetTheMaximumTimeUnit)

--- a/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
@@ -53,6 +53,17 @@ public class TimeSpanHumanizeTests
     }
 
     [Theory]
+    [InlineData(-30, "4 weeks, 2 days")]
+    [InlineData(-31, "1 month")]
+    [InlineData(-32, "1 month, 1 day")]
+    [InlineData(-60, "1 month, 29 days")]
+    public void NegativeMonths(int days, string expected)
+    {
+        var actual = TimeSpan.FromDays(days).Humanize(precision: 3, maxUnit: TimeUnit.Month, minUnit: TimeUnit.Minute);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
     [InlineData(14, "2 weeks")]
     [InlineData(7, "1 week")]
     [InlineData(-14, "2 weeks")]


### PR DESCRIPTION
## Summary

Negative time spans longer than a month now produce the same month/day breakdown as equivalent positive spans. They previously could report overlapping month, week, and day totals because signed day counts drove the decomposition branches. Day-based decomposition now uses the magnitude at the shared decision point, while the separate large-unit overflow handling remains unchanged.

Fixes #1031.

## Validation

- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 57,041 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 57,041 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 57,041 passed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp>` — package created for all targets
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — 0 of 2,535 files changed
