### PR TITLE
test: add RTL bidi-control regression coverage

### DIFF
--- a/tests/Humanizer.Tests/Localisation/RtlBidiControlSweep.cs
+++ b/tests/Humanizer.Tests/Localisation/RtlBidiControlSweep.cs
@@ -1,6 +1,6 @@
 namespace Humanizer.Tests.Localisation;
 
-public class RtlBidiControlSweepTests
+static class RtlBidiControlSweep
 {
     static readonly char[] BidiControls =
     [
@@ -18,15 +18,10 @@ public class RtlBidiControlSweepTests
         '\u2069'
     ];
 
-    [Theory]
-    [InlineData("ar")]
-    [InlineData("he")]
-    [InlineData("fa")]
-    public void RawLocalizedOutputs_DoNotContainBidiControls(string localeName)
+    public static void AssertRawLocalizedOutputsDoNotContainBidiControls(string localeName)
     {
         var culture = CultureInfo.GetCultureInfo(localeName);
         var formatter = Configurator.Formatters.ResolveForCulture(culture);
-        using var _ = new CultureSwap(culture);
         var outputs = new List<(string Surface, string Value)>
         {
             ("cardinal", 1234567.ToWords(culture)),
@@ -48,18 +43,7 @@ public class RtlBidiControlSweepTests
             AssertNoBidiControls(localeName, surface, value);
     }
 
-    [Fact]
-    public void PersianOutput_PreservesZeroWidthNonJoiner()
-    {
-        var culture = CultureInfo.GetCultureInfo("fa");
-        var value = TimeSpan.FromMilliseconds(2).Humanize(culture: culture);
-
-        Assert.Equal("2 میلی\u200Cثانیه", value);
-        Assert.Contains('\u200C', value);
-        AssertNoBidiControls("fa", "millisecond duration", value);
-    }
-
-    static void AssertNoBidiControls(string localeName, string surface, string value)
+    public static void AssertNoBidiControls(string localeName, string surface, string value)
     {
         Assert.NotEmpty(value);
         foreach (var bidiControl in BidiControls)

--- a/tests/Humanizer.Tests/Localisation/RtlBidiControlSweep.cs
+++ b/tests/Humanizer.Tests/Localisation/RtlBidiControlSweep.cs
@@ -18,9 +18,9 @@ static class RtlBidiControlSweep
         '\u2069'
     ];
 
-    public static void AssertRawLocalizedOutputsDoNotContainBidiControls(string localeName)
+    public static void AssertRawLocalizedOutputsDoNotContainBidiControls()
     {
-        var culture = CultureInfo.GetCultureInfo(localeName);
+        var culture = CultureInfo.CurrentCulture;
         var formatter = Configurator.Formatters.ResolveForCulture(culture);
         var outputs = new List<(string Surface, string Value)>
         {
@@ -40,17 +40,17 @@ static class RtlBidiControlSweep
 #endif
 
         foreach (var (surface, value) in outputs)
-            AssertNoBidiControls(localeName, surface, value);
+            AssertNoBidiControls(surface, value);
     }
 
-    public static void AssertNoBidiControls(string localeName, string surface, string value)
+    public static void AssertNoBidiControls(string surface, string value)
     {
         Assert.NotEmpty(value);
         foreach (var bidiControl in BidiControls)
         {
             Assert.False(
                 value.Contains(bidiControl),
-                $"{localeName} {surface} contains U+{(int)bidiControl:X4}: {value}");
+                $"{CultureInfo.CurrentCulture.Name} {surface} contains U+{(int)bidiControl:X4}: {value}");
         }
     }
 }

--- a/tests/Humanizer.Tests/Localisation/RtlBidiControlSweepTests.cs
+++ b/tests/Humanizer.Tests/Localisation/RtlBidiControlSweepTests.cs
@@ -1,0 +1,72 @@
+namespace Humanizer.Tests.Localisation;
+
+public class RtlBidiControlSweepTests
+{
+    static readonly char[] BidiControls =
+    [
+        '\u061C',
+        '\u200E',
+        '\u200F',
+        '\u202A',
+        '\u202B',
+        '\u202C',
+        '\u202D',
+        '\u202E',
+        '\u2066',
+        '\u2067',
+        '\u2068',
+        '\u2069'
+    ];
+
+    [Theory]
+    [InlineData("ar")]
+    [InlineData("he")]
+    [InlineData("fa")]
+    public void RawLocalizedOutputs_DoNotContainBidiControls(string localeName)
+    {
+        var culture = CultureInfo.GetCultureInfo(localeName);
+        var formatter = Configurator.Formatters.ResolveForCulture(culture);
+        using var _ = new CultureSwap(culture);
+        var outputs = new List<(string Surface, string Value)>
+        {
+            ("cardinal", 1234567.ToWords(culture)),
+            ("ordinal words", 21.ToOrdinalWords(GrammaticalGender.Masculine, culture)),
+            ("numeric ordinal", 21.Ordinalize(culture)),
+            ("date", new DateTime(2024, 12, 31).ToOrdinalWords()),
+            ("relative date", formatter.DateHumanize(TimeUnit.Day, Tense.Past, 2)),
+            ("duration", TimeSpan.FromDays(2).Humanize(culture: culture)),
+            ("quantity", "request".ToQuantity(2, format: null, formatProvider: culture)),
+            ("data quantity", ByteSize.FromBytes(2).ToFullWords(provider: culture)),
+            ("time unit", formatter.TimeUnitHumanize(TimeUnit.Hour))
+        };
+
+#if NET6_0_OR_GREATER
+        outputs.Add(("clock", new TimeOnly(13, 23).ToClockNotation(ClockNotationRounding.None, culture)));
+#endif
+
+        foreach (var (surface, value) in outputs)
+            AssertNoBidiControls(localeName, surface, value);
+    }
+
+    [Fact]
+    public void PersianOutput_PreservesZeroWidthNonJoiner()
+    {
+        var culture = CultureInfo.GetCultureInfo("fa");
+        var value = TimeSpan.FromMilliseconds(2).Humanize(culture: culture);
+
+        Assert.Equal("2 میلی\u200Cثانیه", value);
+        Assert.Contains('\u200C', value);
+        AssertNoBidiControls("fa", "millisecond duration", value);
+    }
+
+    static void AssertNoBidiControls(string localeName, string surface, string value)
+    {
+        Assert.NotEmpty(value);
+        foreach (var bidiControl in BidiControls)
+        {
+            Assert.False(
+                value.Contains(bidiControl),
+                $"{localeName} {surface} contains U+{(int)bidiControl:X4}: {value}");
+        }
+    }
+}

--- a/tests/Humanizer.Tests/Localisation/ar/ArabicBidiControlTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ar/ArabicBidiControlTests.cs
@@ -1,0 +1,9 @@
+namespace Humanizer.Tests.Localisation.ar;
+
+[UseCulture("ar")]
+public class ArabicBidiControlTests
+{
+    [Fact]
+    public void RawLocalizedOutputs_DoNotContainBidiControls() =>
+        RtlBidiControlSweep.AssertRawLocalizedOutputsDoNotContainBidiControls("ar");
+}

--- a/tests/Humanizer.Tests/Localisation/ar/ArabicBidiControlTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ar/ArabicBidiControlTests.cs
@@ -5,5 +5,5 @@ public class ArabicBidiControlTests
 {
     [Fact]
     public void RawLocalizedOutputs_DoNotContainBidiControls() =>
-        RtlBidiControlSweep.AssertRawLocalizedOutputsDoNotContainBidiControls("ar");
+        RtlBidiControlSweep.AssertRawLocalizedOutputsDoNotContainBidiControls();
 }

--- a/tests/Humanizer.Tests/Localisation/fa/PersianBidiControlTests.cs
+++ b/tests/Humanizer.Tests/Localisation/fa/PersianBidiControlTests.cs
@@ -1,0 +1,20 @@
+namespace Humanizer.Tests.Localisation.fa;
+
+[UseCulture("fa")]
+public class PersianBidiControlTests
+{
+    [Fact]
+    public void RawLocalizedOutputs_DoNotContainBidiControls() =>
+        RtlBidiControlSweep.AssertRawLocalizedOutputsDoNotContainBidiControls("fa");
+
+    [Fact]
+    public void Output_PreservesZeroWidthNonJoiner()
+    {
+        var culture = CultureInfo.GetCultureInfo("fa");
+        var value = TimeSpan.FromMilliseconds(2).Humanize(culture: culture);
+
+        Assert.Equal("2 میلی\u200Cثانیه", value);
+        Assert.Contains('\u200C', value);
+        RtlBidiControlSweep.AssertNoBidiControls("fa", "millisecond duration", value);
+    }
+}

--- a/tests/Humanizer.Tests/Localisation/fa/PersianBidiControlTests.cs
+++ b/tests/Humanizer.Tests/Localisation/fa/PersianBidiControlTests.cs
@@ -5,7 +5,7 @@ public class PersianBidiControlTests
 {
     [Fact]
     public void RawLocalizedOutputs_DoNotContainBidiControls() =>
-        RtlBidiControlSweep.AssertRawLocalizedOutputsDoNotContainBidiControls("fa");
+        RtlBidiControlSweep.AssertRawLocalizedOutputsDoNotContainBidiControls();
 
     [Fact]
     public void Output_PreservesZeroWidthNonJoiner()
@@ -15,6 +15,6 @@ public class PersianBidiControlTests
 
         Assert.Equal("2 میلی\u200Cثانیه", value);
         Assert.Contains('\u200C', value);
-        RtlBidiControlSweep.AssertNoBidiControls("fa", "millisecond duration", value);
+        RtlBidiControlSweep.AssertNoBidiControls("millisecond duration", value);
     }
 }

