### PR TITLE
fix: support long Italian number words

### DIFF
--- a/src/Humanizer/Localisation/NumberToWords/TriadScaleNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/TriadScaleNumberToWordsConverter.cs
@@ -84,15 +84,16 @@ class TriadScaleNumberToWordsConverter(TriadScaleNumberToWordsConverter.Profile 
             return "quattro bilioni trecentoventicinque miliardi dieci milioni settemiladiciotto";
         }
 
-        if (input is > int.MaxValue or < int.MinValue)
+        var maximumMagnitude = (long)profile.Scales[^1].Value * 1000;
+        if (input >= maximumMagnitude || input <= -maximumMagnitude)
         {
             throw new NotImplementedException();
         }
 
-        var number = (int)input;
+        var number = input;
         if (number < 0)
         {
-            return profile.MinusWord + " " + Convert(Math.Abs(number), gender);
+            return profile.MinusWord + " " + Convert(-number, gender);
         }
 
         if (number == 0)
@@ -159,14 +160,14 @@ class TriadScaleNumberToWordsConverter(TriadScaleNumberToWordsConverter.Profile 
     /// <summary>
     /// Splits a number into three-digit triads, least significant first.
     /// </summary>
-    static int SplitEveryThreeDigits(int number, Span<int> parts)
+    static int SplitEveryThreeDigits(long number, Span<int> parts)
     {
         var count = 0;
         var remaining = number;
 
         while (remaining > 0)
         {
-            parts[count++] = remaining % 1000;
+            parts[count++] = (int)(remaining % 1000);
             remaining /= 1000;
         }
 

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -1028,7 +1028,8 @@ public class CoverageGapTests
         Assert.Throws<ArgumentOutOfRangeException>(() => 2.ToOrdinalWords((GrammaticalGender)999, new CultureInfo("is")));
         Assert.Throws<ArgumentOutOfRangeException>(() => 1.ToWords((GrammaticalGender)999, new CultureInfo("is")));
         Assert.Throws<ArgumentOutOfRangeException>(() => 1.ToWords((GrammaticalGender)999, new CultureInfo("cs")));
-        Assert.Throws<NotImplementedException>(() => ((long)int.MaxValue + 1).ToWords(new CultureInfo("it")));
+        Assert.Throws<NotImplementedException>(() => 1_000_000_000_000L.ToWords(new CultureInfo("it")));
+        Assert.Throws<NotImplementedException>(() => (-1_000_000_000_000L).ToWords(new CultureInfo("it")));
         Assert.Throws<NotImplementedException>(() => ((long)int.MaxValue + 1).ToWords(new CultureInfo("ro")));
         Assert.Throws<ArgumentOutOfRangeException>(() => 1.ToOrdinalWords((GrammaticalGender)999, new CultureInfo("de")));
         Assert.False(string.IsNullOrWhiteSpace(0.ToOrdinalWords(new CultureInfo("lv"))));

--- a/tests/Humanizer.Tests/Localisation/LocaleNumberMagnitudeTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleNumberMagnitudeTheoryData.cs
@@ -416,6 +416,8 @@ public static class LocaleNumberMagnitudeTheoryData
         { "is", 1001000001L, "einn milljarður ein milljón og einn" },
         { "is", 4325010007018L, "fjórar billjónir þrjú hundruð tuttugu og fimm milljarðar tíu milljónir sjö þúsund og átján" },
         { "it", 1001000001L, "un miliardo un milione uno" },
+        { "it-IT", 998999456789L, "novecentonovantotto miliardi novecentonovantanove milioni quattrocentocinquantaseimilasettecentoottantanove" },
+        { "it-IT", -998999456789L, "meno novecentonovantotto miliardi novecentonovantanove milioni quattrocentocinquantaseimilasettecentoottantanove" },
         { "it", 4325010007018L, "quattro bilioni trecentoventicinque miliardi dieci milioni settemiladiciotto" },
         { "ja", 1001000001L, "十億百万一" },
         { "ja", 4325010007018L, "四兆三千二百五十億千万七千十八" },

--- a/tests/Humanizer.Tests/Localisation/LocaleNumberMagnitudeTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleNumberMagnitudeTheoryData.cs
@@ -418,6 +418,8 @@ public static class LocaleNumberMagnitudeTheoryData
         { "it", 1001000001L, "un miliardo un milione uno" },
         { "it-IT", 998999456789L, "novecentonovantotto miliardi novecentonovantanove milioni quattrocentocinquantaseimilasettecentoottantanove" },
         { "it-IT", -998999456789L, "meno novecentonovantotto miliardi novecentonovantanove milioni quattrocentocinquantaseimilasettecentoottantanove" },
+        { "it-IT", 999999999999L, "novecentonovantanove miliardi novecentonovantanove milioni novecentonovantanovemilanovecentonovantanove" },
+        { "it-IT", -999999999999L, "meno novecentonovantanove miliardi novecentonovantanove milioni novecentonovantanovemilanovecentonovantanove" },
         { "it", 4325010007018L, "quattro bilioni trecentoventicinque miliardi dieci milioni settemiladiciotto" },
         { "ja", 1001000001L, "十億百万一" },
         { "ja", 4325010007018L, "四兆三千二百五十億千万七千十八" },


### PR DESCRIPTION
## Summary

Italian `long.ToWords` now converts values through ±999,999,999,999 instead of throwing for every value outside the 32-bit range. The reported `998999456789` case and its negative counterpart produce the expected Italian words, while the unsupported ±1 trillion boundary remains explicit.

Fixes #756.

## Validation

- [x] `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0`
- [x] `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0`
- [x] `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0`
- [x] `dotnet pack src/Humanizer/Humanizer.csproj -c Release`
- [x] `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`

## Checklist

- [x] Implementation is clean and follows existing coding standards.
- [x] No code-analysis warnings were introduced.
- [x] Unit tests cover the reported positive and negative long values and unsupported boundaries.
- [x] No code was copied from external sources.
- [x] No public API or XML documentation change is required.
- [x] The branch is rebased on the latest `main`.
- [x] The issue is linked with a closing reference.
- [x] No README change is required for this bug fix.
