### PR TITLE
fix: use current culture for default locale resolution

### DIFF
--- a/src/Humanizer/Bytes/ByteRate.cs
+++ b/src/Humanizer/Bytes/ByteRate.cs
@@ -33,7 +33,7 @@ public class ByteRate(ByteSize size, TimeSpan interval) :
     /// </summary>
     /// <param name="timeUnit">Unit of time to calculate rate for (defaults is per second)</param>
     /// <param name="format">The string format to use for the number of bytes</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     public string Humanize(string? format, TimeUnit timeUnit = TimeUnit.Second, CultureInfo? culture = null)
     {
         var displayInterval = timeUnit switch

--- a/src/Humanizer/Configuration/Configurator.cs
+++ b/src/Humanizer/Configuration/Configurator.cs
@@ -47,19 +47,19 @@ public static class Configurator
     public static LocaliserRegistry<ITimeOnlyToClockNotationConverter> TimeOnlyToClockNotationConverters { get; } = new TimeOnlyToClockNotationConvertersRegistry();
 #endif
 
-    internal static ICollectionFormatter CollectionFormatter => CollectionFormatters.ResolveForUiCulture();
+    internal static ICollectionFormatter CollectionFormatter => CollectionFormatters.ResolveForCulture(null);
 
     /// <summary>
     /// The formatter to be used
     /// </summary>
-    /// <param name="culture">The culture to retrieve formatter for. Null means that current thread's UI culture should be used.</param>
+    /// <param name="culture">The culture to retrieve formatter for. Null means that current thread's culture should be used.</param>
     internal static IFormatter GetFormatter(CultureInfo? culture) =>
         Formatters.ResolveForCulture(culture);
 
     /// <summary>
     /// The converter to be used
     /// </summary>
-    /// <param name="culture">The culture to retrieve number to words converter for. Null means that current thread's UI culture should be used.</param>
+    /// <param name="culture">The culture to retrieve number to words converter for. Null means that current thread's culture should be used.</param>
     internal static INumberToWordsConverter GetNumberToWordsConverter(CultureInfo? culture) =>
         NumberToWordsConverters.ResolveForCulture(culture);
 
@@ -71,20 +71,20 @@ public static class Configurator
     /// <summary>
     /// The ordinalizer to be used
     /// </summary>
-    internal static IOrdinalizer Ordinalizer => Ordinalizers.ResolveForUiCulture();
+    internal static IOrdinalizer Ordinalizer => Ordinalizers.ResolveForCulture(null);
 
     /// <summary>
     /// The ordinalizer to be used
     /// </summary>
-    internal static IDateToOrdinalWordConverter DateToOrdinalWordsConverter => DateToOrdinalWordsConverters.ResolveForUiCulture();
+    internal static IDateToOrdinalWordConverter DateToOrdinalWordsConverter => DateToOrdinalWordsConverters.ResolveForCulture(null);
 
 #if NET6_0_OR_GREATER
     /// <summary>
     /// The ordinalizer to be used
     /// </summary>
-    internal static IDateOnlyToOrdinalWordConverter DateOnlyToOrdinalWordsConverter => DateOnlyToOrdinalWordsConverters.ResolveForUiCulture();
+    internal static IDateOnlyToOrdinalWordConverter DateOnlyToOrdinalWordsConverter => DateOnlyToOrdinalWordsConverters.ResolveForCulture(null);
 
-    internal static ITimeOnlyToClockNotationConverter TimeOnlyToClockNotationConverter => TimeOnlyToClockNotationConverters.ResolveForUiCulture();
+    internal static ITimeOnlyToClockNotationConverter TimeOnlyToClockNotationConverter => TimeOnlyToClockNotationConverters.ResolveForCulture(null);
 #endif
 
     /// <summary>

--- a/src/Humanizer/Configuration/LocaliserRegistry.cs
+++ b/src/Humanizer/Configuration/LocaliserRegistry.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace Humanizer;
 
 /// <summary>
@@ -10,7 +12,9 @@ public class LocaliserRegistry<TLocaliser>
     readonly object lockObject = new();
     volatile FrozenDictionary<string, Func<CultureInfo, TLocaliser>>? frozenLocalisers;
     readonly Func<CultureInfo, TLocaliser> defaultLocaliser;
-    readonly ConcurrentDictionary<string, TLocaliser> cultureSpecificCache = new();
+#pragma warning disable IL2091
+    readonly ConditionalWeakTable<CultureInfo, TLocaliser> cultureSpecificCache = new();
+#pragma warning restore IL2091
 
     /// <summary>
     /// Creates a localiser registry with the default localiser set to the provided value
@@ -37,15 +41,7 @@ public class LocaliserRegistry<TLocaliser>
     public TLocaliser ResolveForCulture(CultureInfo? culture)
     {
         var cultureInfo = culture ?? CultureInfo.CurrentCulture;
-        var cultureName = cultureInfo.Name;
-
-        // Use ConcurrentDictionary with culture name (string) as key to avoid CultureInfo equality checks
-        // and reduce allocations when the same culture is requested multiple times
-        return cultureSpecificCache.GetOrAdd(cultureName, _ =>
-        {
-            var factory = FindLocaliser(cultureInfo);
-            return factory(cultureInfo);
-        });
+        return cultureSpecificCache.GetValue(cultureInfo, c => FindLocaliser(c)(c));
     }
 
     /// <summary>

--- a/src/Humanizer/Configuration/LocaliserRegistry.cs
+++ b/src/Humanizer/Configuration/LocaliserRegistry.cs
@@ -28,15 +28,15 @@ public class LocaliserRegistry<TLocaliser>
     /// Gets the localiser for the current thread's UI culture
     /// </summary>
     public TLocaliser ResolveForUiCulture() =>
-        ResolveForCulture(null);
+        ResolveForCulture(CultureInfo.CurrentUICulture);
 
     /// <summary>
     /// Gets the localiser for the specified culture
     /// </summary>
-    /// <param name="culture">The culture to retrieve localiser for. If not specified, current thread's UI culture is used.</param>
+    /// <param name="culture">The culture to retrieve localiser for. If not specified, current thread's culture is used.</param>
     public TLocaliser ResolveForCulture(CultureInfo? culture)
     {
-        var cultureInfo = culture ?? CultureInfo.CurrentUICulture;
+        var cultureInfo = culture ?? CultureInfo.CurrentCulture;
         var cultureName = cultureInfo.Name;
 
         // Use ConcurrentDictionary with culture name (string) as key to avoid CultureInfo equality checks

--- a/src/Humanizer/DateHumanizeExtensions.cs
+++ b/src/Humanizer/DateHumanizeExtensions.cs
@@ -11,7 +11,7 @@ public static class DateHumanizeExtensions
     /// <param name="input">The date to be humanized</param>
     /// <param name="utcDate">Nullable boolean value indicating whether the date is in UTC or local. If null, current date is used with the same DateTimeKind of input</param>
     /// <param name="dateToCompareAgainst">Date to compare the input against. If null, current date is used as base</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <returns>distance of time in words</returns>
     public static string Humanize(this DateTime input, bool? utcDate = null, DateTime? dateToCompareAgainst = null, CultureInfo? culture = null)
     {
@@ -28,7 +28,7 @@ public static class DateHumanizeExtensions
     /// <param name="input">The date to be humanized</param>
     /// <param name="utcDate">Nullable boolean value indicating whether the date is in UTC or local. If null, current date is used with the same DateTimeKind of input</param>
     /// <param name="dateToCompareAgainst">Date to compare the input against. If null, current date is used as base</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <returns>distance of time in words</returns>
     public static string Humanize(this DateTime? input, bool? utcDate = null, DateTime? dateToCompareAgainst = null, CultureInfo? culture = null)
     {
@@ -47,7 +47,7 @@ public static class DateHumanizeExtensions
     /// </summary>
     /// <param name="input">The date to be humanized</param>
     /// <param name="dateToCompareAgainst">Date to compare the input against. If null, current date is used as base</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <returns>distance of time in words</returns>
     public static string Humanize(this DateTimeOffset input, DateTimeOffset? dateToCompareAgainst = null, CultureInfo? culture = null)
     {
@@ -61,7 +61,7 @@ public static class DateHumanizeExtensions
     /// </summary>
     /// <param name="input">The date to be humanized</param>
     /// <param name="dateToCompareAgainst">Date to compare the input against. If null, current date is used as base</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <returns>distance of time in words</returns>
     public static string Humanize(this DateTimeOffset? input, DateTimeOffset? dateToCompareAgainst = null, CultureInfo? culture = null)
     {
@@ -81,7 +81,7 @@ public static class DateHumanizeExtensions
     /// </summary>
     /// <param name="input">The date to be humanized</param>
     /// <param name="dateToCompareAgainst">Date to compare the input against. If null, current date is used as base</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <returns>distance of time in words</returns>
     public static string Humanize(this DateOnly input, DateOnly? dateToCompareAgainst = null, CultureInfo? culture = null)
     {
@@ -94,7 +94,7 @@ public static class DateHumanizeExtensions
     /// </summary>
     /// <param name="input">The date to be humanized</param>
     /// <param name="dateToCompareAgainst">Date to compare the input against. If null, current date is used as base</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <returns>distance of time in words</returns>
     public static string Humanize(this DateOnly? input, DateOnly? dateToCompareAgainst = null, CultureInfo? culture = null)
     {
@@ -114,7 +114,7 @@ public static class DateHumanizeExtensions
     /// <param name="input">The date to be humanized</param>
     /// <param name="useUtc">If <paramref name="timeToCompareAgainst"/> is null, used to determine if the current time is UTC or local. Defaults to UTC.</param>
     /// <param name="timeToCompareAgainst">Date to compare the input against. If null, current date is used as base</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <returns>distance of time in words</returns>
     public static string Humanize(this TimeOnly input, TimeOnly? timeToCompareAgainst = null, bool useUtc = true, CultureInfo? culture = null)
     {
@@ -129,7 +129,7 @@ public static class DateHumanizeExtensions
     /// <param name="input">The date to be humanized</param>
     /// <param name="useUtc">If <paramref name="timeToCompareAgainst"/> is null, used to determine if the current time is UTC or local. Defaults to UTC.</param>
     /// <param name="timeToCompareAgainst">Time to compare the input against. If null, current date is used as base</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <returns>distance of time in words</returns>
     public static string Humanize(this TimeOnly? input, TimeOnly? timeToCompareAgainst = null, bool useUtc = true, CultureInfo? culture = null)
     {

--- a/src/Humanizer/NumberToWordsExtension.cs
+++ b/src/Humanizer/NumberToWordsExtension.cs
@@ -11,7 +11,7 @@ public static class NumberToWordsExtension
     /// 1.ToOrdinalWords() -> "first"
     /// </summary>
     /// <param name="number">Number to be turned to ordinal words</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     public static string ToOrdinalWords(this int number, CultureInfo? culture = null) =>
         number == 1 && TryGetNativeFirstOrdinalWord(culture, null) is { } firstOrdinalWord
             ? firstOrdinalWord
@@ -29,7 +29,7 @@ public static class NumberToWordsExtension
     /// </example>
     /// <param name="number">Number to be turned to ordinal words</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     /// <returns>The number converted into ordinal words</returns>
     public static string ToOrdinalWords(this int number, WordForm wordForm, CultureInfo? culture = null) =>
         Configurator.GetNumberToWordsConverter(culture).ConvertToOrdinal(number, wordForm);
@@ -41,7 +41,7 @@ public static class NumberToWordsExtension
     /// </summary>
     /// <param name="number">Number to be turned to words</param>
     /// <param name="gender">The grammatical gender to use for output words</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     public static string ToOrdinalWords(this int number, GrammaticalGender gender, CultureInfo? culture = null) =>
         number == 1 && TryGetNativeFirstOrdinalWord(culture, gender) is { } firstOrdinalWord
             ? firstOrdinalWord
@@ -62,7 +62,7 @@ public static class NumberToWordsExtension
     /// <param name="number">Number to be turned to ordinal words</param>
     /// <param name="gender">The grammatical gender to use for output words</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     /// <returns>The number converted into ordinal words</returns>
     public static string ToOrdinalWords(this int number, GrammaticalGender gender, WordForm wordForm, CultureInfo? culture = null) =>
         number == 1 && TryGetNativeFirstOrdinalWord(culture, gender) is { } firstOrdinalWord
@@ -73,7 +73,7 @@ public static class NumberToWordsExtension
     /// 1.ToTuple() -> "single"
     /// </summary>
     /// <param name="number">Number to be turned to tuple</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     public static string ToTuple(this int number, CultureInfo? culture = null) =>
         Configurator.GetNumberToWordsConverter(culture).ConvertToTuple(number);
 
@@ -81,7 +81,7 @@ public static class NumberToWordsExtension
     /// Converts the given value to localized cardinal words.
     /// </summary>
     /// <param name="number">The value to convert.</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     /// <returns>The localized cardinal words for <paramref name="number"/>.</returns>
     public static string ToWords(this int number, CultureInfo? culture = null) =>
         ((long)number).ToWords(culture);
@@ -98,7 +98,7 @@ public static class NumberToWordsExtension
     /// </example>
     /// <param name="number">Number to be turned to words</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     /// <returns>The number converted to words</returns>
     public static string ToWords(this int number, WordForm wordForm, CultureInfo? culture = null) =>
         ((long)number).ToWords(wordForm, culture);
@@ -133,7 +133,7 @@ public static class NumberToWordsExtension
     /// </summary>
     /// <param name="number">The value to convert.</param>
     /// <param name="addAnd">Whether to include the culture's conjunction before the terminal group.</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     /// <returns>The localized cardinal words for <paramref name="number"/>.</returns>
     public static string ToWords(this int number, bool addAnd, CultureInfo? culture = null) =>
         ((long)number).ToWords(culture, addAnd);
@@ -152,7 +152,7 @@ public static class NumberToWordsExtension
     /// <param name="number">The value to convert.</param>
     /// <param name="addAnd">Whether to include the culture's conjunction before the terminal group.</param>
     /// <param name="wordForm">The requested word form.</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     /// <returns>The localized cardinal words for <paramref name="number"/>.</returns>
     public static string ToWords(this int number, bool addAnd, WordForm wordForm, CultureInfo? culture = null) =>
         ((long)number).ToWords(wordForm, culture, addAnd);
@@ -174,7 +174,7 @@ public static class NumberToWordsExtension
     /// </example>
     /// <param name="number">The value to convert.</param>
     /// <param name="gender">The grammatical gender to use when the locale supports gendered forms.</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     /// <returns>The localized cardinal words for <paramref name="number"/>.</returns>
     public static string ToWords(this int number, GrammaticalGender gender, CultureInfo? culture = null) =>
         ((long)number).ToWords(gender, culture);
@@ -193,7 +193,7 @@ public static class NumberToWordsExtension
     /// <param name="number">The value to convert.</param>
     /// <param name="wordForm">The requested word form.</param>
     /// <param name="gender">The grammatical gender to use when the locale supports gendered forms.</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     /// <returns>The localized cardinal words for <paramref name="number"/>.</returns>
     public static string ToWords(this int number, WordForm wordForm, GrammaticalGender gender, CultureInfo? culture = null) =>
         ((long)number).ToWords(wordForm, gender, culture);
@@ -202,7 +202,7 @@ public static class NumberToWordsExtension
     /// Converts the given value to localized cardinal words using the culture's default conjunction policy.
     /// </summary>
     /// <param name="number">The value to convert.</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     /// <param name="addAnd">Whether to include the culture's conjunction before the terminal group.</param>
     /// <returns>The localized cardinal words for <paramref name="number"/>.</returns>
     public static string ToWords(this long number, CultureInfo? culture = null, bool addAnd = true) =>
@@ -220,7 +220,7 @@ public static class NumberToWordsExtension
     /// </example>
     /// <param name="number">The value to convert.</param>
     /// <param name="wordForm">The requested word form.</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     /// <param name="addAnd">Whether to include the culture's conjunction before the terminal group.</param>
     /// <returns>The localized cardinal words for <paramref name="number"/>.</returns>
     public static string ToWords(this long number, WordForm wordForm, CultureInfo? culture = null, bool addAnd = false) =>
@@ -244,7 +244,7 @@ public static class NumberToWordsExtension
     ///
     /// <param name="number">The value to convert.</param>
     /// <param name="gender">The grammatical gender to use when the locale supports gendered forms.</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     /// <returns>The localized cardinal words for <paramref name="number"/>.</returns>
     public static string ToWords(this long number, GrammaticalGender gender, CultureInfo? culture = null) =>
         Configurator.GetNumberToWordsConverter(culture).Convert(number, gender);
@@ -263,7 +263,7 @@ public static class NumberToWordsExtension
     /// <param name="number">The value to convert.</param>
     /// <param name="wordForm">The requested word form.</param>
     /// <param name="gender">The grammatical gender to use when the locale supports gendered forms.</param>
-    /// <param name="culture">The culture to use. If <c>null</c>, the current UI culture is used.</param>
+    /// <param name="culture">The culture to use. If <c>null</c>, the current culture is used.</param>
     /// <returns>The localized cardinal words for <paramref name="number"/>.</returns>
     public static string ToWords(this long number, WordForm wordForm, GrammaticalGender gender, CultureInfo? culture = null) =>
         Configurator.GetNumberToWordsConverter(culture).Convert(number, wordForm, gender);

--- a/src/Humanizer/OrdinalizeExtensions.cs
+++ b/src/Humanizer/OrdinalizeExtensions.cs
@@ -134,7 +134,7 @@ public static class OrdinalizeExtensions
     /// </summary>
     /// <param name="number">The number to be ordinalized</param>
     public static string Ordinalize(this int number) =>
-        Configurator.Ordinalizer.Convert(number, NormalizeOrdinalNumberString(number.ToString(CultureInfo.InvariantCulture)));
+        number.Ordinalize(CultureInfo.CurrentCulture);
 
     /// <summary>
     /// Turns a number into an ordinal number used to denote the position in an ordered sequence supporting specific locale's variations.
@@ -150,7 +150,7 @@ public static class OrdinalizeExtensions
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
     /// <returns>The number ordinalized</returns>
     public static string Ordinalize(this int number, WordForm wordForm) =>
-        Configurator.Ordinalizer.Convert(number, NormalizeOrdinalNumberString(number.ToString(CultureInfo.InvariantCulture)), wordForm);
+        number.Ordinalize(CultureInfo.CurrentCulture, wordForm);
 
     /// <summary>
     /// Turns a number into an ordinal number used to denote the position in an ordered sequence such as 1st, 2nd, 3rd, 4th.
@@ -192,7 +192,7 @@ public static class OrdinalizeExtensions
     /// <param name="number">The number to be ordinalized</param>
     /// <param name="gender">The grammatical gender to use for output words</param>
     public static string Ordinalize(this int number, GrammaticalGender gender) =>
-        Configurator.Ordinalizer.Convert(number, NormalizeOrdinalNumberString(number.ToString(CultureInfo.InvariantCulture)), gender);
+        number.Ordinalize(gender, CultureInfo.CurrentCulture);
 
     /// <summary>
     /// Turns a number into an ordinal number used to denote the position in an ordered sequence supporting specific
@@ -211,7 +211,7 @@ public static class OrdinalizeExtensions
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
     /// <returns>The number ordinalized</returns>
     public static string Ordinalize(this int number, GrammaticalGender gender, WordForm wordForm) =>
-        Configurator.Ordinalizer.Convert(number, NormalizeOrdinalNumberString(number.ToString(CultureInfo.InvariantCulture)), gender, wordForm);
+        number.Ordinalize(gender, CultureInfo.CurrentCulture, wordForm);
 
     /// <summary>
     /// Turns a number into an ordinal number used to denote the position in an ordered sequence such as 1st, 2nd, 3rd, 4th.

--- a/src/Humanizer/OrdinalizeExtensions.cs
+++ b/src/Humanizer/OrdinalizeExtensions.cs
@@ -34,10 +34,10 @@ public static class OrdinalizeExtensions
     /// Turns a number into an ordinal string used to denote the position in an ordered sequence such as 1st, 2nd, 3rd, 4th.
     /// </summary>
     /// <param name="numberString">The number, in string, to be ordinalized</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     public static string Ordinalize(this string numberString, CultureInfo culture)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(ParseOrdinalNumber(numberString, resolvedCulture), NormalizeOrdinalNumberString(numberString));
     }
 
@@ -52,12 +52,12 @@ public static class OrdinalizeExtensions
     /// </code>
     /// </example>
     /// <param name="numberString">The number to be ordinalized</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
     /// <returns>The number ordinalized</returns>
     public static string Ordinalize(this string numberString, CultureInfo culture, WordForm wordForm)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(ParseOrdinalNumber(numberString, resolvedCulture), NormalizeOrdinalNumberString(numberString), wordForm);
     }
 
@@ -99,10 +99,10 @@ public static class OrdinalizeExtensions
     /// </summary>
     /// <param name="numberString">The number, in string, to be ordinalized</param>
     /// <param name="gender">The grammatical gender to use for output words</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     public static string Ordinalize(this string numberString, GrammaticalGender gender, CultureInfo culture)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(ParseOrdinalNumber(numberString, resolvedCulture), NormalizeOrdinalNumberString(numberString), gender);
     }
 
@@ -120,12 +120,12 @@ public static class OrdinalizeExtensions
     /// </example>
     /// <param name="numberString">The number to be ordinalized</param>
     /// <param name="gender">The grammatical gender to use for output words</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
     /// <returns>The number ordinalized</returns>
     public static string Ordinalize(this string numberString, GrammaticalGender gender, CultureInfo culture, WordForm wordForm)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(ParseOrdinalNumber(numberString, resolvedCulture), NormalizeOrdinalNumberString(numberString), gender, wordForm);
     }
 
@@ -156,10 +156,10 @@ public static class OrdinalizeExtensions
     /// Turns a number into an ordinal number used to denote the position in an ordered sequence such as 1st, 2nd, 3rd, 4th.
     /// </summary>
     /// <param name="number">The number to be ordinalized</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     public static string Ordinalize(this int number, CultureInfo culture)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)));
     }
 
@@ -174,12 +174,12 @@ public static class OrdinalizeExtensions
     /// </code>
     /// </example>
     /// <param name="number">The number to be ordinalized</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
     /// <returns>The number ordinalized</returns>
     public static string Ordinalize(this int number, CultureInfo culture, WordForm wordForm)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)), wordForm);
     }
 
@@ -221,10 +221,10 @@ public static class OrdinalizeExtensions
     /// </summary>
     /// <param name="number">The number to be ordinalized</param>
     /// <param name="gender">The grammatical gender to use for output words</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     public static string Ordinalize(this int number, GrammaticalGender gender, CultureInfo culture)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)), gender);
     }
 
