### PR TITLE
fix: preserve all-caps inflection casing

### DIFF
--- a/src/Humanizer/Inflections/Vocabulary.cs
+++ b/src/Humanizer/Inflections/Vocabulary.cs
@@ -197,7 +197,7 @@ public partial class Vocabulary
 
     static string MatchUpperCase(string word, string replacement) =>
         word.Length > 1 && word.Any(char.IsUpper) && !word.Any(char.IsLower)
-            ? replacement.ToUpper()
+            ? replacement.ToUpperInvariant()
             : char.IsUpper(word[0]) && char.IsLower(replacement[0])
                 ? StringHumanizeExtensions.Concat(char.ToUpper(replacement[0]), replacement.AsSpan(1))
                 : replacement;

--- a/src/Humanizer/Inflections/Vocabulary.cs
+++ b/src/Humanizer/Inflections/Vocabulary.cs
@@ -196,8 +196,11 @@ public partial class Vocabulary
         uncountables.Contains(word);
 
     static string MatchUpperCase(string word, string replacement) =>
-        char.IsUpper(word[0]) &&
-        char.IsLower(replacement[0]) ? StringHumanizeExtensions.Concat(char.ToUpper(replacement[0]), replacement.AsSpan(1)) : replacement;
+        word.Length > 1 && word.Any(char.IsUpper) && !word.Any(char.IsLower)
+            ? replacement.ToUpper()
+            : char.IsUpper(word[0]) && char.IsLower(replacement[0])
+                ? StringHumanizeExtensions.Concat(char.ToUpper(replacement[0]), replacement.AsSpan(1))
+                : replacement;
 
     /// <summary>
     /// If the word is the letter s, singular or plural, return the letter s singular

--- a/src/Humanizer/Inflections/Vocabulary.cs
+++ b/src/Humanizer/Inflections/Vocabulary.cs
@@ -103,7 +103,7 @@ public partial class Vocabulary
         var asSingularAsPlural = ApplyRules(plurals, asSingular, false);
         if (asSingular != null &&
             asSingular != word &&
-            asSingular + "s" != word &&
+            !string.Equals(asSingular + "s", word, StringComparison.OrdinalIgnoreCase) &&
             asSingularAsPlural == word &&
             result != word)
         {
@@ -142,7 +142,7 @@ public partial class Vocabulary
         // the Plurality is unknown so we should check all possibilities
         var asPlural = ApplyRules(plurals, word, false);
         if (asPlural == word ||
-            word + "s" == asPlural)
+            string.Equals(word + "s", asPlural, StringComparison.OrdinalIgnoreCase))
         {
             return result ?? word;
         }

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -86,6 +86,7 @@ public static partial class InflectorExtensions
     /// "cat".Pluralize() => "cats"
     /// "box".Pluralize() => "boxes"
     /// "man".Pluralize() => "men"
+    /// "PERSON".Pluralize() => "PEOPLE"
     /// "cats".Pluralize(inputIsKnownToBeSingular: false) => "cats" (avoids double pluralization)
     /// </code>
     /// </example>
@@ -119,6 +120,7 @@ public static partial class InflectorExtensions
     /// "cats".Singularize() => "cat"
     /// "boxes".Singularize() => "box"
     /// "men".Singularize() => "man"
+    /// "PEOPLE".Singularize() => "PERSON"
     /// "person".Singularize(inputIsKnownToBePlural: false) => "person" (avoids incorrect singularization)
     /// </code>
     /// </example>

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -33,6 +33,16 @@ public class InflectorTests
         Assert.Equal(plural, singular.Pluralize());
 
     [Theory]
+    [InlineData("SINGULAR TYPE NAME", "SINGULAR TYPE NAMES")]
+    [InlineData("BUS", "BUSES")]
+    [InlineData("PERSON", "PEOPLE")]
+    public void InflectionsPreserveAllCaps(string singular, string plural)
+    {
+        Assert.Equal(plural, singular.Pluralize());
+        Assert.Equal(singular, plural.Singularize());
+    }
+
+    [Theory]
     [ClassData(typeof(PluralTestSource))]
     public void PluralizeWordsWithUnknownPlurality(string singular, string plural)
     {

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -40,6 +40,10 @@ public class InflectorTests
     {
         Assert.Equal(plural, singular.Pluralize());
         Assert.Equal(singular, plural.Singularize());
+        Assert.Equal(plural, singular.Pluralize(inputIsKnownToBeSingular: false));
+        Assert.Equal(plural, plural.Pluralize(inputIsKnownToBeSingular: false));
+        Assert.Equal(singular, singular.Singularize(inputIsKnownToBePlural: false));
+        Assert.Equal(singular, plural.Singularize(inputIsKnownToBePlural: false));
     }
 
     [Theory]

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -46,6 +46,10 @@ public class InflectorTests
         Assert.Equal(singular, plural.Singularize(inputIsKnownToBePlural: false));
     }
 
+    [Fact, UseCulture("tr-TR")]
+    public void AllCapsInflectionsUseInvariantCasing() =>
+        Assert.Equal("CACTI", "CACTUS".Pluralize());
+
     [Theory]
     [ClassData(typeof(PluralTestSource))]
     public void PluralizeWordsWithUnknownPlurality(string singular, string plural)


### PR DESCRIPTION
All-caps words and phrases now remain all-caps when pluralized or singularized, so `SINGULAR TYPE NAME` becomes `SINGULAR TYPE NAMES`. The shared inflection casing path handles both regular and irregular replacements while preserving the established single-letter behavior (`A` → `As`).

Fixes #1293.

Validation:

- 57,060 tests passed on each of .NET 8, .NET 10, and .NET 11.
- Release packaging succeeded for all library target frameworks.
- Formatting verification passed for both changed files. The solution-wide check currently reports final-newline violations in two unchanged enum files inherited from `origin/main`.

Here is a checklist you should tick through before submitting a pull request:

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included (not applicable)
- [x] There are very few or no comments
- [x] Xml documentation includes all-caps pluralization and singularization examples
- [x] The PR is rebased on top of the latest `main`
- [x] The fixed issue is linked from the PR description
- [x] Readme is updated if an existing feature changes (not applicable; this corrects casing behavior)
- [x] The repository tests and Release package build succeed
