### PR TITLE
fix: honor explicit cultures in clock notation

### DIFF
--- a/src/Humanizer.SourceGenerators/Common/GenerationHelpers.cs
+++ b/src/Humanizer.SourceGenerators/Common/GenerationHelpers.cs
@@ -72,8 +72,8 @@ public sealed partial class HumanizerSourceGenerator
 
         static string? CreateTimeOnlyToClockNotation(string profile) =>
             profile == "default"
-                ? "TimeOnlyToClockNotationProfileCatalog.Resolve(" + Quote("en") + ")"
-                : "TimeOnlyToClockNotationProfileCatalog.Resolve(" + Quote(profile) + ")";
+                ? "TimeOnlyToClockNotationProfileCatalog.Resolve(" + Quote("en") + ", culture)"
+                : "TimeOnlyToClockNotationProfileCatalog.Resolve(" + Quote(profile) + ", culture)";
 
         static string? CreateWordsToNumber(string profile, string? argument) =>
             profile switch

--- a/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/TimeOnlyToClockNotationProfileCatalogInput.cs
+++ b/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/TimeOnlyToClockNotationProfileCatalogInput.cs
@@ -55,12 +55,13 @@ public sealed partial class HumanizerSourceGenerator
             builder.AppendLine("#if NET6_0_OR_GREATER");
             builder.AppendLine();
             builder.AppendLine("using System;");
+            builder.AppendLine("using System.Globalization;");
             builder.AppendLine();
             builder.AppendLine("namespace Humanizer;");
             builder.AppendLine();
             builder.AppendLine("static partial class TimeOnlyToClockNotationProfileCatalog");
             builder.AppendLine("{");
-            builder.AppendLine("    public static ITimeOnlyToClockNotationConverter Resolve(string kind)");
+            builder.AppendLine("    public static ITimeOnlyToClockNotationConverter Resolve(string kind, CultureInfo culture)");
             builder.AppendLine("    {");
             builder.AppendLine("        switch (kind)");
             builder.AppendLine("        {");
@@ -71,7 +72,7 @@ public sealed partial class HumanizerSourceGenerator
                 builder.Append(QuoteLiteral(profile.ProfileName));
                 builder.Append(": return ");
                 builder.Append(GetCatalogPropertyName(profile.ProfileName));
-                builder.AppendLine(";");
+                builder.AppendLine(".WithCulture(culture);");
             }
 
             builder.AppendLine("            default: throw new ArgumentOutOfRangeException(nameof(kind), kind, \"Unknown clock-notation profile.\");");
@@ -85,7 +86,7 @@ public sealed partial class HumanizerSourceGenerator
                     builder,
                     "    ",
                     "static",
-                    "ITimeOnlyToClockNotationConverter",
+                    "PhraseClockNotationConverter",
                     GetCatalogPropertyName(profile.ProfileName),
                     TimeOnlyToClockNotationEngineContractFactory.Create(profile, contracts));
                 builder.AppendLine();

--- a/src/Humanizer/Configuration/TimeOnlyToClockNotationConvertersRegistry.cs
+++ b/src/Humanizer/Configuration/TimeOnlyToClockNotationConvertersRegistry.cs
@@ -4,7 +4,7 @@ namespace Humanizer;
 
 class TimeOnlyToClockNotationConvertersRegistry : LocaliserRegistry<ITimeOnlyToClockNotationConverter>
 {
-    public TimeOnlyToClockNotationConvertersRegistry() : base(_ => TimeOnlyToClockNotationProfileCatalog.Resolve("en")) =>
+    public TimeOnlyToClockNotationConvertersRegistry() : base(culture => TimeOnlyToClockNotationProfileCatalog.Resolve("en", culture)) =>
         TimeOnlyToClockNotationConvertersRegistryRegistrations.Register(this);
 }
 

