### PR TITLE
fix: humanize relative dates in weeks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -195,6 +195,7 @@ DateTime.UtcNow.AddHours(-30).Humanize() => "yesterday"
 
 DateTime.UtcNow.AddHours(2).Humanize() => "2 hours from now"
 DateTime.UtcNow.AddHours(30).Humanize() => "tomorrow"
+DateTime.UtcNow.AddDays(7).Humanize() => "one week from now"
 
 DateTimeOffset.UtcNow.AddHours(1).Humanize() => "an hour from now"
 ```
@@ -213,7 +214,7 @@ Many localizations are available for this method. Here are a few examples:
 DateTime.UtcNow.AddDays(-1).Humanize() => "أمس"
 DateTime.UtcNow.AddDays(-2).Humanize() => "منذ يومين"
 DateTime.UtcNow.AddDays(-3).Humanize() => "منذ 3 أيام"
-DateTime.UtcNow.AddDays(-11).Humanize() => "منذ 11 يوم"
+DateTime.UtcNow.AddDays(-11).Humanize() => "منذ أسبوع واحد"
 
 // In ru-RU culture
 DateTime.UtcNow.AddMinutes(-1).Humanize() => "минуту назад"

--- a/readme.md
+++ b/readme.md
@@ -195,7 +195,8 @@ DateTime.UtcNow.AddHours(-30).Humanize() => "yesterday"
 
 DateTime.UtcNow.AddHours(2).Humanize() => "2 hours from now"
 DateTime.UtcNow.AddHours(30).Humanize() => "tomorrow"
-DateTime.UtcNow.AddDays(7).Humanize() => "one week from now"
+var now = DateTime.UtcNow;
+now.AddDays(7).Humanize(dateToCompareAgainst: now) => "one week from now"
 
 DateTimeOffset.UtcNow.AddHours(1).Humanize() => "an hour from now"
 ```

--- a/src/Humanizer/DateTimeHumanizeStrategy/DateTimeHumanizeAlgorithms.cs
+++ b/src/Humanizer/DateTimeHumanizeStrategy/DateTimeHumanizeAlgorithms.cs
@@ -209,9 +209,14 @@ static class DateTimeHumanizeAlgorithms
             return formatter.DateHumanize(TimeUnit.Day, tense, days);
         }
 
-        if (ts.TotalDays < 28)
+        if (ts.TotalDays < 7)
         {
             return formatter.DateHumanize(TimeUnit.Day, tense, ts.Days);
+        }
+
+        if (ts.TotalDays < 28)
+        {
+            return formatter.DateHumanize(TimeUnit.Week, tense, ts.Days / 7);
         }
 
         if (ts.TotalDays is >= 28 and < 30)

--- a/tests/Humanizer.Tests/DateHumanizeDefaultStrategyTests.cs
+++ b/tests/Humanizer.Tests/DateHumanizeDefaultStrategyTests.cs
@@ -69,16 +69,22 @@ public class DateHumanizeDefaultStrategyTests
 
     [Theory]
     [InlineData(1, "yesterday")]
-    [InlineData(10, "10 days ago")]
-    [InlineData(27, "27 days ago")]
+    [InlineData(6, "6 days ago")]
+    [InlineData(7, "one week ago")]
+    [InlineData(13, "one week ago")]
+    [InlineData(14, "2 weeks ago")]
+    [InlineData(27, "3 weeks ago")]
     [InlineData(32, "one month ago")]
     public void DaysAgo(int days, string expected) =>
         DateHumanize.Verify(expected, days, TimeUnit.Day, Tense.Past);
 
     [Theory]
     [InlineData(1, "tomorrow")]
-    [InlineData(10, "10 days from now")]
-    [InlineData(27, "27 days from now")]
+    [InlineData(6, "6 days from now")]
+    [InlineData(7, "one week from now")]
+    [InlineData(13, "one week from now")]
+    [InlineData(14, "2 weeks from now")]
+    [InlineData(27, "3 weeks from now")]
     [InlineData(32, "one month from now")]
     public void DaysFromNow(int days, string expected) =>
         DateHumanize.Verify(expected, days, TimeUnit.Day, Tense.Future);
