### PR TITLE
docs: clarify precision strategy default

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -234,7 +234,7 @@ Configurator.DateTimeHumanizeStrategy = new PrecisionDateTimeHumanizeStrategy(pr
 Configurator.DateTimeOffsetHumanizeStrategy = new PrecisionDateTimeOffsetHumanizeStrategy(precision: .75); // configure when humanizing DateTimeOffset
 ```
 
-The default precision is set to .75, but you can pass your desired precision too. With precision set to 0.75:
+The precision-based strategies default to .75, but you can pass your desired precision instead. With precision set to .75:
 
 ```csharp
 44 seconds => 44 seconds ago/from now


### PR DESCRIPTION
## Summary

The README now makes clear that `.75` is the default for the precision-based `DateTime` strategies, not a default parameter for every `Humanize` API.

Fixes #890

## Validation

- `git diff --check`
- Documentation-only wording change; no links or runtime behavior changed

Here is a checklist you should tick through before submitting a pull request:

- [x] Implementation is clean
- [x] Documentation follows the existing coding standards
- [x] No Code Analysis warnings are introduced by this documentation-only change
- [x] Unit tests are not applicable because runtime behavior did not change
- [x] No code was copied from StackOverflow, a blog, or OSS
- [x] No code comments were added
- [x] XML documentation is not applicable because no public API changed
- [x] The PR is based on the latest `main`
- [x] The issue is linked with `Fixes #890`
- [x] The README contains the complete change
- [x] Build and test runs are not applicable to this documentation-only wording change
