### PR TITLE
test(pt-BR): cover merged locale behavior

### DIFF
--- a/tests/Humanizer.Tests/Localisation/pt-BR/BrazilianPortugueseRegressionTests.cs
+++ b/tests/Humanizer.Tests/Localisation/pt-BR/BrazilianPortugueseRegressionTests.cs
@@ -1,0 +1,71 @@
+namespace Humanizer.Tests.Localisation.pt_BR;
+
+[UseCulture("pt-BR")]
+public class BrazilianPortugueseRegressionTests
+{
+    static readonly CultureInfo BrazilianPortuguese = new("pt-BR");
+
+    [Theory]
+    [InlineData("dezesseis", 16L)]
+    [InlineData("dezessete", 17L)]
+    [InlineData("dezenove", 19L)]
+    public void WordsToNumber_ParsesBrazilianCardinals(string words, long expected)
+    {
+        Assert.Equal(expected, words.ToNumber(BrazilianPortuguese));
+        Assert.True(words.TryToNumber(out var result, BrazilianPortuguese));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("um bilhão", 1_000_000_000L)]
+    [InlineData("dois bilhões", 2_000_000_000L)]
+    [InlineData("um trilhão", 1_000_000_000_000L)]
+    [InlineData("dois trilhões", 2_000_000_000_000L)]
+    [InlineData("um quadrilhão", 1_000_000_000_000_000L)]
+    [InlineData("dois quadrilhões", 2_000_000_000_000_000L)]
+    [InlineData("um quintilhão", 1_000_000_000_000_000_000L)]
+    [InlineData("dois quintilhões", 2_000_000_000_000_000_000L)]
+    public void WordsToNumber_ParsesBrazilianLargeScaleWords(string words, long expected)
+    {
+        Assert.Equal(expected, words.ToNumber(BrazilianPortuguese));
+        Assert.True(words.TryToNumber(out var result, BrazilianPortuguese));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("uma", 1L)]
+    [InlineData("duas", 2L)]
+    [InlineData("duzentas", 200L)]
+    [InlineData("trezentas", 300L)]
+    [InlineData("quatrocentas", 400L)]
+    [InlineData("quinhentas", 500L)]
+    [InlineData("seiscentas", 600L)]
+    [InlineData("setecentas", 700L)]
+    [InlineData("oitocentas", 800L)]
+    [InlineData("novecentas", 900L)]
+    [InlineData("duzentas e uma", 201L)]
+    [InlineData("primeira", 1L)]
+    [InlineData("segunda", 2L)]
+    [InlineData("vigésima primeira", 21L)]
+    [InlineData("centésima", 100L)]
+    [InlineData("centésima décima nona", 119L)]
+    [InlineData("1ª", 1L)]
+    public void WordsToNumber_PreservesInheritedFeminineForms(string words, long expected)
+    {
+        Assert.Equal(expected, words.ToNumber(BrazilianPortuguese));
+        Assert.True(words.TryToNumber(out var result, BrazilianPortuguese));
+        Assert.Equal(expected, result);
+    }
+
+#if NET6_0_OR_GREATER
+    [Theory]
+    [InlineData(0, 40, "vinte para a uma")]
+    [InlineData(0, 45, "quinze para a uma")]
+    [InlineData(0, 50, "dez para a uma")]
+    [InlineData(0, 55, "cinco para a uma")]
+    public void ToClockNotation_UsesSingularArticleForNextHourOne(int hours, int minutes, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(hours, minutes).ToClockNotation());
+    }
+#endif
+}


### PR DESCRIPTION
## Summary

Brazilian Portuguese parser and clock improvements now have regression coverage for locale-specific spellings, large numeric scales, inherited feminine forms, and the singular article before one o'clock. This follow-up validates the behavior already contributed by @Kaikygabriel without changing production output.

Related: #1785

## Validation

- Targeted pt-BR class: 32 passed on net8.0
- Full net8.0, net10.0, and net11.0 suites: 57,127 passed on each target
- Release pack: succeeded for net8.0, net10.0, net11.0, net48, and netstandard2.0
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or another OSS project
- [x] There are very few or no comments
- [x] XML documentation is unchanged because no public API changed
- [x] Rebased on the latest `main`
- [x] Related work is linked without closing the merged PR
- [x] Readme changes are not needed for test-only coverage
- [x] Equivalent full test and Release pack validation completed