@@ -134,6 +140,7 @@ public class DateHumanizeDefaultStrategyTests
     [InlineData(1, TimeUnit.Year, Tense.Future, "en-US", "one year from now")]
     [InlineData(40, TimeUnit.Second, Tense.Past, "ru-RU", "40 секунд назад")]
     [InlineData(2, TimeUnit.Day, Tense.Past, "sv-SE", "för 2 dagar sedan")]
+    [InlineData(2, TimeUnit.Week, Tense.Future, "de-DE", "in 2 Wochen")]
     public void CanSpecifyCultureExplicitly(int unit, TimeUnit timeUnit, Tense tense, string culture, string expected) =>
         DateHumanize.Verify(expected, unit, timeUnit, tense, culture: new(culture));
 }

--- a/tests/Humanizer.Tests/DateHumanizeDefaultStrategyTests.cs
+++ b/tests/Humanizer.Tests/DateHumanizeDefaultStrategyTests.cs
@@ -90,6 +90,16 @@ public class DateHumanizeDefaultStrategyTests
         DateHumanize.Verify(expected, days, TimeUnit.Day, Tense.Future);
 
     [Theory]
+    [InlineData(Tense.Past, "one month ago", 3)]
+    [InlineData(Tense.Future, "one month from now", 2)]
+    public void TwentyEightDaysUsesCalendarMonth(Tense tense, string expected, int comparisonMonth)
+    {
+        var comparisonBase = new DateTime(2023, comparisonMonth, 1, 0, 0, 0, DateTimeKind.Local);
+        var comparisonBaseUtc = new DateTime(2023, comparisonMonth, 1, 0, 0, 0, DateTimeKind.Utc);
+        DateHumanize.Verify(expected, 28, TimeUnit.Day, tense, baseDate: comparisonBase, baseDateUtc: comparisonBaseUtc);
+    }
+
+    [Theory]
     [InlineData(1, "one month ago")]
     [InlineData(10, "10 months ago")]
     [InlineData(11, "11 months ago")]

--- a/tests/Humanizer.Tests/DateTimeOffsetHumanizeTests.cs
+++ b/tests/Humanizer.Tests/DateTimeOffsetHumanizeTests.cs
@@ -30,6 +30,17 @@ public class DateTimeOffsetHumanizeTests
     }
 
     [Fact]