--- a/src/Humanizer/Configuration/TimeOnlyToClockNotationConvertersRegistry.cs
+++ b/src/Humanizer/Configuration/TimeOnlyToClockNotationConvertersRegistry.cs
@@ -4,7 +4,7 @@ namespace Humanizer;
 
 class TimeOnlyToClockNotationConvertersRegistry : LocaliserRegistry<ITimeOnlyToClockNotationConverter>
 {
-    public TimeOnlyToClockNotationConvertersRegistry() : base(culture => TimeOnlyToClockNotationProfileCatalog.Resolve("en", culture)) =>
+    public TimeOnlyToClockNotationConvertersRegistry() : base(_ => TimeOnlyToClockNotationProfileCatalog.Resolve("en", CultureInfo.InvariantCulture)) =>
         TimeOnlyToClockNotationConvertersRegistryRegistrations.Register(this);
 }
 

--- a/src/Humanizer/Localisation/TimeToClockNotation/PhraseClockNotationConverter.cs
+++ b/src/Humanizer/Localisation/TimeToClockNotation/PhraseClockNotationConverter.cs
@@ -18,8 +18,8 @@ class PhraseClockNotationConverter(PhraseClockNotationProfile profile, CultureIn
     {
     }
 
-    internal PhraseClockNotationConverter WithCulture(CultureInfo culture) =>
-        new(profile, culture);
+    internal PhraseClockNotationConverter WithCulture(CultureInfo requestedCulture) =>
+        new(profile, requestedCulture);
 
     /// <summary>
     /// Converts the given time using the phrase-clock profile.

--- a/src/Humanizer/Localisation/TimeToClockNotation/PhraseClockNotationConverter.cs
+++ b/src/Humanizer/Localisation/TimeToClockNotation/PhraseClockNotationConverter.cs
@@ -7,10 +7,19 @@ namespace Humanizer;
 /// through YAML-driven configuration: bucket phrases, hour modes, day periods, range templates,
 /// hour/minute suffixes, article selection, and Eifeler rule post-processing.
 /// </summary>
-class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOnlyToClockNotationConverter
+class PhraseClockNotationConverter(PhraseClockNotationProfile profile, CultureInfo culture) : ITimeOnlyToClockNotationConverter
 {
     readonly PhraseClockNotationProfile profile = profile;
+    readonly CultureInfo culture = culture;
     readonly Dictionary<string, TemplatePlan> templatePlans = BuildTemplatePlans(profile);
+
+    internal PhraseClockNotationConverter(PhraseClockNotationProfile profile)
+        : this(profile, CultureInfo.CurrentUICulture)
+    {
+    }
+
+    internal PhraseClockNotationConverter WithCulture(CultureInfo culture) =>
+        new(profile, culture);
 
     /// <summary>
     /// Converts the given time using the phrase-clock profile.
@@ -128,9 +137,9 @@ class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOn
         {
             baseWord = profile.HourGender switch
             {
-                GrammaticalGender.Feminine => hourValue.ToWords(GrammaticalGender.Feminine),
-                GrammaticalGender.Neuter => hourValue.ToWords(GrammaticalGender.Neuter),
-                _ => hourValue.ToWords(GrammaticalGender.Masculine)
+                GrammaticalGender.Feminine => hourValue.ToWords(GrammaticalGender.Feminine, culture),
+                GrammaticalGender.Neuter => hourValue.ToWords(GrammaticalGender.Neuter, culture),
+                _ => hourValue.ToWords(GrammaticalGender.Masculine, culture)
             };
         }
 
@@ -166,9 +175,9 @@ class PhraseClockNotationConverter(PhraseClockNotationProfile profile) : ITimeOn
 
         var words = profile.MinuteGender switch
         {
-            GrammaticalGender.Feminine => minutes.ToWords(GrammaticalGender.Feminine),
-            GrammaticalGender.Neuter => minutes.ToWords(GrammaticalGender.Neuter),
-            _ => minutes.ToWords()
+            GrammaticalGender.Feminine => minutes.ToWords(GrammaticalGender.Feminine, culture),
+            GrammaticalGender.Neuter => minutes.ToWords(GrammaticalGender.Neuter, culture),
+            _ => minutes.ToWords(culture)
         };
 
         // Slovak and similar locales write compound tens+units without spaces in clock notation

--- a/src/Humanizer/TimeOnlyToClockNotationExtensions.cs
+++ b/src/Humanizer/TimeOnlyToClockNotationExtensions.cs
@@ -45,8 +45,12 @@ public static class TimeOnlyToClockNotationExtensions
     /// <param name="roundToNearestFive">The rounding mode to apply before formatting the time.</param>
     /// <param name="culture">The culture to use.</param>
     /// <returns>A culture-specific string representation of the time in clock notation.</returns>
-    public static string ToClockNotation(this TimeOnly input, ClockNotationRounding roundToNearestFive, CultureInfo culture) =>
-        Configurator.TimeOnlyToClockNotationConverters.ResolveForCulture(culture).Convert(input, roundToNearestFive);
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="culture"/> is <c>null</c>.</exception>
+    public static string ToClockNotation(this TimeOnly input, ClockNotationRounding roundToNearestFive, CultureInfo culture)
+    {
+        ArgumentNullException.ThrowIfNull(culture);
+        return Configurator.TimeOnlyToClockNotationConverters.ResolveForCulture(culture).Convert(input, roundToNearestFive);
+    }
 }
 
 #endif

--- a/src/Humanizer/TimeOnlyToClockNotationExtensions.cs
+++ b/src/Humanizer/TimeOnlyToClockNotationExtensions.cs
@@ -37,6 +37,16 @@ public static class TimeOnlyToClockNotationExtensions
     /// </example>
     public static string ToClockNotation(this TimeOnly input, ClockNotationRounding roundToNearestFive = ClockNotationRounding.None) =>
         Configurator.TimeOnlyToClockNotationConverter.Convert(input, roundToNearestFive);
+
+    /// <summary>
+    /// Converts a <see cref="TimeOnly"/> value to clock notation using the specified culture.
+    /// </summary>
+    /// <param name="input">The time to be converted to clock notation.</param>
+    /// <param name="roundToNearestFive">The rounding mode to apply before formatting the time.</param>
+    /// <param name="culture">The culture to use.</param>
+    /// <returns>A culture-specific string representation of the time in clock notation.</returns>
+    public static string ToClockNotation(this TimeOnly input, ClockNotationRounding roundToNearestFive, CultureInfo culture) =>
+        Configurator.TimeOnlyToClockNotationConverters.ResolveForCulture(culture).Convert(input, roundToNearestFive);
 }
 
 #endif

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.cs
@@ -63,6 +63,8 @@ public partial class HumanizerSourceGeneratorTests
         var source = GetGeneratedSource("TimeOnlyToClockNotationProfileCatalog.g.cs");
 
         Assert.Contains("new PhraseClockNotationConverter(", source);
