### PR TITLE
fix: honor Greek feminine hundreds

### DIFF
--- a/src/Humanizer/Localisation/NumberToWords/SegmentedScaleNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/SegmentedScaleNumberToWordsConverter.cs
@@ -10,15 +10,19 @@ class SegmentedScaleNumberToWordsConverter(SegmentedScaleNumberToWordsProfile pr
 
     /// <inheritdoc/>
     public override string Convert(long number) =>
-        Convert(number, SegmentedScaleVariant.Default);
+        Convert(number, null);
 
     /// <inheritdoc/>
     public override string Convert(long number, GrammaticalGender gender, bool addAnd = true) =>
         Convert(number, gender == GrammaticalGender.Feminine
             ? SegmentedScaleVariant.Pluralized
-            : SegmentedScaleVariant.Default);
+            : null);
 
-    string Convert(long number, SegmentedScaleVariant variant)
+    /// <inheritdoc/>
+    public override string Convert(long number, WordForm wordForm, GrammaticalGender gender, bool addAnd = true) =>
+        Convert(number, gender, addAnd);
+
+    string Convert(long number, SegmentedScaleVariant? terminalVariant)
     {
         if ((ulong)profile.MaximumValue < GetAbsoluteValue(number))
         {
@@ -37,7 +41,7 @@ class SegmentedScaleNumberToWordsConverter(SegmentedScaleNumberToWordsProfile pr
             parts.Add(profile.MinusWord);
         }
 
-        parts.Add(ConvertCore(remaining, variant));
+        parts.Add(ConvertCore(remaining, SegmentedScaleVariant.Default, terminalVariant));
         return string.Join(" ", parts);
     }
 
@@ -100,23 +104,27 @@ class SegmentedScaleNumberToWordsConverter(SegmentedScaleNumberToWordsProfile pr
     /// <summary>
     /// Converts the current magnitude using the requested segmented variant.
     /// </summary>
-    string ConvertCore(ulong number, SegmentedScaleVariant variant)
+    string ConvertCore(
+        ulong number,
+        SegmentedScaleVariant variant,
+        SegmentedScaleVariant? terminalVariant = null)
     {
+        var effectiveVariant = terminalVariant ?? variant;
         if (number < 13)
         {
-            return (variant == SegmentedScaleVariant.Pluralized
+            return (effectiveVariant == SegmentedScaleVariant.Pluralized
                 ? profile.UnitsPluralized
                 : profile.UnitsDefault)[(int)number];
         }
 
         if (number < 100)
         {
-            return ConvertUnderOneHundred((int)number, variant);
+            return ConvertUnderOneHundred((int)number, effectiveVariant);
         }
 
         if (number < 1000)
         {
-            return ConvertUnderOneThousand((int)number, variant);
+            return ConvertUnderOneThousand((int)number, effectiveVariant);
         }
 
         foreach (var scale in profile.Scales)
@@ -141,7 +149,7 @@ class SegmentedScaleNumberToWordsConverter(SegmentedScaleNumberToWordsProfile pr
             var remainderVariant = count == 1
                 ? scale.SingularRemainderVariant
                 : scale.PluralRemainderVariant;
-            return scaleText + " " + ConvertCore(remainder, remainderVariant);
+            return scaleText + " " + ConvertCore(remainder, remainderVariant, terminalVariant);
         }
 
         return string.Empty;

--- a/src/Humanizer/Localisation/NumberToWords/SegmentedScaleNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/SegmentedScaleNumberToWordsConverter.cs
@@ -9,7 +9,16 @@ class SegmentedScaleNumberToWordsConverter(SegmentedScaleNumberToWordsProfile pr
     readonly SegmentedScaleNumberToWordsProfile profile = profile;
 
     /// <inheritdoc/>
-    public override string Convert(long number)
+    public override string Convert(long number) =>
+        Convert(number, SegmentedScaleVariant.Default);
+
+    /// <inheritdoc/>
+    public override string Convert(long number, GrammaticalGender gender, bool addAnd = true) =>
+        Convert(number, gender == GrammaticalGender.Feminine
+            ? SegmentedScaleVariant.Pluralized
+            : SegmentedScaleVariant.Default);
+
+    string Convert(long number, SegmentedScaleVariant variant)
     {
         if ((ulong)profile.MaximumValue < GetAbsoluteValue(number))
         {
@@ -28,7 +37,7 @@ class SegmentedScaleNumberToWordsConverter(SegmentedScaleNumberToWordsProfile pr
             parts.Add(profile.MinusWord);
         }
 
-        parts.Add(ConvertCore(remaining, SegmentedScaleVariant.Default));
+        parts.Add(ConvertCore(remaining, variant));
         return string.Join(" ", parts);
     }
 

--- a/tests/Humanizer.Tests/Localisation/el/GreekNumberToWordsTests.cs
+++ b/tests/Humanizer.Tests/Localisation/el/GreekNumberToWordsTests.cs
@@ -1,0 +1,8 @@
+namespace Humanizer.Tests.Localisation.el;
+
+public class GreekNumberToWordsTests
+{
+    [Fact]
+    public void ToWords_UsesFeminineHundreds() =>
+        Assert.Equal("εννιακόσιες", 900.ToWords(GrammaticalGender.Feminine, new CultureInfo("el")));
+}

--- a/tests/Humanizer.Tests/Localisation/el/GreekNumberToWordsTests.cs
+++ b/tests/Humanizer.Tests/Localisation/el/GreekNumberToWordsTests.cs
@@ -1,8 +1,23 @@
 namespace Humanizer.Tests.Localisation.el;
 
+[UseCulture("el")]
 public class GreekNumberToWordsTests
 {
+    static readonly CultureInfo El = new("el");
+
+    [Theory]
+    [InlineData(900, GrammaticalGender.Masculine, "εννιακόσια")]
+    [InlineData(900, GrammaticalGender.Feminine, "εννιακόσιες")]
+    [InlineData(900, GrammaticalGender.Neuter, "εννιακόσια")]
+    [InlineData(1900, GrammaticalGender.Feminine, "χίλια εννιακόσιες")]
+    public void ToWords_UsesRequestedGender(int number, GrammaticalGender gender, string expected) =>
+        Assert.Equal(expected, number.ToWords(gender, El));
+
     [Fact]
-    public void ToWords_UsesFeminineHundreds() =>
-        Assert.Equal("εννιακόσιες", 900.ToWords(GrammaticalGender.Feminine, new CultureInfo("el")));
+    public void ToWords_UsesDefaultGender() =>
+        Assert.Equal("εννιακόσια", 900.ToWords(El));
+
+    [Fact]
+    public void ToWords_WithWordForm_UsesRequestedGender() =>
+        Assert.Equal("εννιακόσιες", 900.ToWords(WordForm.Normal, GrammaticalGender.Feminine, El));
 }


### PR DESCRIPTION
## Summary

Greek feminine cardinal hundreds now use the feminine form, so `900.ToWords(GrammaticalGender.Feminine, el)` returns `εννιακόσιες` instead of the neuter `εννιακόσια`. The requested terminal gender now survives scale decomposition and the combined `WordForm` overload, while scale counts retain their profile-defined grammar and masculine, neuter, and default output remain unchanged.

## Validation

- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` (57,279 passed)
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` (57,279 passed)
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` (57,279 passed)
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <path>`

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No copied code requires attribution
- [x] There are very few or no comments
- [x] XML documentation is unchanged because no public API changed
- [x] The PR is based on the latest `main`
- [ ] No issue reference was provided
- [x] Readme changes are not needed for this corrective locale behavior
- [x] Repository tests and Release pack pass
