### PR TITLE
test(locales): cover day-period boundaries

### DIFF
--- a/tests/Humanizer.Tests/Localisation/bn/BengaliClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/bn/BengaliClockNotationTests.cs
@@ -1,0 +1,21 @@
+namespace Humanizer.Tests.Localisation.bn;
+
+#if NET6_0_OR_GREATER
+[UseCulture("bn")]
+public class BengaliClockNotationTests
+{
+    [Theory]
+    [InlineData(0, 59, "রাত বারো উনষাট")]
+    [InlineData(1, 0, "রাত একটা")]
+    [InlineData(5, 59, "রাত পাঁচ উনষাট")]
+    [InlineData(6, 0, "সকাল ছয়")]
+    [InlineData(11, 59, "সকাল এগারো উনষাট")]
+    [InlineData(12, 0, "দুপুর বারো")]
+    [InlineData(20, 59, "দুপুর আট উনষাট")]
+    [InlineData(21, 0, "রাত নয়")]
+    public void ToClockNotation_UsesAuthoredDayPeriodsAtBoundaries(int hour, int minute, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(hour, minute).ToClockNotation());
+    }
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/fa/PersianClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/fa/PersianClockNotationTests.cs
@@ -1,0 +1,21 @@
+namespace Humanizer.Tests.Localisation.fa;
+
+#if NET6_0_OR_GREATER
+[UseCulture("fa")]
+public class PersianClockNotationTests
+{
+    [Theory]
+    [InlineData(0, 59, "دوازده و پنجاه و نه شب")]
+    [InlineData(1, 0, "یک بامداد")]
+    [InlineData(5, 59, "پنج و پنجاه و نه بامداد")]
+    [InlineData(6, 0, "شش صبح")]
+    [InlineData(11, 59, "یازده و پنجاه و نه صبح")]
+    [InlineData(12, 0, "دوازده بعدازظهر")]
+    [InlineData(20, 59, "هشت و پنجاه و نه بعدازظهر")]
+    [InlineData(21, 0, "نه شب")]
+    public void ToClockNotation_UsesAuthoredDayPeriodsAtBoundaries(int hour, int minute, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(hour, minute).ToClockNotation());
+    }
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/ta/TamilClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ta/TamilClockNotationTests.cs
@@ -1,0 +1,21 @@
+namespace Humanizer.Tests.Localisation.ta;
+
+#if NET6_0_OR_GREATER
+[UseCulture("ta")]
+public class TamilClockNotationTests
+{
+    [Theory]
+    [InlineData(0, 59, "இரவு பனிரெண்டு மணி ஐம்பத்து ஒன்பது நிமிடம்")]
+    [InlineData(1, 0, "அதிகாலை ஒரு மணி")]
+    [InlineData(5, 59, "அதிகாலை ஐந்து மணி ஐம்பத்து ஒன்பது நிமிடம்")]
+    [InlineData(6, 0, "காலை ஆறு மணி")]
+    [InlineData(11, 59, "காலை பதினொன்று மணி ஐம்பத்து ஒன்பது நிமிடம்")]
+    [InlineData(12, 0, "பிற்பகல் பனிரெண்டு மணி")]
+    [InlineData(20, 59, "பிற்பகல் எட்டு மணி ஐம்பத்து ஒன்பது நிமிடம்")]
+    [InlineData(21, 0, "இரவு ஒன்பது மணி")]
+    public void ToClockNotation_UsesAuthoredDayPeriodsAtBoundaries(int hour, int minute, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(hour, minute).ToClockNotation());
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Bengali, Tamil, and Persian clock profiles now have exact regression coverage at every authored day-period transition, including the minute immediately before each threshold. Independent locale review confirmed the existing profile data is correct and that Hebrew has no equivalent day-period contract, so production data remains unchanged.

Related: #1688, #1839

The expectations preserve locale work by Shuhel Ahmed, Borzoo Esmailloo, and Mohamed Mahir, and the YAML clock profiles authored by Claire Novotny.

## Validation

- Focused 24-case Microsoft Testing Platform matrix on .NET 8.0, 10.0, and 11.0
- Full Humanizer.Tests suite: 57,552 passed on each of .NET 8.0, 10.0, and 11.0
- Release package succeeded without warnings or errors
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`

## Checklist

- [x] Implementation is clean and follows existing coding standards
- [x] No Code Analysis warnings
- [x] Proper unit test coverage is included
- [x] No copied third-party code
- [x] Comments and XML documentation are not applicable to this test-only change
- [x] Rebased on the latest `main`
- [x] Related work is linked without closing merged PRs
- [x] README changes are not applicable
- [x] Supported WSL test targets and Release pack pass