--- a/tests/Humanizer.Tests/Localisation/he/HebrewBidiControlTests.cs
+++ b/tests/Humanizer.Tests/Localisation/he/HebrewBidiControlTests.cs
@@ -1,0 +1,9 @@
+namespace Humanizer.Tests.Localisation.he;
+
+[UseCulture("he")]
+public class HebrewBidiControlTests
+{
+    [Fact]
+    public void RawLocalizedOutputs_DoNotContainBidiControls() =>
+        RtlBidiControlSweep.AssertRawLocalizedOutputsDoNotContainBidiControls("he");
+}

--- a/tests/Humanizer.Tests/Localisation/he/HebrewBidiControlTests.cs
+++ b/tests/Humanizer.Tests/Localisation/he/HebrewBidiControlTests.cs
@@ -5,5 +5,5 @@ public class HebrewBidiControlTests
 {
     [Fact]
     public void RawLocalizedOutputs_DoNotContainBidiControls() =>
-        RtlBidiControlSweep.AssertRawLocalizedOutputsDoNotContainBidiControls("he");
+        RtlBidiControlSweep.AssertRawLocalizedOutputsDoNotContainBidiControls();
 }


### PR DESCRIPTION
## Summary

Raw output from the Arabic, Hebrew, and Persian formatters is now protected against invisible bidi-control contamination across representative number, date, time, duration, quantity, and clock surfaces. The regression sweep checks ALM, LRM/RLM, embeddings, overrides, and isolates without treating all Unicode Format characters as invalid, and separately proves that Persian ZWNJ remains intact.

## Validation

- Focused regression tests on .NET 8.0: 4 passed
- Full Humanizer.Tests on .NET 8.0, .NET 10.0, and .NET 11.0: 57,328 passed per target
- Release package build: succeeded without warnings or errors
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`: clean

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No copied third-party code
- [x] Comments are limited to what is necessary
- [x] XML documentation is not applicable because no public API changed
- [x] Rebased on the latest `main`
- [x] No issue is closed by this test-only follow-up
- [x] Readme changes are not applicable
- [x] Supported WSL test targets and package build pass