@@ -242,12 +242,12 @@ public static class OrdinalizeExtensions
     /// </example>
     /// <param name="number">The number to be ordinalized</param>
     /// <param name="gender">The grammatical gender to use for output words</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
     /// <returns>The number ordinalized</returns>
     public static string Ordinalize(this int number, GrammaticalGender gender, CultureInfo culture, WordForm wordForm)
     {
-        var resolvedCulture = culture ?? CultureInfo.CurrentUICulture;
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)), gender, wordForm);
     }
 

--- a/src/Humanizer/OrdinalizeExtensions.cs
+++ b/src/Humanizer/OrdinalizeExtensions.cs
@@ -35,7 +35,7 @@ public static class OrdinalizeExtensions
     /// </summary>
     /// <param name="numberString">The number, in string, to be ordinalized</param>
     /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
-    public static string Ordinalize(this string numberString, CultureInfo culture)
+    public static string Ordinalize(this string numberString, CultureInfo? culture)
     {
         var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(ParseOrdinalNumber(numberString, resolvedCulture), NormalizeOrdinalNumberString(numberString));
@@ -55,7 +55,7 @@ public static class OrdinalizeExtensions
     /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
     /// <returns>The number ordinalized</returns>
-    public static string Ordinalize(this string numberString, CultureInfo culture, WordForm wordForm)
+    public static string Ordinalize(this string numberString, CultureInfo? culture, WordForm wordForm)
     {
         var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(ParseOrdinalNumber(numberString, resolvedCulture), NormalizeOrdinalNumberString(numberString), wordForm);
@@ -100,7 +100,7 @@ public static class OrdinalizeExtensions
     /// <param name="numberString">The number, in string, to be ordinalized</param>
     /// <param name="gender">The grammatical gender to use for output words</param>
     /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
-    public static string Ordinalize(this string numberString, GrammaticalGender gender, CultureInfo culture)
+    public static string Ordinalize(this string numberString, GrammaticalGender gender, CultureInfo? culture)
     {
         var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(ParseOrdinalNumber(numberString, resolvedCulture), NormalizeOrdinalNumberString(numberString), gender);
@@ -123,7 +123,7 @@ public static class OrdinalizeExtensions
     /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
     /// <returns>The number ordinalized</returns>
-    public static string Ordinalize(this string numberString, GrammaticalGender gender, CultureInfo culture, WordForm wordForm)
+    public static string Ordinalize(this string numberString, GrammaticalGender gender, CultureInfo? culture, WordForm wordForm)
     {
         var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(ParseOrdinalNumber(numberString, resolvedCulture), NormalizeOrdinalNumberString(numberString), gender, wordForm);
@@ -157,7 +157,7 @@ public static class OrdinalizeExtensions
     /// </summary>
     /// <param name="number">The number to be ordinalized</param>
     /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
-    public static string Ordinalize(this int number, CultureInfo culture)
+    public static string Ordinalize(this int number, CultureInfo? culture)
     {
         var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)));
@@ -177,7 +177,7 @@ public static class OrdinalizeExtensions
     /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
     /// <returns>The number ordinalized</returns>
-    public static string Ordinalize(this int number, CultureInfo culture, WordForm wordForm)
+    public static string Ordinalize(this int number, CultureInfo? culture, WordForm wordForm)
     {
         var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)), wordForm);
