### PR TITLE
test: document MTP filters and pin culture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ These instructions apply to the entire repository.
 ## Testing Expectations
 - Every functional change must include or update xUnit tests in `tests/Humanizer.Tests`.
 - Use culture-specific folders and `UseCulture` attribute for localization tests when applicable.
-- Run the test suite for the supported .NET targets: `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0`, `--framework net10.0`, and `--framework net11.0` on all platforms. The `net48` TFM is only included in the test project on Windows; run `--framework net48` tests only on Windows hosts. Allow a few minutes for each run to complete.
+- Run the test suite for the supported .NET targets: `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0`, `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0`, and `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` on all platforms. The `net48` TFM is only included in the test project on Windows; run `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net48` tests only on Windows hosts. Allow a few minutes for each run to complete.
 - The repository uses Microsoft Testing Platform. Filter targeted runs with `--filter-class <fully-qualified-class-name>`, `--filter-method <fully-qualified-method-name>`, or `--filter-namespace <namespace>`; do not use the legacy VSTest `--filter FullyQualifiedName~...` syntax.
 - Tests that require a specific culture must declare it with `UseCulture`; do not rely on the process's ambient culture, which is invariant-like when WSL starts with `C.UTF-8`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,9 @@ These instructions apply to the entire repository.
 ## Testing Expectations
 - Every functional change must include or update xUnit tests in `tests/Humanizer.Tests`.
 - Use culture-specific folders and `UseCulture` attribute for localization tests when applicable.
-- Run the test suite for the supported .NET targets: `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0`, `--framework net11.0` and `--framework net8.0` on all platforms. The `net48` TFM is only included in the test project on Windows; run `--framework net48` tests only on Windows hosts. Allow a few minutes for each run to complete.
+- Run the test suite for the supported .NET targets: `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0`, `--framework net10.0`, and `--framework net11.0` on all platforms. The `net48` TFM is only included in the test project on Windows; run `--framework net48` tests only on Windows hosts. Allow a few minutes for each run to complete.
+- The repository uses Microsoft Testing Platform. Filter targeted runs with `--filter-class <fully-qualified-class-name>`, `--filter-method <fully-qualified-method-name>`, or `--filter-namespace <namespace>`; do not use the legacy VSTest `--filter FullyQualifiedName~...` syntax.
+- Tests that require a specific culture must declare it with `UseCulture`; do not rely on the process's ambient culture, which is invariant-like when WSL starts with `C.UTF-8`.
 
 ## Build & Validation
 - Build command: `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <path>` (from the repository root). It must succeed without warnings or errors.

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -492,6 +492,7 @@ public class CoverageGapTests
     }
 
     [Fact]
+    [UseCulture("en-US")]
     public void SmallUtilityBranchesCoverInvalidAndFallbackPaths()
     {
         Assert.Equal("hello", "HELLO".Transform(CultureInfo.InvariantCulture, To.LowerCase));

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -491,8 +491,8 @@ public class CoverageGapTests
         Assert.Equal("{value} old", formatter.TimeSpanHumanize_Age());
     }
 
-    [Fact]
     [UseCulture("en-US")]
+    [Fact]
     public void SmallUtilityBranchesCoverInvalidAndFallbackPaths()
     {
         Assert.Equal("hello", "HELLO".Transform(CultureInfo.InvariantCulture, To.LowerCase));


### PR DESCRIPTION
## Summary

Targeted test runs now use Microsoft Testing Platform’s native class and method filters instead of legacy VSTest syntax. The ambient-culture-dependent coverage test is also pinned to `en-US`, so its English ordinal expectations remain stable when WSL starts under `C.UTF-8`.

## Validation

- `--filter-class Humanizer.Tests.CoverageGapTests`: 189 passed
- `--filter-method Humanizer.Tests.CoverageGapTests.SmallUtilityBranchesCoverInvalidAndFallbackPaths`: 1 passed
- Full `net8.0`, `net10.0`, and `net11.0` suites: 57,324 passed on each target
- Release package created successfully
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`: 0 of 2,544 files changed

Here is a checklist you should tick through before submitting a pull request:

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or OSS
- [x] There are very few or no comments
- [x] XML documentation is not applicable because no public API changed
- [x] The PR is rebased on the latest `main`
- [x] No issue reference was provided for this test-infrastructure follow-up
- [x] Readme changes are not applicable because product behavior did not change
- [x] The repository test, pack, and format commands pass
