### PR TITLE
fix: treat software as uncountable

### DIFF
--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -99,6 +99,7 @@ public static class Vocabularies
 
         _default.AddUncountable("staff");
         _default.AddUncountable("training");
+        _default.AddUncountable("software");
         _default.AddUncountable("equipment");
         _default.AddUncountable("information");
         _default.AddUncountable("corn");

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -253,6 +253,7 @@ class PluralTestSource : IEnumerable<object[]>
         yield return ["personnel", "personnel"];
         yield return ["staff", "staff"];
         yield return ["training", "training"];
+        yield return ["software", "software"];
 
         yield return ["basis", "bases"];
         yield return ["diagnosis", "diagnoses"];


### PR DESCRIPTION
## Summary

`"software".Pluralize()` now returns `"software"` instead of `"softwares"`. The default English vocabulary treats `software` as uncountable, with the shared inflector regression data covering pluralization and singularization behavior.

Fixes #1156.

## Validation

- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 57,028 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 57,028 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 57,028 passed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temporary-path>` — succeeded without warnings or errors
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — no changes required

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or OSS
- [x] There are very few or no comments
- [x] XML documentation was reviewed; no public API changed
- [x] The PR is based on the latest `main`
- [x] The fixed issue is linked with `Fixes #1156`
- [x] Readme impact was reviewed; no documentation change is needed
- [x] Required builds and tests pass
