### PR TITLE
fix: make identifier casing culture-invariant

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -501,6 +501,7 @@ Convert numbers to ordinal strings (1st, 2nd, 3rd, etc.):
 #### Titleize, Pascalize, Camelize
 
 Convert strings to various coding conventions:
+`Pascalize` and `Camelize` use culture-invariant casing; `Titleize` follows the current culture.
 
 ```csharp
 // Titleize: Title Case with spaces
@@ -517,6 +518,7 @@ Convert strings to various coding conventions:
 #### Underscore, Dasherize, Kebaberize
 
 Transform to common naming conventions:
+`Underscore` and `Kebaberize` use culture-invariant casing.
 
 ```csharp
 // Underscore: snake_case

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -162,6 +162,7 @@ public static partial class InflectorExtensions
     /// </returns>
     /// <remarks>
     /// PascalCase (also known as UpperCamelCase) is commonly used for class names and type names in .NET.
+    /// Casing is culture-invariant.
     /// </remarks>
     /// <example>
     /// <code>
@@ -175,7 +176,7 @@ public static partial class InflectorExtensions
             ? result
             : PascalizeRegex().Replace(input, match => match
                 .Groups[1]
-                .Value.ToUpper());
+                .Value.ToUpperInvariant());
 
     /// <summary>
     /// Converts a string to camelCase (lowerCamelCase) by capitalizing the first letter of each word
@@ -189,6 +190,7 @@ public static partial class InflectorExtensions
     /// <remarks>
     /// camelCase is the same as PascalCase except the first character is lowercase.
     /// It's commonly used for variable and method parameter names in .NET.
+    /// Casing is culture-invariant.
     /// </remarks>
     /// <example>
     /// <code>
@@ -207,7 +209,7 @@ public static partial class InflectorExtensions
         var word = input.Pascalize();
         return word.Length > 0
             ? StringHumanizeExtensions.Concat(
-                char.ToLower(word[0]),
+                char.ToLowerInvariant(word[0]),
                 word.AsSpan(1))
             : word;
     }
@@ -220,7 +222,7 @@ public static partial class InflectorExtensions
             return false;
         }
 
-        var textInfo = CultureInfo.CurrentCulture.TextInfo;
+        var textInfo = CultureInfo.InvariantCulture.TextInfo;
         var buffer = new char[input.Length];
         var pos = 0;
         var capitalizeNext = true;
@@ -256,6 +258,7 @@ public static partial class InflectorExtensions
     /// </returns>
     /// <remarks>
     /// This transformation is commonly used for database column names, file names, and URL slugs in some conventions.
+    /// Casing is culture-invariant.
     /// </remarks>
     /// <example>
     /// <code>
@@ -272,7 +275,7 @@ public static partial class InflectorExtensions
                 .Replace(
                     UnderscoreRegex2().Replace(
                         UnderscoreRegex1().Replace(input, "$1_$2"), "$1_$2"), "_")
-                .ToLower();
+                .ToLowerInvariant();
 
     /// <summary>
     /// Replaces all underscores in the string with dashes (hyphens).
@@ -322,6 +325,7 @@ public static partial class InflectorExtensions
     /// <remarks>
     /// Kebab-case is commonly used for CSS class names, HTML attributes, and URL slugs.
     /// This is equivalent to calling <see cref="Underscore"/> followed by <see cref="Dasherize"/>.
+    /// Casing is culture-invariant.
     /// </remarks>
     /// <example>
     /// <code>
@@ -345,7 +349,7 @@ public static partial class InflectorExtensions
             return false;
         }
 
-        var textInfo = CultureInfo.CurrentCulture.TextInfo;
+        var textInfo = CultureInfo.InvariantCulture.TextInfo;
         var buffer = new char[Math.Max(1, input.Length * 2)];
         var pos = 0;
         for (var i = 0; i < input.Length; i++)

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -144,11 +144,6 @@ public class InflectorTests
     public void Pascalize(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Pascalize());
 
-    [Theory, UseCulture("tr-TR")]
-    [InlineData("istanbul_input", "İstanbulİnput")]
-    public void PascalizeUsesTurkishCasing(string input, string expectedOutput) =>
-        Assert.Equal(expectedOutput, input.Pascalize());
-
     // Same as pascalize, except first char is lowercase
     [Theory]
     [InlineData("customer", "customer")]
@@ -165,11 +160,6 @@ public class InflectorTests
     public void Camelize(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Camelize());
 