@@ -222,7 +222,7 @@ public static class OrdinalizeExtensions
     /// <param name="number">The number to be ordinalized</param>
     /// <param name="gender">The grammatical gender to use for output words</param>
     /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
-    public static string Ordinalize(this int number, GrammaticalGender gender, CultureInfo culture)
+    public static string Ordinalize(this int number, GrammaticalGender gender, CultureInfo? culture)
     {
         var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)), gender);
@@ -245,7 +245,7 @@ public static class OrdinalizeExtensions
     /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
     /// <returns>The number ordinalized</returns>
-    public static string Ordinalize(this int number, GrammaticalGender gender, CultureInfo culture, WordForm wordForm)
+    public static string Ordinalize(this int number, GrammaticalGender gender, CultureInfo? culture, WordForm wordForm)
     {
         var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)), gender, wordForm);

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -15,7 +15,7 @@ public static class TimeSpanHumanizeExtensions
     /// Turns a TimeSpan into a human readable form. E.g. 1 day.
     /// </summary>
     /// <param name="precision">The maximum number of time units to return. Defaulted is 1 which means the largest unit is returned</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="maxUnit">The maximum unit of time to output. The default value is <see cref="TimeUnit.Week"/>. The time units <see cref="TimeUnit.Month"/> and <see cref="TimeUnit.Year"/> will give approximations for time spans bigger 30 days by calculating with 365.2425 days a year and 30.4369 days a month.</param>
     /// <param name="minUnit">The minimum unit of time to output.</param>
     /// <param name="collectionSeparator">The separator to use when combining humanized time parts. If null, the default collection formatter for the current culture is used.</param>
