### PR TITLE
fix: humanize current DateOnly values as today

### DIFF
--- a/docs/adding-a-locale.md
+++ b/docs/adding-a-locale.md
@@ -204,6 +204,7 @@ surfaces:
   phrases:
     relativeDate:
       now: '<text>'
+      today: '<text>'
       never: '<text>'
       past: {}
       future: {}

--- a/src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs
+++ b/src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs
@@ -872,6 +872,7 @@ public sealed partial class HumanizerSourceGenerator
                     DateHumanize = new
                     {
                         locale.Phrases.DateHumanize.Now,
+                        locale.Phrases.DateHumanize.Today,
                         locale.Phrases.DateHumanize.Never,
                         Past = CreateDatePhraseMap(locale.Phrases.DateHumanize.Past),
                         Future = CreateDatePhraseMap(locale.Phrases.DateHumanize.Future)

--- a/src/Humanizer.SourceGenerators/Common/LocalePhraseModels.cs
+++ b/src/Humanizer.SourceGenerators/Common/LocalePhraseModels.cs
@@ -26,16 +26,19 @@ public sealed partial class HumanizerSourceGenerator
 
     internal sealed class DateHumanizePhraseSet(
         string? now,
+        string? today,
         string? never,
         ImmutableDictionary<string, DateHumanizePhrase> past,
         ImmutableDictionary<string, DateHumanizePhrase> future)
     {
         public string? Now { get; } = now;
+        public string? Today { get; } = today;
         public string? Never { get; } = never;
         public ImmutableDictionary<string, DateHumanizePhrase> Past { get; } = past;
         public ImmutableDictionary<string, DateHumanizePhrase> Future { get; } = future;
 
         public static DateHumanizePhraseSet Empty { get; } = new(
+            null,
             null,
             null,
             EmptyDateHumanizeUnits,

--- a/src/Humanizer.SourceGenerators/Common/LocalePhraseNormalization.cs
+++ b/src/Humanizer.SourceGenerators/Common/LocalePhraseNormalization.cs
@@ -46,7 +46,7 @@ public sealed partial class HumanizerSourceGenerator
         static DateHumanizePhraseSet ParseDateHumanize(string localeCode, SimpleYamlValue value, string path)
         {
             var mapping = ExpectMapping(value, path);
-            RejectUnknownKeys(mapping, path, ["now", "never", "past", "future"]);
+            RejectUnknownKeys(mapping, path, ["now", "today", "never", "past", "future"]);
             var past = mapping.TryGetValue("past", out var pastValue)
                 ? ParseDateHumanizeUnits(pastValue, $"{path}.past")
                 : ImmutableDictionary<string, DateHumanizePhrase>.Empty.WithComparers(StringComparer.Ordinal);
@@ -56,6 +56,7 @@ public sealed partial class HumanizerSourceGenerator
 
             return new DateHumanizePhraseSet(
                 GetOptionalLiteral(mapping, "now", $"{path}.now"),
+                GetOptionalLiteral(mapping, "today", $"{path}.today"),
                 GetOptionalLiteral(mapping, "never", $"{path}.never"),
                 past,
                 future);

--- a/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/LocalePhraseTableCatalogInput.cs
+++ b/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/LocalePhraseTableCatalogInput.cs
@@ -106,6 +106,7 @@ public sealed partial class HumanizerSourceGenerator
         static string CreateLocalePhraseTableExpression(LocalePhraseCatalog catalog) =>
             "new LocalePhraseTable(" +
             QuoteOrNull(catalog.DateHumanize.Now) + ", " +
+            QuoteOrNull(catalog.DateHumanize.Today) + ", " +
             QuoteOrNull(catalog.DateHumanize.Never) + ", " +
             QuoteOrNull(catalog.TimeSpan.Zero) + ", " +
             QuoteOrNull(catalog.TimeSpan.Age) + ", " +

--- a/src/Humanizer/DateTimeHumanizeStrategy/DateTimeHumanizeAlgorithms.cs
+++ b/src/Humanizer/DateTimeHumanizeStrategy/DateTimeHumanizeAlgorithms.cs
@@ -171,9 +171,10 @@ static class DateTimeHumanizeAlgorithms
     static string DateOnlyHumanizeToday(CultureInfo? culture)
     {
         var formatter = Configurator.GetFormatter(culture);
+        var now = formatter.DateHumanize(TimeUnit.Millisecond, Tense.Past, 0);
         return formatter is DefaultFormatter defaultFormatter
-            ? defaultFormatter.DateHumanize_Today()
-            : formatter.DateHumanize_Now();
+            ? defaultFormatter.DateHumanize_Today(now)
+            : now;
     }
 
     /// <summary>

--- a/src/Humanizer/DateTimeHumanizeStrategy/DateTimeHumanizeAlgorithms.cs
+++ b/src/Humanizer/DateTimeHumanizeStrategy/DateTimeHumanizeAlgorithms.cs
@@ -22,7 +22,12 @@ static class DateTimeHumanizeAlgorithms
     /// </summary>
     public static string PrecisionHumanize(DateOnly input, DateOnly comparisonBase, double precision, CultureInfo? culture)
     {
-        var diffDays = Math.Abs(comparisonBase.DayOfYear - input.DayOfYear);
+        if (input == comparisonBase)
+        {
+            return DateOnlyHumanizeToday(culture);
+        }
+
+        var diffDays = Math.Abs(comparisonBase.DayNumber - input.DayNumber);
         var ts = new TimeSpan(diffDays, 0, 0, 0);
         var tense = input > comparisonBase ? Tense.Future : Tense.Past;
 
@@ -147,6 +152,11 @@ static class DateTimeHumanizeAlgorithms
     /// </summary>
     public static string DefaultHumanize(DateOnly input, DateOnly comparisonBase, CultureInfo? culture)
     {
+        if (input == comparisonBase)
+        {
+            return DateOnlyHumanizeToday(culture);
+        }
+
         var tense = input > comparisonBase ? Tense.Future : Tense.Past;
         var diffDays = Math.Abs(comparisonBase.DayNumber - input.DayNumber);
         var ts = new TimeSpan(diffDays, 0, 0, 0);
@@ -156,6 +166,14 @@ static class DateTimeHumanizeAlgorithms
         var days = Math.Abs(input.DayNumber - comparisonBase.DayNumber);
 
         return DefaultHumanize(ts, sameMonth, days, tense, culture);
+    }
+
+    static string DateOnlyHumanizeToday(CultureInfo? culture)
+    {
+        var formatter = Configurator.GetFormatter(culture);
+        return formatter is DefaultFormatter defaultFormatter
+            ? defaultFormatter.DateHumanize_Today()
+            : formatter.DateHumanize_Now();
     }
 
     /// <summary>

--- a/src/Humanizer/Locales/en.yml
+++ b/src/Humanizer/Locales/en.yml
@@ -7,6 +7,7 @@ surfaces:
   phrases:
     relativeDate:
       now: 'now'
+      today: 'today'
       never: 'never'
       past:
         millisecond:

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -37,13 +37,10 @@ public class DefaultFormatter : IFormatter
     public virtual string DateHumanize_Now() =>
         phraseTable.DateNow ?? "now";
 
-    internal string DateHumanize_Today()
-    {
-        var now = DateHumanize_Now();
-        return now == phraseTable.DateNow
+    internal string DateHumanize_Today(string now) =>
+        now == (phraseTable.DateNow ?? "now")
             ? phraseTable.DateToday ?? now
             : now;
-    }
 
     /// <inheritdoc/>
     public virtual string DateHumanize_Never() =>

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -37,6 +37,9 @@ public class DefaultFormatter : IFormatter
     public virtual string DateHumanize_Now() =>
         phraseTable.DateNow ?? "now";
 
+    internal string DateHumanize_Today() =>
+        phraseTable.DateToday ?? DateHumanize_Now();
+
     /// <inheritdoc/>
     public virtual string DateHumanize_Never() =>
         phraseTable.DateNever ?? "never";

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -37,8 +37,13 @@ public class DefaultFormatter : IFormatter
     public virtual string DateHumanize_Now() =>
         phraseTable.DateNow ?? "now";
 
-    internal string DateHumanize_Today() =>
-        phraseTable.DateToday ?? DateHumanize_Now();
+    internal string DateHumanize_Today()
+    {
+        var now = DateHumanize_Now();
+        return now == phraseTable.DateNow
+            ? phraseTable.DateToday ?? now
+            : now;
+    }
 
     /// <inheritdoc/>
     public virtual string DateHumanize_Never() =>

--- a/src/Humanizer/Localisation/Formatters/LocalePhraseTable.cs
+++ b/src/Humanizer/Localisation/Formatters/LocalePhraseTable.cs
@@ -53,6 +53,7 @@ readonly record struct LocalizedUnitPhrase(
 
 sealed class LocalePhraseTable(
     string? dateNow,
+    string? dateToday,
     string? dateNever,
     string? timeSpanZero,
     string? timeSpanAge,
@@ -69,6 +70,7 @@ sealed class LocalePhraseTable(
     readonly LocalizedUnitPhrase?[] timeUnits = timeUnits;
 
     public string? DateNow { get; } = dateNow;
+    public string? DateToday { get; } = dateToday;
     public string? DateNever { get; } = dateNever;
     public string? TimeSpanZero { get; } = timeSpanZero;
     public string? TimeSpanAge { get; } = timeSpanAge;

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/CanonicalLocaleSchemaTests.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/CanonicalLocaleSchemaTests.cs
@@ -708,6 +708,27 @@ surfaces:
     }
 
     [Fact]
+    public void SemanticDiffDetectsRelativeDateTodayChanges()
+    {
+        var leftCatalog = CreateCatalog(("zz", """
+locale: 'zz'
+surfaces:
+  phrases:
+    relativeDate:
+      today: 'today'
+"""));
+        var rightCatalog = CreateCatalog(("zz", """
+locale: 'zz'
+surfaces:
+  phrases:
+    relativeDate:
+      today: 'this day'
+"""));
+
+        Assert.NotEmpty(HumanizerSourceGenerator.LocaleSemanticDiff.Compare(leftCatalog.Locales, rightCatalog.Locales));
+    }
+
+    [Fact]
     public void CanonicalSurfacesMustBeMappings()
     {
         var exception = Assert.Throws<InvalidOperationException>(() =>

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/LocalePhraseNormalizationTests.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/LocalePhraseNormalizationTests.cs
@@ -7,6 +7,20 @@ namespace Humanizer.SourceGenerators.Tests;
 public class LocalePhraseNormalizationTests
 {
     [Fact]
+    public void RelativeDateTodayIsNormalized()
+    {
+        var catalog = HumanizerSourceGenerator.LocalePhraseNormalization.ParseLocalePhraseCatalogForTests(
+            "zz",
+            """
+            phrases:
+              relativeDate:
+                today: 'today'
+            """);
+
+        Assert.Equal("today", catalog.DateHumanize.Today);
+    }
+
+    [Fact]
     public void ScalarFormsCollapseToDefaultOnly()
     {
         var catalog = HumanizerSourceGenerator.LocalePhraseNormalization.ParseLocalePhraseCatalogForTests(

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -617,6 +617,9 @@ public class CoverageGapTests
             timeUnit: new(Forms: new("hour"))));
 
         Assert.Equal("now", scalarFallbacks.DateHumanize_Now());
+        Assert.Equal(
+            "today",
+            new FormatterHarness(CreateLocalePhraseTable(dateToday: "today")).DateHumanize_Today("now"));
         Assert.Equal("never", scalarFallbacks.DateHumanize_Never());
         Assert.Equal("no time", scalarFallbacks.TimeSpanHumanize_Zero());
         Assert.Equal("{0}", scalarFallbacks.TimeSpanHumanize_Age());
@@ -3159,6 +3162,7 @@ public class CoverageGapTests
     }
 
     static LocalePhraseTable CreateLocalePhraseTable(
+        string? dateToday = null,
         LocalizedDatePhrase? dateFuture = null,
         LocalizedTimeSpanPhrase? timeSpan = null,
         LocalizedUnitPhrase? dataUnit = null,
@@ -3177,7 +3181,7 @@ public class CoverageGapTests
         dataUnits[(int)DataUnit.Byte] = dataUnit;
         timeUnits[(int)TimeUnit.Hour] = timeUnit;
 
-        return new(null, null, null, null, null, datePast, dateFuturePhrases, timeSpanUnits, dataUnits, timeUnits);
+        return new(null, dateToday, null, null, null, datePast, dateFuturePhrases, timeSpanUnits, dataUnits, timeUnits);
     }
 
     static ProfiledFormatter CreateProfiledFormatter(

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -2347,7 +2347,7 @@ public class CoverageGapTests
         dataUnits[(int)DataUnit.Byte] = new(Symbol: "B");
         timeUnits[(int)TimeUnit.Second] = new(Symbol: "s");
 
-        return new("now", "never", "zero", "age", datePast, dateFuture, timeSpanUnits, dataUnits, timeUnits);
+        return new("now", "today", "never", "zero", "age", datePast, dateFuture, timeSpanUnits, dataUnits, timeUnits);
     }
 
     static T?[] NewPhraseArray<T, TEnum>()
@@ -3177,7 +3177,7 @@ public class CoverageGapTests
         dataUnits[(int)DataUnit.Byte] = dataUnit;
         timeUnits[(int)TimeUnit.Hour] = timeUnit;
 
-        return new(null, null, null, null, datePast, dateFuturePhrases, timeSpanUnits, dataUnits, timeUnits);
+        return new(null, null, null, null, null, datePast, dateFuturePhrases, timeSpanUnits, dataUnits, timeUnits);
     }
 
     static ProfiledFormatter CreateProfiledFormatter(

--- a/tests/Humanizer.Tests/DateOnlyHumanizeTests.cs
+++ b/tests/Humanizer.Tests/DateOnlyHumanizeTests.cs
@@ -33,11 +33,12 @@ public class DateOnlyHumanizeTests
     }
 
     [Fact]
-    public void TodayWording_PreservesCustomNowOverride()
+    public void TodayWording_PreservesCustomDateHumanizeOverride()
     {
-        var formatter = new CustomNowFormatter();
+        var formatter = new CustomDateHumanizeFormatter();
+        var now = formatter.DateHumanize(TimeUnit.Millisecond, Tense.Past, 0);
 
-        Assert.Equal("custom now", formatter.DateHumanize_Today());
+        Assert.Equal("custom now", formatter.DateHumanize_Today(now));
     }
 
     [Fact]
@@ -132,11 +133,11 @@ public class DateOnlyHumanizeTests
         Assert.Equal(never.Value.Humanize(), never.Humanize());
     }
 
-    sealed class CustomNowFormatter()
+    sealed class CustomDateHumanizeFormatter()
         : DefaultFormatter("en")
     {
-        public override string DateHumanize_Now() =>
-            "custom now";
+        public override string DateHumanize(TimeUnit timeUnit, Tense timeUnitTense, int unit) =>
+            $"custom {base.DateHumanize(timeUnit, timeUnitTense, unit)}";
     }
 }
 

--- a/tests/Humanizer.Tests/DateOnlyHumanizeTests.cs
+++ b/tests/Humanizer.Tests/DateOnlyHumanizeTests.cs
@@ -33,6 +33,14 @@ public class DateOnlyHumanizeTests
     }
 
     [Fact]
+    public void TodayWording_PreservesCustomNowOverride()
+    {
+        var formatter = new CustomNowFormatter();
+
+        Assert.Equal("custom now", formatter.DateHumanize_Today());
+    }
+
+    [Fact]
     public void DefaultStrategy_MonthApart()
     {
         Configurator.DateOnlyHumanizeStrategy = new DefaultDateOnlyHumanizeStrategy();
@@ -122,6 +130,13 @@ public class DateOnlyHumanizeTests
         DateOnly? never = new DateOnly(2015, 12, 7);
 
         Assert.Equal(never.Value.Humanize(), never.Humanize());
+    }
+
+    sealed class CustomNowFormatter()
+        : DefaultFormatter("en")
+    {
+        public override string DateHumanize_Now() =>
+            "custom now";
     }
 }
 

--- a/tests/Humanizer.Tests/DateOnlyHumanizeTests.cs
+++ b/tests/Humanizer.Tests/DateOnlyHumanizeTests.cs
@@ -11,10 +11,25 @@ public class DateOnlyHumanizeTests
         var inputTime = new DateOnly(2015, 07, 05);
         var baseTime = new DateOnly(2015, 07, 05);
 
-        const string expectedResult = "now";
+        const string expectedResult = "today";
         var actualResult = inputTime.Humanize(baseTime);
 
         Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SameDate_UsesDateOnlyWordingWithoutChangingCultureFallback(bool usePrecisionStrategy)
+    {
+        Configurator.DateOnlyHumanizeStrategy = usePrecisionStrategy
+            ? new PrecisionDateOnlyHumanizeStrategy()
+            : new DefaultDateOnlyHumanizeStrategy();
+
+        var date = DateOnly.MinValue;
+
+        Assert.Equal("today", date.Humanize(date, new("en-GB")));
+        Assert.Equal("maintenant", date.Humanize(date, new("fr-FR")));
     }
 
     [Fact]
@@ -72,6 +87,26 @@ public class DateOnlyHumanizeTests
         var actualResult = inputTime.Humanize(baseTime);
 
         Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Theory]
+    [InlineData(2015, 12, 31, 2016, 1, 1, "tomorrow")]
+    [InlineData(2015, 1, 1, 2016, 1, 1, "one year from now")]
+    public void PrecisionStrategy_UsesAbsoluteDayDistance(
+        int baseYear,
+        int baseMonth,
+        int baseDay,
+        int inputYear,
+        int inputMonth,
+        int inputDay,
+        string expectedResult)
+    {
+        Configurator.DateOnlyHumanizeStrategy = new PrecisionDateOnlyHumanizeStrategy(0.75);
+
+        var baseTime = new DateOnly(baseYear, baseMonth, baseDay);
+        var inputTime = new DateOnly(inputYear, inputMonth, inputDay);
+
+        Assert.Equal(expectedResult, inputTime.Humanize(baseTime));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

`DateOnly.Humanize` now returns "today" for an equal English date instead of the instant-oriented "now"; `DateTime`, `DateTimeOffset`, and nonzero `DateOnly` wording remain unchanged. Precision-based `DateOnly` humanization also measures absolute day distance across year boundaries, so December 31 to January 1 is "tomorrow" rather than approximately a year.

Locales without a dedicated `today` phrase retain their existing localized `now` wording. Existing formatter overrides remain on the established virtual `DateHumanize` path, and the locale-authoring guide documents the optional `today` key. Thanks to @AJacksonCT for the original contribution that motivated this focused replacement, and to @behroozbc for the report.

Fixes #1186

Related: #1278

## Validation

- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0 --culture en-US` — 57,343 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0 --culture en-US` — 57,343 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0 --culture en-US` — 57,343 passed
- Source-generator tests on net10.0 and net11.0 — 113 passed per framework
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release` — succeeded without warnings
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic --no-restore` — clean (0 of 2,547 files)

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No external code was copied
- [x] Comments remain minimal
- [x] XML documentation is unchanged because no public API changed
- [x] Rebased on the latest `main`
- [x] Linked the fixed issue and related prior PR
- [x] Readme changes are not needed for this correction
- [x] Supported WSL test targets, package build, and format verification pass