+        Assert.Contains("Resolve(string kind, CultureInfo culture)", source);
+        Assert.Contains(".WithCulture(culture);", source);
         Assert.DoesNotContain("new FrenchTimeOnlyToClockNotationConverter()", source);
         Assert.DoesNotContain("new GermanTimeOnlyToClockNotationConverter()", source);
         Assert.DoesNotContain("new LuxembourgishTimeOnlyToClockNotationConverter()", source);

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -1868,6 +1868,7 @@ namespace Humanizer
     public static class TimeOnlyToClockNotationExtensions
     {
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive = 0) { }
+        public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive, System.Globalization.CultureInfo culture) { }
     }
     public static class TimeSpanHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -1868,6 +1868,7 @@ namespace Humanizer
     public static class TimeOnlyToClockNotationExtensions
     {
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive = 0) { }
+        public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive, System.Globalization.CultureInfo culture) { }
     }
     public static class TimeSpanHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -1867,6 +1867,7 @@ namespace Humanizer
     public static class TimeOnlyToClockNotationExtensions
     {
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive = 0) { }
+        public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive, System.Globalization.CultureInfo culture) { }
     }
     public static class TimeSpanHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/Localisation/LocaleRegistrySweepTests.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleRegistrySweepTests.cs
@@ -341,6 +341,29 @@ public class LocaleRegistrySweepTests
     }
 
     [Theory]
