### PR TITLE
test(locales): cover authored calendar month tables

### DIFF
--- a/tests/Humanizer.Tests/Localisation/bn/BengaliCalendarMonthTests.cs
+++ b/tests/Humanizer.Tests/Localisation/bn/BengaliCalendarMonthTests.cs
@@ -1,0 +1,37 @@
+namespace Humanizer.Tests.Localisation.bn;
+
+[UseCulture("bn")]
+public class BengaliCalendarMonthTests
+{
+    public static TheoryData<int, string> MonthNames { get; } = new()
+    {
+        { 1, "জানুয়ারী" },
+        { 2, "ফেব্রুয়ারী" },
+        { 3, "মার্চ" },
+        { 4, "এপ্রিল" },
+        { 5, "মে" },
+        { 6, "জুন" },
+        { 7, "জুলাই" },
+        { 8, "আগস্ট" },
+        { 9, "সেপ্টেম্বর" },
+        { 10, "অক্টোবর" },
+        { 11, "নভেম্বর" },
+        { 12, "ডিসেম্বর" }
+    };
+
+    [Theory]
+    [MemberData(nameof(MonthNames))]
+    public void DateTimeToOrdinalWords_UsesAuthoredMonthNames(int month, string monthName)
+    {
+        Assert.Equal($"15 {monthName} 2024", new DateTime(2024, month, 15).ToOrdinalWords());
+    }
+
+#if NET6_0_OR_GREATER
+    [Theory]
+    [MemberData(nameof(MonthNames))]
+    public void DateOnlyToOrdinalWords_UsesAuthoredMonthNames(int month, string monthName)
+    {
+        Assert.Equal($"15 {monthName} 2024", new DateOnly(2024, month, 15).ToOrdinalWords());
+    }
+#endif
+}

--- a/tests/Humanizer.Tests/Localisation/fa/PersianCalendarMonthTests.cs
+++ b/tests/Humanizer.Tests/Localisation/fa/PersianCalendarMonthTests.cs
@@ -1,0 +1,37 @@
+namespace Humanizer.Tests.Localisation.fa;
+
+[UseCulture("fa")]
+public class PersianCalendarMonthTests
+{
+    public static TheoryData<int, string> MonthNames { get; } = new()
+    {
+        { 1, "ژانویهٔ" },
+        { 2, "فوریهٔ" },
+        { 3, "مارس" },
+        { 4, "آوریل" },
+        { 5, "مهٔ" },
+        { 6, "ژوئن" },
+        { 7, "ژوئیهٔ" },
+        { 8, "اوت" },
+        { 9, "سپتامبر" },
+        { 10, "اکتبر" },
+        { 11, "نوامبر" },
+        { 12, "دسامبر" }
+    };
+
+    [Theory]
+    [MemberData(nameof(MonthNames))]
+    public void DateTimeToOrdinalWords_UsesAuthoredMonthNames(int month, string monthName)
+    {
+        Assert.Equal($"15 {monthName} 2024", new DateTime(2024, month, 15).ToOrdinalWords());
+    }
+
+#if NET6_0_OR_GREATER
+    [Theory]
+    [MemberData(nameof(MonthNames))]
+    public void DateOnlyToOrdinalWords_UsesAuthoredMonthNames(int month, string monthName)
+    {
+        Assert.Equal($"15 {monthName} 2024", new DateOnly(2024, month, 15).ToOrdinalWords());
+    }
+#endif
+}

