### PR TITLE
fix(pl): apply paucal forms to compound counts

### DIFF
--- a/docs/locale-yaml-reference.md
+++ b/docs/locale-yaml-reference.md
@@ -554,6 +554,7 @@ These are the non-lexical option values that currently appear in checked-in loca
 - `arabic-like`
 - `between2-and4-paucal`
 - `lithuanian`
+- `polish`
 - `russian`
 - `slovenian`
 - `south-slavic`
@@ -563,6 +564,7 @@ These are the non-lexical option values that currently appear in checked-in loca
 - `arabic-like`
 - `between2-and4-paucal`
 - `lithuanian`
+- `polish`
 - `russian`
 - `singular-plural`
 - `slovenian`

--- a/src/Humanizer/Locales/pl.yml
+++ b/src/Humanizer/Locales/pl.yml
@@ -7,10 +7,10 @@ surfaces:
 
   formatter:
     engine: 'profiled'
-    resourceKeyDetector: 'between2-and4-paucal'
+    resourceKeyDetector: 'polish'
     resourceKeySuffixes:
       paucal: '_Paucal'
-    dataUnitDetector: 'between2-and4-paucal'
+    dataUnitDetector: 'polish'
     dataUnitSuffixes:
       singular: '_Singular'
       paucal: '_Paucal'

--- a/src/Humanizer/Localisation/Formatters/ProfiledFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/ProfiledFormatter.cs
@@ -28,6 +28,11 @@ enum FormatterNumberDetectorKind
     Between2And4Paucal,
 
     /// <summary>
+    /// Use the Polish paucal form for values ending in two through four, except twelve through fourteen.
+    /// </summary>
+    Polish,
+
+    /// <summary>
     /// Use the South Slavic singular, paucal, and default rules.
     /// </summary>
     SouthSlavic,
@@ -263,6 +268,7 @@ sealed class ProfiledFormatter(CultureInfo culture, FormatterProfile profile) : 
                 > 1 and < 5 => FormatterNumberForm.Paucal,
                 _ => FormatterNumberForm.Default
             },
+            FormatterNumberDetectorKind.Polish => DetectPolishForm(absoluteNumber),
             FormatterNumberDetectorKind.SouthSlavic => DetectSouthSlavicForm(absoluteNumber),
             FormatterNumberDetectorKind.Slovenian => absoluteNumber switch
             {
@@ -309,6 +315,13 @@ sealed class ProfiledFormatter(CultureInfo culture, FormatterProfile profile) : 
             },
             _ => forms.Resolve(form)
         };
+
+    static FormatterNumberForm DetectPolishForm(int absoluteNumber) =>
+        absoluteNumber % 10 is > 1 and < 5 && absoluteNumber % 100 is not 12 and not 13 and not 14
+            ? FormatterNumberForm.Paucal
+            : absoluteNumber == 1
+                ? FormatterNumberForm.Singular
+                : FormatterNumberForm.Default;
 
     /// <summary>
     /// Detects the South Slavic singular and paucal forms.

--- a/tests/Humanizer.Tests/Localisation/pl/PolishPaucalTests.cs
+++ b/tests/Humanizer.Tests/Localisation/pl/PolishPaucalTests.cs
@@ -1,0 +1,33 @@
+namespace Humanizer.Tests.Localisation.pl;
+
+[UseCulture("pl")]
+public class PolishPaucalTests
+{
+    static readonly CultureInfo Polish = new("pl");
+    static readonly IFormatter Formatter = Configurator.GetFormatter(new("pl"));
+
+    [Theory]
+    [InlineData(12, "12 minut")]
+    [InlineData(13, "13 minut")]
+    [InlineData(14, "14 minut")]
+    [InlineData(21, "21 minut")]
+    [InlineData(22, "22 minuty")]
+    [InlineData(23, "23 minuty")]
+    [InlineData(24, "24 minuty")]
+    [InlineData(25, "25 minut")]
+    public void TimeSpanHumanize_UsesPaucalFormForMatchingLastDigits(int count, string expected) =>
+        Assert.Equal(expected, TimeSpan.FromMinutes(count).Humanize(culture: Polish));
+
+    [Theory]
+    [InlineData(12, "za 12 minut")]
+    [InlineData(22, "za 22 minuty")]
+    public void DateHumanize_UsesPaucalFormForMatchingLastDigits(int count, string expected) =>
+        Assert.Equal(expected, Formatter.DateHumanize(TimeUnit.Minute, Tense.Future, count));
+
+    [Theory]
+    [InlineData(12, "bajtów")]
+    [InlineData(21, "bajtów")]
+    [InlineData(22, "bajty")]
+    public void DataUnitHumanize_UsesPaucalFormForMatchingLastDigits(int count, string expected) =>
+        Assert.Equal(expected, Formatter.DataUnitHumanize(DataUnit.Byte, count, toSymbol: false));
+}


### PR DESCRIPTION
## Summary

Polish time-unit and data-unit counts ending in 2–4 now use paucal forms such as `22 minuty` and `22 bajty`, while 12–14, 21, and 25 keep their existing genitive-plural forms. The Polish-specific rule leaves Czech and Slovak behavior unchanged and applies consistently to relative dates, durations, and full-word data units.

Thanks to @Jarek300 for the original Polish grammar report and @hazzik for tracking it as #1470.

Fixes #1470.

## Validation

- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0 --culture en-US` — 57,108 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0 --culture en-US` — 57,108 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0 --culture en-US` — 57,108 passed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp> -m:1` — succeeded with no warnings
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — clean

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or another OSS project
- [x] Comments are limited to API documentation
- [x] XML documentation is added for the new detector
- [x] The branch is rebased on the latest `main`
- [x] The fixed issue is linked above
- [x] Locale authoring documentation is updated
- [x] Required build and test validation passes