@@ -28,7 +28,7 @@ public static class TimeSpanHumanizeExtensions
     /// </summary>
     /// <param name="precision">The maximum number of time units to return.</param>
     /// <param name="countEmptyUnits">Controls whether empty time units should be counted towards maximum number of time units. Leading empty time units never count.</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="maxUnit">The maximum unit of time to output. The default value is <see cref="TimeUnit.Week"/>. The time units <see cref="TimeUnit.Month"/> and <see cref="TimeUnit.Year"/> will give approximations for time spans bigger than 30 days by calculating with 365.2425 days a year and 30.4369 days a month.</param>
     /// <param name="minUnit">The minimum unit of time to output.</param>
     /// <param name="collectionSeparator">The separator to use when combining humanized time parts. If null, the default collection formatter for the current culture is used.</param>
@@ -49,7 +49,7 @@ public static class TimeSpanHumanizeExtensions
     /// Turns a TimeSpan into an age expression, e.g. "40 years old"
     /// </summary>
     /// <param name="timeSpan">Elapsed time</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="maxUnit">The maximum unit of time to output. The default value is <see cref="TimeUnit.Year"/>.</param>
     /// <param name="toWords">Uses words instead of numbers if true. E.g. "forty years old".</param>
     /// <returns>Age expression in the given culture/language</returns>