--- a/tests/Humanizer.Tests/Localisation/he/HebrewCalendarMonthTests.cs
+++ b/tests/Humanizer.Tests/Localisation/he/HebrewCalendarMonthTests.cs
@@ -1,0 +1,37 @@
+namespace Humanizer.Tests.Localisation.he;
+
+[UseCulture("he")]
+public class HebrewCalendarMonthTests
+{
+    public static TheoryData<int, string> MonthNames { get; } = new()
+    {
+        { 1, "בינואר" },
+        { 2, "בפברואר" },
+        { 3, "במרץ" },
+        { 4, "באפריל" },
+        { 5, "במאי" },
+        { 6, "ביוני" },
+        { 7, "ביולי" },
+        { 8, "באוגוסט" },
+        { 9, "בספטמבר" },
+        { 10, "באוקטובר" },
+        { 11, "בנובמבר" },
+        { 12, "בדצמבר" }
+    };
+
+    [Theory]
+    [MemberData(nameof(MonthNames))]
+    public void DateTimeToOrdinalWords_UsesAuthoredMonthNames(int month, string monthName)
+    {
+        Assert.Equal($"15 {monthName} 2024", new DateTime(2024, month, 15).ToOrdinalWords());
+    }
+
+#if NET6_0_OR_GREATER
+    [Theory]
+    [MemberData(nameof(MonthNames))]
+    public void DateOnlyToOrdinalWords_UsesAuthoredMonthNames(int month, string monthName)
+    {
+        Assert.Equal($"15 {monthName} 2024", new DateOnly(2024, month, 15).ToOrdinalWords());
+    }
+#endif
+}

--- a/tests/Humanizer.Tests/Localisation/ta/TamilCalendarMonthTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ta/TamilCalendarMonthTests.cs
@@ -1,0 +1,37 @@
+namespace Humanizer.Tests.Localisation.ta;
+
+[UseCulture("ta")]
+public class TamilCalendarMonthTests
+{
+    public static TheoryData<int, string> MonthNames { get; } = new()
+    {
+        { 1, "ஜனவரி" },
+        { 2, "பிப்ரவரி" },
+        { 3, "மார்ச்" },
+        { 4, "ஏப்ரல்" },
+        { 5, "மே" },
+        { 6, "ஜூன்" },
+        { 7, "ஜூலை" },
+        { 8, "ஆகஸ்ட்" },
+        { 9, "செப்டம்பர்" },
+        { 10, "அக்டோபர்" },
+        { 11, "நவம்பர்" },
+        { 12, "டிசம்பர்" }
+    };
+
+    [Theory]
+    [MemberData(nameof(MonthNames))]
+    public void DateTimeToOrdinalWords_UsesAuthoredMonthNames(int month, string monthName)
+    {
+        Assert.Equal($"15 {monthName} 2024", new DateTime(2024, month, 15).ToOrdinalWords());
+    }
+
+#if NET6_0_OR_GREATER
+    [Theory]
+    [MemberData(nameof(MonthNames))]
+    public void DateOnlyToOrdinalWords_UsesAuthoredMonthNames(int month, string monthName)
+    {
+        Assert.Equal($"15 {monthName} 2024", new DateOnly(2024, month, 15).ToOrdinalWords());
+    }
+#endif
+}


### PR DESCRIPTION
## Summary

The explicit Hebrew, Bengali, Tamil, and Persian calendar overrides now have regression coverage across all 12 month indexes for both `DateTime` and `DateOnly`. Independent locale reviews confirmed the authored tables are correct, so no production data changed.

Related: #1688

This builds on the locale work of Shuhel Ahmed (Bengali), Borzoo Esmailloo (#127, Persian), Igal Tabachnik (Hebrew), and Mohamed Mahir (#979, Tamil), and on the YAML calendar overrides authored by Claire Novotny in #1688.

## Validation

- Focused 96-case locale matrix: .NET 8.0, 10.0, and 11.0
- Full Humanizer.Tests suite: 57,420 passed on each of .NET 8.0, 10.0, and 11.0
- Release package: succeeded without warnings or errors
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`

## Checklist

- [x] Implementation is clean and follows existing coding standards
- [x] No Code Analysis warnings
- [x] Proper unit test coverage is included
- [x] No copied third-party code
- [x] Comments and XML documentation are not applicable to this test-only change
- [x] Rebased on the latest `main`
- [x] Related work is linked without closing the already-merged source PR
- [x] README changes are not applicable
- [x] Supported WSL test targets and Release pack pass

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