-    [Theory, UseCulture("tr-TR")]
-    [InlineData("Istanbul_input", "ıstanbulİnput")]
-    public void CamelizeUsesTurkishCasing(string input, string expectedOutput) =>
-        Assert.Equal(expectedOutput, input.Camelize());
-
     //Makes an underscored lowercase string
     [Theory]
     [InlineData("SomeTitle", "some_title")]
@@ -182,11 +172,6 @@ public class InflectorTests
     public void Underscore(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Underscore());
 
-    [Theory, UseCulture("tr-TR")]
-    [InlineData("IstanbulInput", "ıstanbul_ınput")]
-    public void UnderscoreUsesTurkishCasing(string input, string expectedOutput) =>
-        Assert.Equal(expectedOutput, input.Underscore());
-
     // transform words into lowercase and separate with a -
     [Theory]
     [InlineData("SomeWords", "some-words")]
@@ -197,10 +182,26 @@ public class InflectorTests
     public void Kebaberize(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Kebaberize());
 
-    [Theory, UseCulture("tr-TR")]
-    [InlineData("IstanbulInput", "ıstanbul-ınput")]
-    public void KebaberizeUsesTurkishCasing(string input, string expectedOutput) =>
-        Assert.Equal(expectedOutput, input.Kebaberize());
+    [Fact, UseCulture("tr-TR")]
+    public void IdentifierTransformationsUseInvariantCasingInTurkish() =>
+        VerifyIdentifierTransformationsUseInvariantCasing();
+
+    [Fact, UseCulture("az-Latn-AZ")]
+    public void IdentifierTransformationsUseInvariantCasingInAzeri() =>
+        VerifyIdentifierTransformationsUseInvariantCasing();
+
+    static void VerifyIdentifierTransformationsUseInvariantCasing()
+    {
+        Assert.Equal("IWillBreakStuff", "i will_break-stuff".Pascalize());
+        Assert.Equal("iWillBreakStuff", "I will_break-stuff".Camelize());
+        Assert.Equal("istanbul_input", "IstanbulInput".Underscore());
+        Assert.Equal("istanbul-input", "IstanbulInput".Kebaberize());
+
+        Assert.Equal("ÉlanInput", "élan_input".Pascalize());
+        Assert.Equal("élanInput", "Élan_input".Camelize());
+        Assert.Equal("élan_input", "ÉlanInput".Underscore());
+        Assert.Equal("élan-input", "ÉlanInput".Kebaberize());
+    }
 }
 
 class PluralTestSource : IEnumerable<object[]>

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -201,6 +201,16 @@ public class InflectorTests
         Assert.Equal("élanInput", "Élan_input".Camelize());
         Assert.Equal("élan_input", "ÉlanInput".Underscore());
         Assert.Equal("élan-input", "ÉlanInput".Kebaberize());
+
+        Assert.Equal("İstanbulInput", "İstanbul_input".Pascalize());
+        Assert.Equal("İstanbulInput", "İstanbul_input".Camelize());
+        Assert.Equal("İstanbul_input", "İstanbulInput".Underscore());
+        Assert.Equal("İstanbul-input", "İstanbulInput".Kebaberize());
+
+        Assert.Equal("ıstanbulInput", "ıstanbul_input".Pascalize());
+        Assert.Equal("ıstanbulInput", "ıstanbul_input".Camelize());
+        Assert.Equal("ıstanbul_input", "ıstanbulInput".Underscore());
+        Assert.Equal("ıstanbul-input", "ıstanbulInput".Kebaberize());
     }
 }
 


### PR DESCRIPTION
## Summary

`Pascalize`, `Camelize`, `Underscore`, and `Kebaberize` now produce the same identifiers under every current culture, preventing Turkish and Azeri dotted/dotless-I rules from changing serialized keys. Identifier casing is invariant in both the ASCII fast paths and Unicode fallbacks, while user-facing `Humanize` and `Titleize` behavior remains culture-sensitive.

This follows @bdach's original report and invariant-casing workaround in ppy/osu#19221. The upper-case/acronym API work in #1577 and leading-underscore behavior in #1821 remain separate.

Fixes #1212.

## Validation

- 57,054 tests passed on each of net8.0, net10.0, and net11.0
- Turkish and Azeri tests cover all four transformations through ASCII and Unicode paths
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release` succeeded without warnings
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` passed

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or another OSS project
- [x] There are very few or no comments
- [x] XML documentation is updated for the behavior change
- [x] The branch is based on the latest `main`
- [x] The fixed issue is linked with a closing reference
- [x] The README documents the invariant-casing contract
- [x] Repository tests, formatting, and Release packaging completed successfully
