### PR TITLE
test: cover Romanian singular durations and exact hours

### DIFF
--- a/tests/Humanizer.Tests/Localisation/ro/RomanianLocaleRegressionTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ro/RomanianLocaleRegressionTests.cs
@@ -1,5 +1,6 @@
 namespace Humanizer.Tests.Localisation.ro;
 
+[UseCulture("ro-RO")]
 public class RomanianLocaleRegressionTests
 {
     static readonly CultureInfo Romanian = new("ro-RO");
@@ -20,9 +21,11 @@ public class RomanianLocaleRegressionTests
         Assert.Equal(expected, formatter.TimeSpanHumanize(unit, 1, toWords: true));
     }
 
+#if NET6_0_OR_GREATER
     [Fact]
     public void ExactHourUsesMin0Template() =>
         Assert.Equal(
             "ora unu",
             new TimeOnly(13, 0).ToClockNotation(ClockNotationRounding.None, Romanian));
+#endif
 }

--- a/tests/Humanizer.Tests/Localisation/ro/RomanianLocaleRegressionTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ro/RomanianLocaleRegressionTests.cs
@@ -1,0 +1,28 @@
+namespace Humanizer.Tests.Localisation.ro;
+
+public class RomanianLocaleRegressionTests
+{
+    static readonly CultureInfo Romanian = new("ro-RO");
+
+    [Theory]
+    [InlineData(TimeUnit.Millisecond, "o milisecundă")]
+    [InlineData(TimeUnit.Second, "o secundă")]
+    [InlineData(TimeUnit.Minute, "un minut")]
+    [InlineData(TimeUnit.Hour, "o oră")]
+    [InlineData(TimeUnit.Day, "o zi")]
+    [InlineData(TimeUnit.Week, "o săptămână")]
+    [InlineData(TimeUnit.Month, "o lună")]
+    [InlineData(TimeUnit.Year, "un an")]
+    public void ToWordsUsesSingularFormForEverySupportedUnit(TimeUnit unit, string expected)
+    {
+        var formatter = Configurator.Formatters.ResolveForCulture(Romanian);
+
+        Assert.Equal(expected, formatter.TimeSpanHumanize(unit, 1, toWords: true));
+    }
+
+    [Fact]
+    public void ExactHourUsesMin0Template() =>
+        Assert.Equal(
+            "ora unu",
+            new TimeOnly(13, 0).ToClockNotation(ClockNotationRounding.None, Romanian));
+}


### PR DESCRIPTION
## Summary

Romanian locale regressions will now catch loss of the word-based singular phrase for every supported duration unit and changes to the exact-hour `min0` clock template.

## Validation

- Romanian regression class: 9 passed on .NET 10
- Full Humanizer.Tests suite: 57,333 passed on each of .NET 8, .NET 10, and .NET 11
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release`

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or OSS
- [x] There are very few or no comments
- [x] XML documentation is not applicable to this test-only change
- [x] The PR is based on the latest `main`
- [x] Issue linkage is not applicable to this audit follow-up
- [x] Readme changes are not applicable to this test-only change
- [x] Repository tests and Release pack pass
