### PR TITLE
test: isolate date and time humanization strategies

### DIFF
--- a/tests/Humanizer.Tests/DateOnlyHumanizeTests.cs
+++ b/tests/Humanizer.Tests/DateOnlyHumanizeTests.cs
@@ -6,8 +6,6 @@ public class DateOnlyHumanizeTests
     [Fact]
     public void DefaultStrategy_SameDate()
     {
-        Configurator.DateOnlyHumanizeStrategy = new DefaultDateOnlyHumanizeStrategy();
-
         var inputTime = new DateOnly(2015, 07, 05);
         var baseTime = new DateOnly(2015, 07, 05);
 
@@ -44,8 +42,6 @@ public class DateOnlyHumanizeTests
     [Fact]
     public void DefaultStrategy_MonthApart()
     {
-        Configurator.DateOnlyHumanizeStrategy = new DefaultDateOnlyHumanizeStrategy();
-
         var inputTime = new DateOnly(2015, 08, 05);
         var baseTime = new DateOnly(2015, 07, 05);
 
@@ -58,8 +54,6 @@ public class DateOnlyHumanizeTests
     [Fact]
     public void DefaultStrategy_DaysAgo()
     {
-        Configurator.DateOnlyHumanizeStrategy = new DefaultDateOnlyHumanizeStrategy();
-
         var inputTime = new DateOnly(2015, 07, 02);
         var baseTime = new DateOnly(2015, 07, 05);
 
@@ -72,8 +66,6 @@ public class DateOnlyHumanizeTests
     [Fact]
     public void DefaultStrategy_YearsAgo()
     {
-        Configurator.DateOnlyHumanizeStrategy = new DefaultDateOnlyHumanizeStrategy();
-
         var baseDate = DateTime.Now;
         var inputTime = DateOnly.FromDateTime(baseDate.AddMonths(-24));
         var baseTime = DateOnly.FromDateTime(baseDate);
@@ -87,13 +79,12 @@ public class DateOnlyHumanizeTests
     [Fact]
     public void PrecisionStrategy_NextDay()
     {
-        Configurator.DateOnlyHumanizeStrategy = new PrecisionDateOnlyHumanizeStrategy(0.75);
-
         var inputTime = new DateOnly(2015, 07, 05);
         var baseTime = new DateOnly(2015, 07, 04);
 
         const string expectedResult = "tomorrow";
-        var actualResult = inputTime.Humanize(baseTime);
+        var actualResult = new PrecisionDateOnlyHumanizeStrategy(0.75)
+            .Humanize(inputTime, baseTime, CultureInfo.CurrentUICulture);
 
         Assert.Equal(expectedResult, actualResult);
     }

--- a/tests/Humanizer.Tests/DateOnlyHumanizeTests.cs
+++ b/tests/Humanizer.Tests/DateOnlyHumanizeTests.cs
@@ -20,14 +20,14 @@ public class DateOnlyHumanizeTests
     [InlineData(true)]
     public void SameDate_UsesDateOnlyWordingWithoutChangingCultureFallback(bool usePrecisionStrategy)
     {
-        Configurator.DateOnlyHumanizeStrategy = usePrecisionStrategy
+        IDateOnlyHumanizeStrategy strategy = usePrecisionStrategy
             ? new PrecisionDateOnlyHumanizeStrategy()
             : new DefaultDateOnlyHumanizeStrategy();
 
         var date = DateOnly.MinValue;
 
-        Assert.Equal("today", date.Humanize(date, new("en-GB")));
-        Assert.Equal("maintenant", date.Humanize(date, new("fr-FR")));
+        Assert.Equal("today", strategy.Humanize(date, date, new("en-GB")));
+        Assert.Equal("maintenant", strategy.Humanize(date, date, new("fr-FR")));
     }
 
     [Fact]
@@ -101,12 +101,12 @@ public class DateOnlyHumanizeTests
         int inputDay,
         string expectedResult)
     {
-        Configurator.DateOnlyHumanizeStrategy = new PrecisionDateOnlyHumanizeStrategy(0.75);
-
         var baseTime = new DateOnly(baseYear, baseMonth, baseDay);
         var inputTime = new DateOnly(inputYear, inputMonth, inputDay);
 
-        Assert.Equal(expectedResult, inputTime.Humanize(baseTime));
+        Assert.Equal(
+            expectedResult,
+            new PrecisionDateOnlyHumanizeStrategy(0.75).Humanize(inputTime, baseTime, CultureInfo.CurrentUICulture));
     }
 
     [Fact]

--- a/tests/Humanizer.Tests/Localisation/ResourceBackedPhraseTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ResourceBackedPhraseTests.cs
@@ -40,9 +40,10 @@ public class ResourceBackedPhraseTests
     public void UsesExpectedTimeOnlyDefaultHumanizePhrases(string localeName, string inputTime, string comparisonBase, string expected)
     {
         var culture = GetCulture(localeName);
-        Configurator.TimeOnlyHumanizeStrategy = new DefaultTimeOnlyHumanizeStrategy();
 
-        Assert.Equal(expected, TimeOnly.Parse(inputTime).Humanize(TimeOnly.Parse(comparisonBase), culture: culture));
+        Assert.Equal(
+            expected,
+            new DefaultTimeOnlyHumanizeStrategy().Humanize(TimeOnly.Parse(inputTime), TimeOnly.Parse(comparisonBase), culture));
     }
 
     [Theory]
@@ -50,9 +51,10 @@ public class ResourceBackedPhraseTests
     public void UsesExpectedTimeOnlyPrecisionHumanizePhrases(string localeName, string inputTime, string comparisonBase, double precision, string expected)
     {
         var culture = GetCulture(localeName);
-        Configurator.TimeOnlyHumanizeStrategy = new PrecisionTimeOnlyHumanizeStrategy(precision);
 
-        Assert.Equal(expected, TimeOnly.Parse(inputTime).Humanize(TimeOnly.Parse(comparisonBase), culture: culture));
+        Assert.Equal(
+            expected,
+            new PrecisionTimeOnlyHumanizeStrategy(precision).Humanize(TimeOnly.Parse(inputTime), TimeOnly.Parse(comparisonBase), culture));
     }
 
     [Theory]
@@ -60,7 +62,6 @@ public class ResourceBackedPhraseTests
     public void UsesExpectedTimeOnlyNeverPhrase(string localeName, string expected)
     {
         var culture = GetCulture(localeName);
-        Configurator.TimeOnlyHumanizeStrategy = new DefaultTimeOnlyHumanizeStrategy();
 
         Assert.Equal(expected, ((TimeOnly?)null).Humanize(culture: culture));
     }
@@ -70,7 +71,6 @@ public class ResourceBackedPhraseTests
     public void TimeOnlyNullableValueMatchesNonNullableHumanize(string localeName, string timeValue)
     {
         var culture = GetCulture(localeName);
-        Configurator.TimeOnlyHumanizeStrategy = new DefaultTimeOnlyHumanizeStrategy();
         var nullableTime = TimeOnly.Parse(timeValue);
 
         Assert.Equal(nullableTime.Humanize(culture: culture), ((TimeOnly?)nullableTime).Humanize(culture: culture));

--- a/tests/Humanizer.Tests/TimeOnlyHumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeOnlyHumanizeTests.cs
@@ -6,8 +6,6 @@ public class TimeOnlyHumanizeTests
     [Fact]
     public void DefaultStrategy_SameTime()
     {
-        Configurator.TimeOnlyHumanizeStrategy = new DefaultTimeOnlyHumanizeStrategy();
-
         var inputTime = new TimeOnly(13, 07, 05);
         var baseTime = new TimeOnly(13, 07, 05);
 
@@ -20,8 +18,6 @@ public class TimeOnlyHumanizeTests
     [Fact]
     public void DefaultStrategy_HoursApart()
     {
-        Configurator.TimeOnlyHumanizeStrategy = new DefaultTimeOnlyHumanizeStrategy();
-
         var inputTime = new TimeOnly(13, 08, 05);
         var baseTime = new TimeOnly(1, 08, 05);
 
@@ -32,10 +28,38 @@ public class TimeOnlyHumanizeTests
     }
 
     [Fact]
+    public async Task StrategiesAreIsolatedAcrossParallelCultures()
+    {
+        using var strategiesReady = new Barrier(2);
+
+        var defaultResult = Task.Run(() =>
+        {
+            CultureInfo.CurrentCulture = new("en-US");
+            CultureInfo.CurrentUICulture = new("fr");
+            strategiesReady.SignalAndWait();
+
+            return new DefaultTimeOnlyHumanizeStrategy()
+                .Humanize(new(13, 08, 05), new(1, 08, 05), null);
+        });
+        var precisionResult = Task.Run(() =>
+        {
+            CultureInfo.CurrentCulture = new("fr");
+            CultureInfo.CurrentUICulture = new("is");
+            strategiesReady.SignalAndWait();
+
+            return new PrecisionTimeOnlyHumanizeStrategy(0.5)
+                .Humanize(new(13, 08, 05), new(1, 08, 05), null);
+        });
+
+        var results = await Task.WhenAll(defaultResult, precisionResult);
+
+        Assert.Equal("dans 12 heures", results[0]);
+        Assert.Equal("á morgun", results[1]);
+    }
+
+    [Fact]
     public void DefaultStrategy_HoursAgo()
     {
-        Configurator.TimeOnlyHumanizeStrategy = new DefaultTimeOnlyHumanizeStrategy();
-
         var inputTime = new TimeOnly(13, 07, 02);
         var baseTime = new TimeOnly(17, 07, 05);
 
@@ -48,13 +72,12 @@ public class TimeOnlyHumanizeTests
     [Fact]
     public void PrecisionStrategy_NextDay()
     {
-        Configurator.TimeOnlyHumanizeStrategy = new PrecisionTimeOnlyHumanizeStrategy(0.75);
-
         var inputTime = new TimeOnly(18, 10, 49);
         var baseTime = new TimeOnly(13, 07, 04);
 
         const string expectedResult = "5 hours from now";
-        var actualResult = inputTime.Humanize(baseTime);
+        var actualResult = new PrecisionTimeOnlyHumanizeStrategy(0.75)
+            .Humanize(inputTime, baseTime, CultureInfo.CurrentUICulture);
 
         Assert.Equal(expectedResult, actualResult);
     }

--- a/tests/Humanizer.Tests/TimeOnlyHumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeOnlyHumanizeTests.cs
@@ -32,29 +32,45 @@ public class TimeOnlyHumanizeTests
     {
         using var strategiesReady = new Barrier(2);
 
-        var defaultResult = Task.Run(() =>
-        {
-            CultureInfo.CurrentCulture = new("en-US");
-            CultureInfo.CurrentUICulture = new("fr");
-            strategiesReady.SignalAndWait();
-
-            return new DefaultTimeOnlyHumanizeStrategy()
-                .Humanize(new(13, 08, 05), new(1, 08, 05), null);
-        });
-        var precisionResult = Task.Run(() =>
-        {
-            CultureInfo.CurrentCulture = new("fr");
-            CultureInfo.CurrentUICulture = new("is");
-            strategiesReady.SignalAndWait();
-
-            return new PrecisionTimeOnlyHumanizeStrategy(0.5)
-                .Humanize(new(13, 08, 05), new(1, 08, 05), null);
-        });
+        var defaultResult = Task.Run(() => Humanize(
+            new("en-US"),
+            new("fr"),
+            new DefaultTimeOnlyHumanizeStrategy()));
+        var precisionResult = Task.Run(() => Humanize(
+            new("fr"),
+            new("is"),
+            new PrecisionTimeOnlyHumanizeStrategy(0.5)));
 
         var results = await Task.WhenAll(defaultResult, precisionResult);
 
         Assert.Equal("dans 12 heures", results[0]);
         Assert.Equal("á morgun", results[1]);
+
+        string Humanize(
+            CultureInfo currentCulture,
+            CultureInfo currentUICulture,
+            ITimeOnlyHumanizeStrategy strategy)
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            var originalUICulture = CultureInfo.CurrentUICulture;
+
+            try
+            {
+                CultureInfo.CurrentCulture = currentCulture;
+                CultureInfo.CurrentUICulture = currentUICulture;
+                if (!strategiesReady.SignalAndWait(TimeSpan.FromSeconds(30)))
+                {
+                    throw new TimeoutException("Parallel strategies did not synchronize.");
+                }
+
+                return strategy.Humanize(new(13, 08, 05), new(1, 08, 05), null);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+                CultureInfo.CurrentUICulture = originalUICulture;
+            }
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

DateOnly and TimeOnly humanization tests no longer corrupt one another's process-wide strategy when parallel work overlaps. The intermittent French `demain` occurred when an Icelandic precision case installed `PrecisionTimeOnlyHumanizeStrategy(0.5)` between another test's setup and humanization call, causing 12 hours to round to one day.

Precision cases now invoke their strategy instances directly, while default extension cases leave global configuration untouched. This is test isolation only; production behavior and public APIs are unchanged. Thanks @SimonCropp for the original report.

Fixes #1327.

## Validation

- [x] Deterministic pre-fix regression reproduced `Expected: "dans 12 heures"; Actual: "demain"`
- [x] Focused net8.0 tests: 7 TimeOnly, 12 DateOnly, and 5,575 resource-backed phrase cases passed
- [x] TimeOnly regression repeated 20 times under divergent `CurrentCulture`/`CurrentUICulture`
- [x] Full Humanizer.Tests passed on net8.0, net10.0, and net11.0: 57,513 tests per target
- [x] Release package created without warnings or errors
- [x] `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` changed 0 files
- [x] net48 left to Windows CI, as required on macOS

## Checklist

- [x] Implementation is clean and follows existing coding standards
- [x] No code-analysis or formatting warnings
- [x] Focused regression coverage exercises parallel divergent cultures
- [x] No code copied from external sources
- [x] XML documentation and README changes are not applicable to this test-only fix
- [x] Rebased on the latest `main`