--- a/src/Humanizer/TimeUnitToSymbolExtensions.cs
+++ b/src/Humanizer/TimeUnitToSymbolExtensions.cs
@@ -9,7 +9,7 @@ public static class TimeUnitToSymbolExtensions
     /// TimeUnit.Day.ToSymbol() -> "d"
     /// </summary>
     /// <param name="unit">Unit of time to be turned to a symbol</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     public static string ToSymbol(this TimeUnit unit, CultureInfo? culture = null) =>
         Configurator.GetFormatter(culture).TimeUnitHumanize(unit);
 }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -1849,18 +1849,18 @@ namespace Humanizer
         public static string Ordinalize(this string numberString) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this int number, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this int number, System.Globalization.CultureInfo culture) { }
+        public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this string numberString, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo culture) { }
+        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture) { }
-        public static string Ordinalize(this int number, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture) { }
-        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
     }
     public enum Plurality
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -1849,18 +1849,18 @@ namespace Humanizer
         public static string Ordinalize(this string numberString) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this int number, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this int number, System.Globalization.CultureInfo culture) { }
+        public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this string numberString, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo culture) { }
+        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture) { }
-        public static string Ordinalize(this int number, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture) { }
-        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
     }
     public enum Plurality
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -1848,18 +1848,18 @@ namespace Humanizer
         public static string Ordinalize(this string numberString) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this int number, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this int number, System.Globalization.CultureInfo culture) { }
