### PR TITLE
test: isolate sixty-day precision regression

### DIFF
--- a/tests/Humanizer.Tests/DateTimeOffsetHumanizeTests.cs
+++ b/tests/Humanizer.Tests/DateTimeOffsetHumanizeTests.cs
@@ -63,12 +63,11 @@ public class DateTimeOffsetHumanizeTests
     [InlineData(29)]
     public void PrecisionStrategy_TwoMonthsAroundSixtyDays(int day)
     {
-        Configurator.DateTimeOffsetHumanizeStrategy = new PrecisionDateTimeOffsetHumanizeStrategy(0.75);
-
+        var strategy = new PrecisionDateTimeOffsetHumanizeStrategy(0.75);
         var inputTime = new DateTimeOffset(2019, 01, day, 0, 0, 0, TimeSpan.Zero);
         var baseTime = new DateTimeOffset(2019, 03, 29, 0, 0, 0, TimeSpan.Zero);
 
-        Assert.Equal("2 months ago", inputTime.Humanize(baseTime));
+        Assert.Equal("2 months ago", strategy.Humanize(inputTime, baseTime, null));
     }
 
     [Fact]


### PR DESCRIPTION
The merged sixty-day regression test no longer changes the process-wide `Configurator.DateTimeOffsetHumanizeStrategy`. It exercises the precision strategy instance directly, preserving the same 59/60/61-day coverage without leaving shared test state behind.

Related: #1819
Related: #805

Validation:

- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 57,063 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 57,063 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 57,063 passed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <path> -m:1` — succeeded without warnings
- `git diff --check` — clean
- Repository-wide `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` is blocked only by two confirmed `FINALNEWLINE` defects already on `main` in `EnumHumanizeExtensions.cs` and `EnumHumanizeTests.cs`; those are being repaired separately.

Here is a checklist you should tick through before submitting a pull request:

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No copied code requires disclosure
- [x] There are very few or no comments
- [x] XML documentation is not applicable to this test-only change
- [x] The PR is based on the latest `main`
- [x] Related issue and merged regression PR are linked above
- [x] Readme updates are not applicable
- [x] Required test targets and Release pack pass
