### PR TITLE
docs: clarify sentence casing compatibility contract

### DIFF
--- a/docs/string-humanization.md
+++ b/docs/string-humanization.md
@@ -60,7 +60,7 @@ Control the output casing:
 
 Available casing options:
 - `LetterCasing.Title` - Capitalizes the first letter of each word
-- `LetterCasing.Sentence` - Uppercases only the first character, leaving the remainder unchanged
+- `LetterCasing.Sentence` - Uppercases only the first character of the humanized result, leaving the remainder of that result unchanged
 - `LetterCasing.AllCaps` - All uppercase
 - `LetterCasing.LowerCase` - All lowercase
 

--- a/docs/string-humanization.md
+++ b/docs/string-humanization.md
@@ -60,7 +60,7 @@ Control the output casing:
 
 Available casing options:
 - `LetterCasing.Title` - Capitalizes the first letter of each word
-- `LetterCasing.Sentence` - Capitalizes only the first letter
+- `LetterCasing.Sentence` - Uppercases only the first character, leaving the remainder unchanged
 - `LetterCasing.AllCaps` - All uppercase
 - `LetterCasing.LowerCase` - All lowercase
 

--- a/src/Humanizer/CasingExtensions.cs
+++ b/src/Humanizer/CasingExtensions.cs
@@ -15,7 +15,7 @@ public static class CasingExtensions
     /// - <see cref="LetterCasing.Title"/>: Each word is capitalized (e.g., "Some String")
     /// - <see cref="LetterCasing.LowerCase"/>: All letters are lowercase (e.g., "some string")
     /// - <see cref="LetterCasing.AllCaps"/>: All letters are uppercase (e.g., "SOME STRING")
-    /// - <see cref="LetterCasing.Sentence"/>: First letter capitalized, rest lowercase (e.g., "Some string")
+    /// - <see cref="LetterCasing.Sentence"/>: First character uppercased, remainder unchanged (e.g., "Some string")
     /// </returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when an invalid <see cref="LetterCasing"/> value is provided.</exception>
     /// <example>

--- a/src/Humanizer/Transformer/To.cs
+++ b/src/Humanizer/Transformer/To.cs
@@ -42,7 +42,7 @@ public static class To
     public static ICulturedStringTransformer UpperCase { get; } = new ToUpperCase();
 
     /// <summary>
-    /// Changes the string to sentence case
+    /// Uppercases the first character of the string, leaving all remaining characters unchanged
     /// </summary>
     /// <example>
     /// "lower case statement" -> "Lower case statement"

--- a/tests/Humanizer.Tests/StringHumanizeTests.cs
+++ b/tests/Humanizer.Tests/StringHumanizeTests.cs
@@ -83,6 +83,7 @@ public class StringHumanizeTests
     [InlineData("égoïste", "Égoïste")]
     [InlineData("Normal; Normal and PascalCase", "Normal; normal and pascal case")]
     [InlineData("I,and No One else", "I, and no one else")]
+    [InlineData("first. second", "First second")]
     public void CanHumanizeIntoSentenceCase(string input, string expectedResult) =>
         Assert.Equal(expectedResult, input.Humanize(LetterCasing.Sentence));
 

--- a/tests/Humanizer.Tests/TransformersTests.cs
+++ b/tests/Humanizer.Tests/TransformersTests.cs
@@ -44,11 +44,23 @@ public class TransformersTests
         Assert.Equal(expectedOutput, input.Transform(To.LowerCase));
 
     [Theory]
+    [InlineData("", "")]
     [InlineData("lower case statement", "Lower case statement")]
     [InlineData("Sentence casing", "Sentence casing")]
     [InlineData("honors UPPER case", "Honors UPPER case")]
+    [InlineData("hello. world? yes! no", "Hello. world? yes! no")]
+    [InlineData("first.\nsecond!\n\nthird?", "First.\nsecond!\n\nthird?")]
+    [InlineData("  hello", "  hello")]
+    [InlineData("123 hello", "123 hello")]
+    [InlineData("NASA and the FBI", "NASA and the FBI")]
     public void TransformToSentenceCase(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Transform(To.SentenceCase));
+
+    [Theory]
+    [InlineData("tr-TR", "istanbul. izmir", "İstanbul. izmir")]
+    [InlineData("fr-FR", "égoïste. déjà", "Égoïste. déjà")]
+    public void TransformToSentenceCaseUsesSpecifiedCulture(string cultureName, string input, string expectedOutput) =>
+        Assert.Equal(expectedOutput, input.Transform(new(cultureName), To.SentenceCase));
 
     [Theory]
     [InlineData("lower case statement", "LOWER CASE STATEMENT")]


### PR DESCRIPTION
## Summary

Sentence casing remains backward-compatible: `To.SentenceCase` and `LetterCasing.Sentence` uppercase only the first character and leave the remainder unchanged. The clarified contract avoids implying that later sentence boundaries or remaining casing are rewritten.

Characterization coverage now makes punctuation, paragraphs/newlines, leading whitespace, digits, acronyms, empty input, and culture-aware Unicode casing explicit. It also records that `Humanize(LetterCasing.Sentence)` performs identifier humanization before casing, so prose punctuation is not preserved by that pipeline.

Recognizing sentence boundaries by default would change established results such as `"hello. world"` from `"Hello. world"` to `"Hello. World"` and would require separate decisions for abbreviations, punctuation, digits, scripts, and paragraph segmentation.

Related: #1019

Thanks to @Praveen-Rai for the original report and sample, and to @04alband and @JaixTim for documenting the expected paragraph behavior.

## Validation

- Focused post-rebase net8 run: 90 transformer and string-humanization tests passed.
- Full net8, net10, and net11 suites: 57,525 tests passed per target before the unrelated base rebase.
- Release pack succeeded without warnings or errors.
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` passed.

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No copied external code
- [x] There are very few or no comments
- [x] XML documentation is updated
- [x] Rebased on the latest `main`
- [x] Linked the related issue without closing it as an implemented enhancement
- [x] README update is not required because runtime behavior is unchanged
- [x] Repository tests and Release pack pass
