### PR TITLE
fix: singularize regular words ending in axes

### DIFF
--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -55,7 +55,7 @@ public static class Vocabularies
         _default.AddSingular("(^[m|l])ice$", "$1ouse");
         _default.AddSingular("(?<!^[a-z])(o)es$", "$1");
         _default.AddSingular("(shoe)s$", "$1");
-        _default.AddSingular("(cris|ax|test)es$", "$1is");
+        _default.AddSingular("(^ax|cris|test)es$", "$1is");
         _default.AddSingular("(octop|vir|alumn|fung|cact|foc|hippopotam|radi|stimul|syllab|nucle)i$", "$1us");
         _default.AddSingular("(alias|bias|iris|status|campus|apparatus|virus|walrus|trellis)es$", "$1");
         _default.AddSingular("^(ox)en", "$1");

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -55,7 +55,7 @@ public static class Vocabularies
         _default.AddSingular("(^[m|l])ice$", "$1ouse");
         _default.AddSingular("(?<!^[a-z])(o)es$", "$1");
         _default.AddSingular("(shoe)s$", "$1");
-        _default.AddSingular("((?<![a-z])ax|(?-i:(?<=[a-z])Ax)|cris|test)es$", "$1is");
+        _default.AddSingular("((?<![a-z])ax|(?-i:(?<=[A-Za-z])Ax)|cris|test)es$", "$1is");
         _default.AddSingular("(octop|vir|alumn|fung|cact|foc|hippopotam|radi|stimul|syllab|nucle)i$", "$1us");
         _default.AddSingular("(alias|bias|iris|status|campus|apparatus|virus|walrus|trellis)es$", "$1");
         _default.AddSingular("^(ox)en", "$1");

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -55,7 +55,7 @@ public static class Vocabularies
         _default.AddSingular("(^[m|l])ice$", "$1ouse");
         _default.AddSingular("(?<!^[a-z])(o)es$", "$1");
         _default.AddSingular("(shoe)s$", "$1");
-        _default.AddSingular("(^ax|cris|test)es$", "$1is");
+        _default.AddSingular("((?<![a-z])ax|(?-i:(?<=[a-z])Ax)|cris|test)es$", "$1is");
         _default.AddSingular("(octop|vir|alumn|fung|cact|foc|hippopotam|radi|stimul|syllab|nucle)i$", "$1us");
         _default.AddSingular("(alias|bias|iris|status|campus|apparatus|virus|walrus|trellis)es$", "$1");
         _default.AddSingular("^(ox)en", "$1");

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -396,6 +396,10 @@ class PluralTestSource : IEnumerable<object[]>
         yield return ["matrix", "matrices"];
 
         yield return ["axis", "axes"];
+        yield return ["tax", "taxes"];
+        yield return ["fax", "faxes"];
+        yield return ["surtax", "surtaxes"];
+        yield return ["syntax", "syntaxes"];
         yield return ["testis", "testes"];
         yield return ["crisis", "crises"];
 

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -396,6 +396,8 @@ class PluralTestSource : IEnumerable<object[]>
         yield return ["matrix", "matrices"];
 
         yield return ["axis", "axes"];
+        yield return ["coordinate_axis", "coordinate_axes"];
+        yield return ["CoordinateAxis", "CoordinateAxes"];
         yield return ["tax", "taxes"];
         yield return ["fax", "faxes"];
         yield return ["surtax", "surtaxes"];

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -398,6 +398,7 @@ class PluralTestSource : IEnumerable<object[]>
         yield return ["axis", "axes"];
         yield return ["coordinate_axis", "coordinate_axes"];
         yield return ["CoordinateAxis", "CoordinateAxes"];
+        yield return ["XMLAxis", "XMLAxes"];
         yield return ["tax", "taxes"];
         yield return ["fax", "faxes"];
         yield return ["surtax", "surtaxes"];


### PR DESCRIPTION
## Summary

Regular plurals ending in `-axes`, including `taxes`, `faxes`, `surtaxes`, and `syntaxes`, now singularize to their `-ax` forms instead of `-axis`. The exact `axes` exception and the existing `crises` and `testes` mappings remain intact, as does the priority of user-added vocabulary rules.

Thanks @McGregorsoft for reporting the original EF Core scaffolding case.

Fixes #1499

## Validation

- [x] Focused inflector tests on .NET 8 (`946` passed)
- [x] Full Humanizer.Tests suite on .NET 8, .NET 10, and .NET 11 (`57,528` passed per target)
- [x] Release package build with no warnings or errors
- [x] Full `dotnet format` verification

## Checklist

- [x] Implementation is focused and follows existing coding standards
- [x] Regression coverage includes the reported case and affected sibling words
- [x] No copied code or new public API
- [x] Rebased onto the latest `main`