+    public void DefaultStrategy_WeekAcrossDifferentOffsets()
+    {
+        Configurator.DateTimeOffsetHumanizeStrategy = new DefaultDateTimeOffsetHumanizeStrategy();
+
+        var baseTime = new DateTimeOffset(2024, 01, 01, 10, 0, 0, TimeSpan.FromHours(2));
+        var inputTime = new DateTimeOffset(2024, 01, 08, 03, 0, 0, TimeSpan.FromHours(-5));
+
+        Assert.Equal("one week from now", inputTime.Humanize(baseTime));
+    }
+
+    [Fact]
     public void PrecisionStrategy_SameOffset()
     {
         Configurator.DateTimeOffsetHumanizeStrategy = new PrecisionDateTimeOffsetHumanizeStrategy(0.75);

--- a/tests/Humanizer.Tests/Localisation/FormatterExactOutputTests.cs
+++ b/tests/Humanizer.Tests/Localisation/FormatterExactOutputTests.cs
@@ -2,9 +2,7 @@ namespace Humanizer.Tests.Localisation;
 
 public class FormatterExactOutputTests
 {
-    static readonly DateTime LocalBase = new(2013, 6, 20, 11, 58, 22, DateTimeKind.Local);
-    static readonly DateTime UtcBase = new(2013, 6, 20, 9, 58, 22, DateTimeKind.Utc);
-    static readonly int[] RelativeDayCounts = [2, 3, 4, 5];
+    static readonly int[] RelativeWeekDayCounts = [7, 14, 21, 27];
     static readonly int[] Pair = [1, 2];
     static readonly int[] Triple = [1, 2, 3];
     static readonly int[] Quadruple = [1, 2, 3, 4];
@@ -14,13 +12,28 @@ public class FormatterExactOutputTests
     public void UsesExpectedDateHumanizeDayPluralOutputs(string localeName, LocaleFormatterExactTheoryData.DateDayPluralExpectationRow expected)
     {
         var culture = GetCulture(localeName);
+        var formatter = Configurator.Formatters.ResolveForCulture(culture);
 
-        foreach (var dayCount in RelativeDayCounts)
+        foreach (var dayCount in LocaleFormatterExactTheoryData.DatePluralDayCounts)
         {
-            Assert.Equal(expected.PastFor(dayCount), ToVisibleText(LocalBase.AddDays(-dayCount).Humanize(false, LocalBase, culture)));
-            Assert.Equal(expected.PastFor(dayCount), ToVisibleText(UtcBase.AddDays(-dayCount).Humanize(true, UtcBase, culture)));
-            Assert.Equal(expected.FutureFor(dayCount), ToVisibleText(LocalBase.AddDays(dayCount).Humanize(false, LocalBase, culture)));
-            Assert.Equal(expected.FutureFor(dayCount), ToVisibleText(UtcBase.AddDays(dayCount).Humanize(true, UtcBase, culture)));
+            Assert.Equal(expected.PastFor(dayCount), ToVisibleText(formatter.DateHumanize(TimeUnit.Day, Tense.Past, dayCount)));
+            Assert.Equal(expected.FutureFor(dayCount), ToVisibleText(formatter.DateHumanize(TimeUnit.Day, Tense.Future, dayCount)));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(LocaleFormatterExactTheoryData.DateDayPluralCases), MemberType = typeof(LocaleFormatterExactTheoryData))]
+    public void UsesExpectedDateHumanizeWeekOutputs(string localeName, LocaleFormatterExactTheoryData.DateDayPluralExpectationRow _)
+    {
+        var culture = GetCulture(localeName);
+        var formatter = Configurator.Formatters.ResolveForCulture(culture);
+
+        foreach (var dayCount in RelativeWeekDayCounts)
+        {
+            var weekCount = dayCount / 7;
+
+            DateHumanize.Verify(formatter.DateHumanize(TimeUnit.Week, Tense.Past, weekCount), dayCount, TimeUnit.Day, Tense.Past, culture: culture);
+            DateHumanize.Verify(formatter.DateHumanize(TimeUnit.Week, Tense.Future, weekCount), dayCount, TimeUnit.Day, Tense.Future, culture: culture);
         }
     }
 

--- a/tests/Humanizer.Tests/Localisation/FormatterExactOutputTests.cs
+++ b/tests/Humanizer.Tests/Localisation/FormatterExactOutputTests.cs
@@ -4,6 +4,7 @@ public class FormatterExactOutputTests
 {
     static readonly DateTime LocalBase = new(2013, 6, 20, 11, 58, 22, DateTimeKind.Local);
     static readonly DateTime UtcBase = new(2013, 6, 20, 9, 58, 22, DateTimeKind.Utc);
+    static readonly int[] RelativeDayCounts = [2, 3, 4, 5];
     static readonly int[] Pair = [1, 2];
     static readonly int[] Triple = [1, 2, 3];
     static readonly int[] Quadruple = [1, 2, 3, 4];
@@ -14,10 +15,8 @@ public class FormatterExactOutputTests
     {
         var culture = GetCulture(localeName);
 
-        for (var index = 0; index < LocaleFormatterExactTheoryData.DatePluralDayCounts.Length; index++)
+        foreach (var dayCount in RelativeDayCounts)
         {
-            var dayCount = LocaleFormatterExactTheoryData.DatePluralDayCounts[index];
-
             Assert.Equal(expected.PastFor(dayCount), ToVisibleText(LocalBase.AddDays(-dayCount).Humanize(false, LocalBase, culture)));
             Assert.Equal(expected.PastFor(dayCount), ToVisibleText(UtcBase.AddDays(-dayCount).Humanize(true, UtcBase, culture)));
             Assert.Equal(expected.FutureFor(dayCount), ToVisibleText(LocalBase.AddDays(dayCount).Humanize(false, LocalBase, culture)));

--- a/tests/Humanizer.Tests/Localisation/ResourceBackedPhraseTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ResourceBackedPhraseTests.cs
@@ -7,7 +7,7 @@ public class ResourceBackedPhraseTests
     public void UsesExpectedDateHumanizePhrases(string localeName, int unit, TimeUnit timeUnit, Tense tense, string expected)
     {
         var culture = GetCulture(localeName);
-        DateHumanize.Verify(expected, unit, timeUnit, tense, culture: culture);
+        VerifyDateHumanizePhrase(expected, unit, timeUnit, tense, culture);
     }
 
     [Theory]
@@ -15,7 +15,7 @@ public class ResourceBackedPhraseTests
     public void UsesExpectedDateHumanizeBoundaryPhrases(string localeName, int unit, TimeUnit timeUnit, Tense tense, string expected)
     {
         var culture = GetCulture(localeName);
-        DateHumanize.Verify(expected, unit, timeUnit, tense, culture: culture);
+        VerifyDateHumanizePhrase(expected, unit, timeUnit, tense, culture);
     }
 
     [Theory]
@@ -23,7 +23,7 @@ public class ResourceBackedPhraseTests
     public void UsesExpectedAdditionalDateHumanizePhrases(string localeName, int unit, TimeUnit timeUnit, Tense tense, string expected)
     {
         var culture = GetCulture(localeName);
-        DateHumanize.Verify(expected, unit, timeUnit, tense, culture: culture);
+        VerifyDateHumanizePhrase(expected, unit, timeUnit, tense, culture);
     }
 
     [Theory]
@@ -266,6 +266,18 @@ public class ResourceBackedPhraseTests
     }
 
     static CultureInfo GetCulture(string localeName) => CultureInfo.GetCultureInfo(localeName);
+
+    static void VerifyDateHumanizePhrase(string expected, int unit, TimeUnit timeUnit, Tense tense, CultureInfo culture)
+    {
+        if (timeUnit == TimeUnit.Day && Math.Abs(unit) >= 7)
+        {
+            var formatter = Configurator.Formatters.ResolveForCulture(culture);
+            Assert.Equal(expected, formatter.DateHumanize(timeUnit, tense, Math.Abs(unit)));
+            return;
+        }
+
+        DateHumanize.Verify(expected, unit, timeUnit, tense, culture: culture);
+    }
 
     static TimeSpan CreateTimeSpan(int unit, TimeUnit timeUnit) => timeUnit switch
     {


### PR DESCRIPTION
## Summary

Relative `DateTime` and `DateTimeOffset` spans from 7 through 27 days now read as whole weeks, so seven days becomes “one week from now” instead of “7 days from now.” This carries forward Alex Knight’s implementation from #807 now that every shipped locale provides past and future relative-week phrases. The separate precision-based DateTime strategy remains unchanged, and the recently merged TimeSpan week decomposition is not involved.

Fixes #765.

## Attribution

The strategy commit preserves Alex Knight (`@AKTheKnight`) as its author and carries forward his work from #807.

## Validation

- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 57,203 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 57,203 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 57,203 passed
- Focused review-feedback regressions — 6,616 passed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp>` — warning-free package created for every target
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — 0 of 2,535 files changed

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] Earlier same-repository work is disclosed and attributed above
- [x] There are very few or no comments
- [x] XML documentation is unchanged because no public API changed
- [x] The PR is rebased on the latest `main`
- [x] The issue is linked with `Fixes #765`
- [x] Readme examples reflect the changed relative-week behavior
- [x] Supported tests and Release packing pass

