### PR TITLE
Fix Camelize dropping leading underscores

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -512,6 +512,7 @@ Convert strings to various coding conventions:
 
 // Camelize: lowerCamelCase without spaces
 "some_title for something".Camelize() => "someTitleForSomething"
+"_some_title".Camelize() => "_someTitle"
 ```
 
 

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -211,14 +211,15 @@ public static partial class InflectorExtensions
             leadingUnderscoreCount++;
         }
 
+        var suffix = leadingUnderscoreCount > 0 ? input[leadingUnderscoreCount..] : input;
         string camelized;
-        if (TryPascalizeAscii(input, lowerFirst: true, out var result))
+        if (TryPascalizeAscii(suffix, lowerFirst: true, out var result))
         {
             camelized = result;
         }
         else
         {
-            var word = input.Pascalize();
+            var word = suffix.Pascalize();
             camelized = word.Length > 0
                 ? StringHumanizeExtensions.Concat(
                     char.ToLowerInvariant(word[0]),

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -181,16 +181,17 @@ public static partial class InflectorExtensions
                 .Value.ToUpperInvariant());
 
     /// <summary>
-    /// Converts a string to camelCase (lowerCamelCase) by capitalizing the first letter of each word
-    /// except the first word, and removing spaces, underscores, and dashes.
+    /// Converts a string to camelCase (lowerCamelCase) by preserving leading underscores, capitalizing
+    /// the first letter of each word except the first word, and removing other spaces, underscores, and dashes.
     /// </summary>
     /// <param name="input">The string to be camelized. Must not be null.</param>
     /// <returns>
-    /// A camelCase version of the input where the first word starts with a lowercase letter,
-    /// subsequent words start with uppercase letters, and spaces, underscores, and dashes are removed.
+    /// A camelCase version of the input where leading underscores are preserved, the first word starts
+    /// with a lowercase letter, subsequent words start with uppercase letters, and other separators are removed.
     /// </returns>
     /// <remarks>
-    /// camelCase is the same as PascalCase except the first character is lowercase.
+    /// camelCase is the same as PascalCase except any leading underscores are preserved and the first
+    /// character after them is lowercase.
     /// It's commonly used for variable and method parameter names in .NET.
     /// Casing is culture-invariant.
     /// </remarks>
@@ -199,21 +200,37 @@ public static partial class InflectorExtensions
     /// "some_property_name".Camelize() => "somePropertyName"
     /// "some property name".Camelize() => "somePropertyName"
     /// "SomePropertyName".Camelize() => "somePropertyName"
+    /// "_some_property_name".Camelize() => "_somePropertyName"
     /// </code>
     /// </example>
     public static string Camelize(this string input)
     {
-        if (TryPascalizeAscii(input, lowerFirst: true, out var result))
+        var leadingUnderscoreCount = 0;
+        while (leadingUnderscoreCount < input.Length && input[leadingUnderscoreCount] == '_')
         {
-            return result;
+            leadingUnderscoreCount++;
         }
 
-        var word = input.Pascalize();
-        return word.Length > 0
+        string camelized;
+        if (TryPascalizeAscii(input, lowerFirst: true, out var result))
+        {
+            camelized = result;
+        }
+        else
+        {
+            var word = input.Pascalize();
+            camelized = word.Length > 0
+                ? StringHumanizeExtensions.Concat(
+                    char.ToLowerInvariant(word[0]),
+                    word.AsSpan(1))
+                : word;
+        }
+
+        return leadingUnderscoreCount > 0
             ? StringHumanizeExtensions.Concat(
-                char.ToLowerInvariant(word[0]),
-                word.AsSpan(1))
-            : word;
+                input.AsSpan(0, leadingUnderscoreCount),
+                camelized.AsSpan())
+            : camelized;
     }
 
     static bool TryPascalizeAscii(string input, bool lowerFirst, [NotNullWhen(true)] out string? result)

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -197,6 +197,7 @@ public class InflectorTests
     [InlineData("_", "_")]
     [InlineData("___", "___")]
     [InlineData("_Ägypten_name", "_ägyptenName")]
+    [InlineData("_\nÄ", "_\nÄ")]
     public void Camelize(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Camelize());
 

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -192,6 +192,11 @@ public class InflectorTests
     [InlineData("customer name $", "customerName$")]
     [InlineData("customer   name", "customerName")]
     [InlineData("", "")]
+    [InlineData("_Name", "_name")]
+    [InlineData("__customer_name", "__customerName")]
+    [InlineData("_", "_")]
+    [InlineData("___", "___")]
+    [InlineData("_Ägypten_name", "_ägyptenName")]
     public void Camelize(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Camelize());
 


### PR DESCRIPTION
## Summary

`Camelize()` now preserves leading underscores, so `_Name` returns `_name` instead of `name`. This applies consistently to ASCII and Unicode inputs, including multiple and underscore-only prefixes.

Fixes #1736.

## Validation

- `dotnet test` passed 57,061 tests on each of net8.0, net10.0, and net11.0.
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` formatted 0 files.
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release` completed successfully.

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or another OSS project
- [x] There are very few or no comments
- [x] XML documentation is updated for the behavior change
- [x] The PR is rebased on the latest `main`
- [x] The fixed issue is linked with a closing reference
- [x] The readme is updated for the behavior change
- [x] Repository test, format, and pack validation completed successfully