+        public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this string numberString, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo culture) { }
+        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture) { }
-        public static string Ordinalize(this int number, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture) { }
-        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
     }
     public enum Plurality
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -1193,18 +1193,18 @@ namespace Humanizer
         public static string Ordinalize(this string numberString) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this int number, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this int number, System.Globalization.CultureInfo culture) { }
+        public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this string numberString, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo culture) { }
+        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture) { }
-        public static string Ordinalize(this int number, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture) { }
-        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
-        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
     }
     public enum Plurality
     {

--- a/tests/Humanizer.Tests/Localisation/LocaliserRegistryTests.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaliserRegistryTests.cs
@@ -14,14 +14,43 @@ public class LocaliserRegistryTests
     }
 
     [Fact]
-    public void ResolveForCultureNullUsesCurrentUiCulture()
+    public void ResolveForCultureNullUsesCurrentCulture()
     {
         var registry = new LocaliserRegistry<string>(culture => $"default:{culture.Name}");
         registry.Register("fr", culture => $"fr:{culture.Name}");
 
         using var _ = new DistinctCultureSwap(new("en-US"), new("fr-CH"));
 
-        Assert.Equal("fr:fr-CH", registry.ResolveForCulture(null));
+        Assert.Equal("default:en-US", registry.ResolveForCulture(null));
+    }
+
+    [Fact]
+    public void DefaultRegistryCallersUseCurrentCulture()
+    {
+        using var _ = new DistinctCultureSwap(new("en-US"), new("de-DE"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.Equal("one", 1.ToWords());
+            Assert.Equal("1st", 1.Ordinalize());
+            Assert.Equal("January 1st, 2015", new DateTime(2015, 1, 1).ToOrdinalWords());
+            Assert.Equal("January 1st, 2015", new DateOnly(2015, 1, 1).ToOrdinalWords());
+            Assert.Equal("a and b", new List<string> { "a", "b" }.Humanize());
+            Assert.Equal("1 day", TimeSpan.FromDays(1).Humanize());
+            Assert.Equal("one twenty-three", new TimeOnly(13, 23).ToClockNotation());
+        });
+    }
+
+    [Fact]
+    public void OrdinalizeNullCultureUsesCurrentCultureForNumberFormatting()
+    {
+        var culture = new CultureInfo("en-US");
+        culture.NumberFormat.NegativeSign = "~";
+        var uiCulture = new CultureInfo("en-US");
+        uiCulture.NumberFormat.NegativeSign = "!";
+        using var _ = new DistinctCultureSwap(culture, uiCulture);
+
+        Assert.Equal("~1st", (-1).Ordinalize(null!));
     }
 
     [Fact]

