### PR TITLE
test: cover Slavic clock inflection branches

### DIFF
--- a/tests/Humanizer.Tests/Localisation/bg/BulgarianClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/bg/BulgarianClockNotationTests.cs
@@ -1,0 +1,15 @@
+namespace Humanizer.Tests.Localisation.bg;
+
+#if NET6_0_OR_GREATER
+[UseCulture("bg")]
+public class BulgarianClockNotationTests
+{
+    [Theory]
+    [InlineData(2, 2, "два часа и две минути")]
+    [InlineData(22, 22, "двадесет и два часа и двадесет и две минути")]
+    public void ToClockNotation_UsesFeminineMinuteNumbers(int hours, int minutes, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(hours, minutes).ToClockNotation());
+    }
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/cs/CzechClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/cs/CzechClockNotationTests.cs
@@ -1,0 +1,17 @@
+namespace Humanizer.Tests.Localisation.cs;
+
+#if NET6_0_OR_GREATER
+[UseCulture("cs")]
+public class CzechClockNotationTests
+{
+    [Theory]
+    [InlineData(2, 2, "dvě hodiny dva minuty")]
+    [InlineData(3, 3, "tři hodiny tři minuty")]
+    [InlineData(4, 4, "čtyři hodiny čtyři minuty")]
+    [InlineData(22, 22, "dvacet dvě hodin dvacet dva minut")]
+    public void ToClockNotation_UsesLowOnlyPaucalMinuteSuffix(int hours, int minutes, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(hours, minutes).ToClockNotation());
+    }
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/hr/CroatianClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/hr/CroatianClockNotationTests.cs
@@ -1,0 +1,17 @@
+namespace Humanizer.Tests.Localisation.hr;
+
+#if NET6_0_OR_GREATER
+[UseCulture("hr")]
+public class CroatianClockNotationTests
+{
+    [Theory]
+    [InlineData(2, 2, "dva sata i dva minute")]
+    [InlineData(3, 3, "tri sata i tri minute")]
+    [InlineData(4, 4, "četiri sata i četiri minute")]
+    [InlineData(22, 22, "dvadeset dva sata i dvadeset dva minute")]
+    public void ToClockNotation_UsesPaucalMinuteSuffix(int hours, int minutes, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(hours, minutes).ToClockNotation());
+    }
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/lt/LithuanianClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/lt/LithuanianClockNotationTests.cs
@@ -1,0 +1,15 @@
+namespace Humanizer.Tests.Localisation.lt;
+
+#if NET6_0_OR_GREATER
+[UseCulture("lt")]
+public class LithuanianClockNotationTests
+{
+    [Theory]
+    [InlineData(2, 2, "dvi valandų dvi minutės")]
+    [InlineData(22, 22, "dvidešimt dvi valandų dvidešimt dvi minutės")]
+    public void ToClockNotation_UsesFeminineMinuteNumbers(int hours, int minutes, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(hours, minutes).ToClockNotation());
+    }
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/ru/RussianClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ru/RussianClockNotationTests.cs
@@ -1,0 +1,15 @@
+namespace Humanizer.Tests.Localisation.ru;
+
+#if NET6_0_OR_GREATER
+[UseCulture("ru")]
+public class RussianClockNotationTests
+{
+    [Theory]
+    [InlineData(2, 2, "два две")]
+    [InlineData(22, 22, "десять двадцать две")]
+    public void ToClockNotation_UsesFeminineMinuteNumbers(int hours, int minutes, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(hours, minutes).ToClockNotation());
+    }
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/sk/SlovakClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sk/SlovakClockNotationTests.cs
@@ -1,0 +1,17 @@
+namespace Humanizer.Tests.Localisation.sk;
+
+#if NET6_0_OR_GREATER
+[UseCulture("sk")]
+public class SlovakClockNotationTests
+{
+    [Theory]
+    [InlineData(2, 2, "dve hodiny dva minúty")]
+    [InlineData(3, 3, "tri hodiny tri minúty")]
+    [InlineData(4, 4, "štyri hodiny štyri minúty")]
+    [InlineData(22, 22, "dvadsať dve hodín dvadsaťdva minút")]
+    public void ToClockNotation_UsesLowOnlyPaucalMinuteSuffix(int hours, int minutes, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(hours, minutes).ToClockNotation());
+    }
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/uk/UkrainianClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/uk/UkrainianClockNotationTests.cs
@@ -1,0 +1,15 @@
+namespace Humanizer.Tests.Localisation.uk;
+
+#if NET6_0_OR_GREATER
+[UseCulture("uk")]
+public class UkrainianClockNotationTests
+{
+    [Theory]
+    [InlineData(2, 2, "друга дві")]
+    [InlineData(22, 22, "десята двадцять дві")]
+    public void ToClockNotation_UsesFeminineMinuteNumbers(int hours, int minutes, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(hours, minutes).ToClockNotation());
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Slavic clock notation now has regression coverage for the inflection branches most likely to regress: Czech and Slovak low-only paucal suffixes, Croatian modulo-paucal suffixes, and feminine minute-number forms in Bulgarian, Russian, Ukrainian, and Lithuanian. The assertions preserve the current generated YAML behavior; no production behavior changes are included.

Review note: the current Czech, Croatian, and Slovak clock profiles do not select feminine number gender for minutes. These tests intentionally preserve that behavior while native-speaker review determines whether a separate locale correction is appropriate.

Locale work credited: the YAML clock profiles originated in #1688 from @clairernovotny; Czech and Slovak contributions include @igorkulman; Croatian includes @MPejcinovic and @Flynt56; Bulgarian includes @ivanst-stoyanov, @oxi-mix, and @hazzik; Russian includes @hazzik and @clazarev; Ukrainian includes @dmytro-i; Lithuanian includes @ogix.

## Validation

- 20 focused tests passed using repeated .NET Testing Platform `--filter-class` selectors
- 57,351 tests passed on each of `net8.0`, `net10.0`, and `net11.0`
- Release package built with zero warnings or errors
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` formatted 0 of 2,568 files
- `net48` was not run because this validation was performed on WSL

## Checklist

- [x] Implementation is clean and follows existing coding standards
- [x] No code-analysis warnings
- [x] Targeted unit-test coverage is included
- [x] No copied third-party code
- [x] Comments remain minimal
- [x] XML documentation is unchanged because this is test-only
- [x] Rebased on the latest `main`
- [x] No issue is closed; this is follow-up coverage from the locale audit
- [x] Readme is unchanged because behavior and public APIs are unchanged
- [x] Supported WSL test targets, Release pack, and format verification pass

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
