### PR TITLE
test: cover sixty-day date precision regression

### DIFF
--- a/tests/Humanizer.Tests/DateTimeOffsetHumanizeTests.cs
+++ b/tests/Humanizer.Tests/DateTimeOffsetHumanizeTests.cs
@@ -57,6 +57,20 @@ public class DateTimeOffsetHumanizeTests
         Assert.Equal(expectedResult, actualResult);
     }
 
+    [Theory]
+    [InlineData(27)]
+    [InlineData(28)]
+    [InlineData(29)]
+    public void PrecisionStrategy_TwoMonthsAroundSixtyDays(int day)
+    {
+        Configurator.DateTimeOffsetHumanizeStrategy = new PrecisionDateTimeOffsetHumanizeStrategy(0.75);
+
+        var inputTime = new DateTimeOffset(2019, 01, day, 0, 0, 0, TimeSpan.Zero);
+        var baseTime = new DateTimeOffset(2019, 03, 29, 0, 0, 0, TimeSpan.Zero);
+
+        Assert.Equal("2 months ago", inputTime.Humanize(baseTime));
+    }
+
     [Fact]
     public void Never()
     {


### PR DESCRIPTION
## Summary

The reported 59/60/61-day `DateTimeOffset` inputs now have exact regression coverage and consistently humanize as two months. The shared rounding fix is already on `main`; this follow-up adds only the original public reproduction, with no duplicate production change.

Thanks to @tompazourek for the report and @AKTheKnight for the original root-cause analysis.

Fixes #805.

Related: #1814

## Validation

- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0`
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0`
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0`
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temporary-output>`
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`

## Checklist

- [x] The change is limited to focused regression coverage.
- [x] Existing coding standards and formatting are preserved.
- [x] No code analysis warnings were introduced.
- [x] No copied implementation code is included.
- [x] No comments, XML documentation, or README changes are required.
- [x] The branch is based on current `main`.
- [x] The fixed issue and related PR are linked.
- [x] The supported test matrix and Release package build pass.