--- a/tests/Humanizer.Tests/Localisation/LocaliserRegistryTests.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaliserRegistryTests.cs
@@ -34,10 +34,31 @@ public class LocaliserRegistryTests
             Assert.Equal("one", 1.ToWords());
             Assert.Equal("1st", 1.Ordinalize());
             Assert.Equal("January 1st, 2015", new DateTime(2015, 1, 1).ToOrdinalWords());
+#if NET6_0_OR_GREATER
             Assert.Equal("January 1st, 2015", new DateOnly(2015, 1, 1).ToOrdinalWords());
+#endif
             Assert.Equal("a and b", new List<string> { "a", "b" }.Humanize());
             Assert.Equal("1 day", TimeSpan.FromDays(1).Humanize());
+#if NET6_0_OR_GREATER
             Assert.Equal("one twenty-three", new TimeOnly(13, 23).ToClockNotation());
+#endif
+        });
+    }
+
+    [Fact]
+    public void RegistryCacheDistinguishesCulturesWithTheSameName()
+    {
+        var culture = new CultureInfo("en-US");
+        culture.NumberFormat.NegativeSign = "~";
+        var uiCulture = new CultureInfo("en-US");
+        uiCulture.NumberFormat.NegativeSign = "!";
+        var registry = new LocaliserRegistry<string>(resolvedCulture => resolvedCulture.NumberFormat.NegativeSign);
+        using var _ = new DistinctCultureSwap(culture, uiCulture);
+
+        Assert.Multiple(() =>
+        {
+            Assert.Equal("!", registry.ResolveForUiCulture());
+            Assert.Equal("~", registry.ResolveForCulture(null));
         });
     }
 

