### PR TITLE
test(clock): cover locale day-period boundaries

### DIFF
--- a/tests/Humanizer.Tests/Localisation/ar/ArabicClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ar/ArabicClockNotationTests.cs
@@ -1,0 +1,30 @@
+namespace Humanizer.Tests.Localisation.ar;
+
+#if NET6_0_OR_GREATER
+[UseCulture("ar")]
+public class ArabicClockNotationTests
+{
+    [Theory]
+    [InlineData(0, "الثانية عشرة مساءً")]
+    [InlineData(20, "الثامنة بعد الظهر")]
+    [InlineData(21, "التاسعة مساءً")]
+    public void ToClockNotation_UsesDayPeriodBoundaries(int hour, string expected) =>
+        Assert.Equal(expected, new TimeOnly(hour, 0).ToClockNotation());
+
+    [Theory]
+    [InlineData(1, "الواحدة صباحًا")]
+    [InlineData(2, "الثانية صباحًا")]
+    [InlineData(3, "الثالثة صباحًا")]
+    [InlineData(4, "الرابعة صباحًا")]
+    [InlineData(5, "الخامسة صباحًا")]
+    [InlineData(6, "السادسة صباحًا")]
+    [InlineData(7, "السابعة صباحًا")]
+    [InlineData(8, "الثامنة صباحًا")]
+    [InlineData(9, "التاسعة صباحًا")]
+    [InlineData(10, "العاشرة صباحًا")]
+    [InlineData(11, "الحادية عشرة صباحًا")]
+    [InlineData(12, "الثانية عشرة بعد الظهر")]
+    public void ToClockNotation_UsesEveryMappedHour(int hour, string expected) =>
+        Assert.Equal(expected, new TimeOnly(hour, 0).ToClockNotation());
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/ko/KoreanClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ko/KoreanClockNotationTests.cs
@@ -1,0 +1,30 @@
+namespace Humanizer.Tests.Localisation.ko;
+
+#if NET6_0_OR_GREATER
+[UseCulture("ko")]
+public class KoreanClockNotationTests
+{
+    [Theory]
+    [InlineData(0, "밤 열두 시")]
+    [InlineData(20, "오후 여덟 시")]
+    [InlineData(21, "밤 아홉 시")]
+    public void ToClockNotation_UsesDayPeriodBoundaries(int hour, string expected) =>
+        Assert.Equal(expected, new TimeOnly(hour, 0).ToClockNotation());
+
+    [Theory]
+    [InlineData(1, "오전 한 시")]
+    [InlineData(2, "오전 두 시")]
+    [InlineData(3, "오전 세 시")]
+    [InlineData(4, "오전 네 시")]
+    [InlineData(5, "오전 다섯 시")]
+    [InlineData(6, "오전 여섯 시")]
+    [InlineData(7, "오전 일곱 시")]
+    [InlineData(8, "오전 여덟 시")]
+    [InlineData(9, "오전 아홉 시")]
+    [InlineData(10, "오전 열 시")]
+    [InlineData(11, "오전 열한 시")]
+    [InlineData(12, "오후 열두 시")]
+    public void ToClockNotation_UsesEveryMappedHour(int hour, string expected) =>
+        Assert.Equal(expected, new TimeOnly(hour, 0).ToClockNotation());
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/ms/MalayClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/ms/MalayClockNotationTests.cs
@@ -1,0 +1,19 @@
+namespace Humanizer.Tests.Localisation.ms;
+
+#if NET6_0_OR_GREATER
+[UseCulture("ms")]
+public class MalayClockNotationTests
+{
+    [Theory]
+    [InlineData(0, "pukul dua belas malam")]
+    [InlineData(1, "pukul satu pagi")]
+    [InlineData(5, "pukul lima pagi")]
+    [InlineData(6, "pukul enam pagi")]
+    [InlineData(11, "pukul sebelas pagi")]
+    [InlineData(12, "pukul dua belas petang")]
+    [InlineData(20, "pukul lapan petang")]
+    [InlineData(21, "pukul sembilan malam")]
+    public void ToClockNotation_UsesDayPeriodBoundaries(int hour, string expected) =>
+        Assert.Equal(expected, new TimeOnly(hour, 0).ToClockNotation());
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/th/ThaiClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/th/ThaiClockNotationTests.cs
@@ -1,0 +1,19 @@
+namespace Humanizer.Tests.Localisation.th;
+
+#if NET6_0_OR_GREATER
+[UseCulture("th")]
+public class ThaiClockNotationTests
+{
+    [Theory]
+    [InlineData(0, "กลางคืนสิบสอง")]
+    [InlineData(1, "ตีหนึ่ง")]
+    [InlineData(5, "ตีห้า")]
+    [InlineData(6, "ตอนเช้าหก")]
+    [InlineData(11, "ตอนเช้าสิบเอ็ด")]
+    [InlineData(12, "บ่ายสิบสอง")]
+    [InlineData(20, "บ่ายแปด")]
+    [InlineData(21, "กลางคืนเก้า")]
+    public void ToClockNotation_UsesDayPeriodBoundaries(int hour, string expected) =>
+        Assert.Equal(expected, new TimeOnly(hour, 0).ToClockNotation());
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/vi/VietnameseClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/vi/VietnameseClockNotationTests.cs
@@ -1,0 +1,19 @@
+namespace Humanizer.Tests.Localisation.vi;
+
+#if NET6_0_OR_GREATER
+[UseCulture("vi")]
+public class VietnameseClockNotationTests
+{
+    [Theory]
+    [InlineData(0, "mười hai giờ tối")]
+    [InlineData(1, "một giờ sáng")]
+    [InlineData(5, "năm giờ sáng")]
+    [InlineData(6, "sáu giờ sáng")]
+    [InlineData(11, "mười một giờ sáng")]
+    [InlineData(12, "mười hai giờ chiều")]
+    [InlineData(20, "tám giờ chiều")]
+    [InlineData(21, "chín giờ tối")]
+    public void ToClockNotation_UsesDayPeriodBoundaries(int hour, string expected) =>
+        Assert.Equal(expected, new TimeOnly(hour, 0).ToClockNotation());
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/zh-Hans/SimplifiedChineseClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/zh-Hans/SimplifiedChineseClockNotationTests.cs
@@ -1,0 +1,19 @@
+namespace Humanizer.Tests.Localisation.zh_Hans;
+
+#if NET6_0_OR_GREATER
+[UseCulture("zh-Hans")]
+public class SimplifiedChineseClockNotationTests
+{
+    [Theory]
+    [InlineData(0, "晚上十二")]
+    [InlineData(1, "凌晨一")]
+    [InlineData(5, "凌晨五")]
+    [InlineData(6, "上午六")]
+    [InlineData(11, "上午十一")]
+    [InlineData(12, "下午十二")]
+    [InlineData(20, "下午八")]
+    [InlineData(21, "晚上九")]
+    public void ToClockNotation_UsesDayPeriodBoundaries(int hour, string expected) =>
+        Assert.Equal(expected, new TimeOnly(hour, 0).ToClockNotation());
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/zh-Hant/TraditionalChineseClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/zh-Hant/TraditionalChineseClockNotationTests.cs
@@ -1,0 +1,19 @@
+namespace Humanizer.Tests.Localisation.zh_Hant;
+
+#if NET6_0_OR_GREATER
+[UseCulture("zh-Hant")]
+public class TraditionalChineseClockNotationTests
+{
+    [Theory]
+    [InlineData(0, "晚上十二")]
+    [InlineData(1, "凌晨一")]
+    [InlineData(5, "凌晨五")]
+    [InlineData(6, "上午六")]
+    [InlineData(11, "上午十一")]
+    [InlineData(12, "下午十二")]
+    [InlineData(20, "下午八")]
+    [InlineData(21, "晚上九")]
+    public void ToClockNotation_UsesDayPeriodBoundaries(int hour, string expected) =>
+        Assert.Equal(expected, new TimeOnly(hour, 0).ToClockNotation());
+}
+#endif


### PR DESCRIPTION
## Summary

Clock regressions can no longer silently shift day-period labels at midnight, morning, noon, or night for Arabic, Korean, Malay, Thai, Vietnamese, Simplified Chinese, and Traditional Chinese.

Arabic and Korean coverage also pins every authored 12-hour word-map entry. Simplified Chinese covers the generated template family shared by `zh-Hans` and `zh-CN`; `zh-Hant` covers the distinct Traditional Chinese family.

This is test-only because the audited generated behavior is already correct.

## Validation

- `net8.0`: 57,598 passed, 0 failed
- `net10.0`: 57,598 passed, 0 failed
- `net11.0`: 57,598 passed, 0 failed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release`: succeeded without warnings or errors
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`: 0 of 2,619 files changed

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No copied code is included
- [x] Comments are limited to existing conventions
- [x] XML documentation is not applicable to this test-only change
- [x] Rebased on the latest `main`
- [x] No issue is linked because this follows a locale coverage audit rather than an issue
- [x] Readme changes are not applicable to this test-only change
- [x] Supported tests and Release packaging pass