+    [InlineData("en-US", "one twenty-three")]
+    [InlineData("en-IN", "one twenty three")]
+    [InlineData("es-ES", "la una y veintitrés de la tarde")]
+    [InlineData("fr-FR", "treize heures vingt-trois")]
+    public void TimeOnlyToClockNotation_ResolvedCulture_DoesNotUseCurrentUiCulture(string localeName, string expected)
+    {
+        using var _ = new DistinctCultureSwap(new("en-US"), new("de-DE"));
+        var converter = Configurator.TimeOnlyToClockNotationConverters.ResolveForCulture(new(localeName));
+
+        Assert.Equal(expected, converter.Convert(new(13, 23), ClockNotationRounding.None));
+    }
+
+    [Fact]
+    public void TimeOnlyToClockNotation_ExplicitCulture_DoesNotUseCurrentUiCulture()
+    {
+        using var _ = new DistinctCultureSwap(new("en-US"), new("de-DE"));
+
+        Assert.Equal(
+            "twenty-five past one",
+            new TimeOnly(13, 23).ToClockNotation(ClockNotationRounding.NearestFiveMinutes, new("en-US")));
+    }
+
+    [Theory]
     [MemberData(nameof(LocaleCoverageData.TimeOnlyToClockNotation1323RoundedExpectationTheoryData), MemberType = typeof(LocaleCoverageData))]
     public void TimeOnlyToClockNotation_1323RoundedToNearestFiveMinutes_UsesExpectedForms(string localeName, ClockExpectationRow expected)
     {

--- a/tests/Humanizer.Tests/Localisation/LocaleRegistrySweepTests.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleRegistrySweepTests.cs
@@ -363,6 +363,16 @@ public class LocaleRegistrySweepTests
             new TimeOnly(13, 23).ToClockNotation(ClockNotationRounding.NearestFiveMinutes, new("en-US")));
     }
 
+    [Fact]
+    public void TimeOnlyToClockNotation_UnsupportedCulture_UsesEnglishFallback()
+    {
+        using var _ = new DistinctCultureSwap(new("en-US"), new("fr-FR"));
+
+        Assert.Equal(
+            "one twenty-three",
+            new TimeOnly(13, 23).ToClockNotation(ClockNotationRounding.None, new("eo")));
+    }
+
     [Theory]
     [MemberData(nameof(LocaleCoverageData.TimeOnlyToClockNotation1323RoundedExpectationTheoryData), MemberType = typeof(LocaleCoverageData))]
     public void TimeOnlyToClockNotation_1323RoundedToNearestFiveMinutes_UsesExpectedForms(string localeName, ClockExpectationRow expected)

--- a/tests/Humanizer.Tests/Localisation/LocaleRegistrySweepTests.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleRegistrySweepTests.cs
@@ -373,6 +373,15 @@ public class LocaleRegistrySweepTests
             new TimeOnly(13, 23).ToClockNotation(ClockNotationRounding.None, new("eo")));
     }
 
+    [Fact]
+    public void TimeOnlyToClockNotation_ExplicitCulture_ThrowsForNullCulture()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new TimeOnly(13, 23).ToClockNotation(ClockNotationRounding.None, null!));
+
+        Assert.Equal("culture", exception.ParamName);
+    }
+
     [Theory]
     [MemberData(nameof(LocaleCoverageData.TimeOnlyToClockNotation1323RoundedExpectationTheoryData), MemberType = typeof(LocaleCoverageData))]
     public void TimeOnlyToClockNotation_1323RoundedToNearestFiveMinutes_UsesExpectedForms(string localeName, ClockExpectationRow expected)


### PR DESCRIPTION
## Summary

Clock notation resolved for an explicit culture no longer mixes localized templates with number words from `CurrentUICulture`. For example, a French converter used under a German UI culture now returns fully French output, and callers can choose a culture through a backward-compatible overload without changing `ITimeOnlyToClockNotationConverter`.

@RenNagasaki first proposed the explicit-culture API in #1537. This reimplements that idea on the current YAML-generated phrase-clock engine and preserves Julian Katzwinkel's contribution through commit co-authorship.

Fixes #1519.

## Test plan

- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 57,042 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 57,042 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 57,042 passed
- `dotnet test --project tests/Humanizer.SourceGenerators.Tests/Humanizer.SourceGenerators.Tests.csproj` — 222 passed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <path>` — succeeded without warnings
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — clean

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or other OSS
- [x] There are very few comments
- [x] XML documentation is added for the public overload
- [x] The branch is rebased on the latest `main`
- [x] The issue is linked with a closing reference
- [x] README changes are not needed; the public API addition is documented in XML
- [x] The repository test, pack, and formatting checks pass