--- a/tests/Humanizer.Tests/Localisation/LocaliserRegistryTests.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaliserRegistryTests.cs
@@ -71,7 +71,11 @@ public class LocaliserRegistryTests
         uiCulture.NumberFormat.NegativeSign = "!";
         using var _ = new DistinctCultureSwap(culture, uiCulture);
 
-        Assert.Equal("~1st", (-1).Ordinalize(null!));
+        Assert.Multiple(() =>
+        {
+            Assert.Equal("~1st", (-1).Ordinalize());
+            Assert.Equal("~1st", (-1).Ordinalize(null));
+        });
     }
 
     [Fact]

--- a/tests/Humanizer.Tests/TimeOnlyHumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeOnlyHumanizeTests.cs
@@ -43,8 +43,8 @@ public class TimeOnlyHumanizeTests
 
         var results = await Task.WhenAll(defaultResult, precisionResult);
 
-        Assert.Equal("dans 12 heures", results[0]);
-        Assert.Equal("á morgun", results[1]);
+        Assert.Equal("12 hours from now", results[0]);
+        Assert.Equal("demain", results[1]);
 
         string Humanize(
             CultureInfo currentCulture,


### PR DESCRIPTION
## Summary

When `CurrentCulture` and `CurrentUICulture` differ, Humanizer's number, date, collection, duration, ordinal, and clock outputs now follow `CurrentCulture` instead of selecting UI-language converters and mixing formatting conventions. `ResolveForUiCulture()` remains explicitly tied to `CurrentUICulture` for callers that need UI-resource behavior.

This builds on the approach proposed by @wyf027 in #1789; the original contributor is credited as a commit co-author.

Fixes #1562

## Validation

- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 57,530 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 57,530 passed
- `dotnet test --project tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 57,530 passed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp-path>` — package created without warnings or errors
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — clean

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] Copied-code attribution is not applicable; #1789's contributor is credited
- [x] Comments remain minimal
- [x] XML documentation is updated
- [x] Rebased on the latest `main`
- [x] The fixed issue is linked
- [x] Readme changes are not applicable to this bug fix
- [x] Required test, pack, and format commands pass
