### PR TITLE
test(uk): cover curly-apostrophe ordinal parsing

### DIFF
--- a/tests/Humanizer.Tests/WordsToNumberTests.cs
+++ b/tests/Humanizer.Tests/WordsToNumberTests.cs
@@ -1104,6 +1104,28 @@ public class WordsToNumberTests_Slovak
 public class WordsToNumberTests_Ukrainian
 {
     [Theory]
+    [InlineData("п’ята", 5)]
+    [InlineData("п’ятий", 5)]
+    [InlineData("п’яте", 5)]
+    [InlineData("двадцять п’ята", 25)]
+    [InlineData("двадцять п’ятий", 25)]
+    [InlineData("двадцять п’яте", 25)]
+    [InlineData("П’ЯТА.", 5)]
+    public void OrdinalParser_AcceptsCanonicalCurlyApostropheForms(string words, long expectedNumber)
+    {
+        var culture = CultureInfo.CurrentCulture;
+
+        Assert.Equal(expectedNumber, words.ToNumber(culture));
+
+        Assert.True(words.TryToNumber(out var parsedNumber, culture));
+        Assert.Equal(expectedNumber, parsedNumber);
+
+        Assert.True(words.TryToNumber(out parsedNumber, culture, out var unrecognizedWord));
+        Assert.Equal(expectedNumber, parsedNumber);
+        Assert.Null(unrecognizedWord);
+    }
+
+    [Theory]
     [InlineData("нуль", 0, null)]
     [InlineData("мінус сто двадцять три", -123, null)]
     [InlineData("одна тисяча сто дванадцять", 1112, null)]


### PR DESCRIPTION
## Summary

Ukrainian ordinal parsing now has regression coverage for canonical U+2019 apostrophes across feminine, masculine, and neuter forms at 5 and 25. The matrix exercises all three public parsing APIs and confirms case/period normalization; existing YAML behavior already passes, so no production change is needed.

This builds on the original Ukrainian locale work by @dmytro-i in #414 and the YAML parser and U+2019 compatibility work by @clairernovotny in #1688.

## Validation

- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 57,331 passed
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 57,331 passed
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 57,331 passed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp> -m:1`
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic --no-restore` — 0 files formatted

## Checklist

- [x] Implementation is clean and follows existing coding standards
- [x] No code-analysis warnings
- [x] Proper unit-test coverage is included
- [x] No copied external code
- [x] No unnecessary comments
- [x] XML documentation is unchanged because there is no public API change
- [x] Rebased onto the latest `main`
- [x] README is unchanged because behavior is unchanged
- [x] Supported WSL test targets and Release pack pass
