### PR TITLE
fix: inflect compound rates by numerator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -418,6 +418,7 @@ Intelligently pluralize words, handling irregular and uncountable forms:
 "Man".Pluralize() => "Men"
 "string".Pluralize() => "strings"
 "person".Pluralize() => "people"
+"meter per second".Pluralize() => "meters per second"
 
 // Uncertain plurality? Use the optional parameter
 "Men".Pluralize(inputIsKnownToBeSingular: false) => "Men"
@@ -433,6 +434,7 @@ Convert plural words to singular form:
 "Men".Singularize() => "Man"
 "strings".Singularize() => "string"
 "people".Singularize() => "person"
+"meters per second".Singularize() => "meter per second"
 
 // Uncertain plurality? Use the optional parameter
 "Man".Singularize(inputIsKnownToBePlural: false) => "Man"

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -150,6 +150,7 @@ public static class Vocabularies
         //Fix 1132
         _default.AddUncountable("metadata");
 
+        _default.MarkRulesAsBuiltIn();
         return _default;
     }
 }

--- a/src/Humanizer/Inflections/Vocabulary.cs
+++ b/src/Humanizer/Inflections/Vocabulary.cs
@@ -266,10 +266,10 @@ public partial class Vocabulary
         length >= 2 &&
         word[length - 2] is 'a' or 'A' &&
         word[length - 1] is 's' or 'S' &&
-        (length == 2 || IsHorizontalWhitespace(word[length - 3]));
+        (length == 2 || !char.IsLetterOrDigit(word[length - 3]));
 
     static bool IsHorizontalWhitespace(char character) =>
-        character is ' ' or '\t';
+        character == '\t' || char.GetUnicodeCategory(character) == UnicodeCategory.SpaceSeparator;
 
     static string MatchUpperCase(string word, string replacement) =>
         word.Length > 1 && word.Any(char.IsUpper) && !word.Any(char.IsLower)

--- a/src/Humanizer/Inflections/Vocabulary.cs
+++ b/src/Humanizer/Inflections/Vocabulary.cs
@@ -73,6 +73,19 @@ public partial class Vocabulary
     public void AddSingular(string rule, string replacement) =>
         singulars.Add(new(rule, replacement));
 
+    internal void MarkRulesAsBuiltIn()
+    {
+        foreach (var rule in plurals)
+        {
+            rule.IsBuiltIn = true;
+        }
+
+        foreach (var rule in singulars)
+        {
+            rule.IsBuiltIn = true;
+        }
+    }
+
     /// <summary>
     /// Pluralizes the provided input considering irregular words
     /// </summary>
@@ -92,7 +105,13 @@ public partial class Vocabulary
             return s + "s";
         }
 
-        var result = ApplyRules(plurals, word, false);
+        var result = ApplyRules(plurals, word, false, out var wholeWordMatch);
+
+        var compoundHeadLength = CompoundHeadLength(word);
+        if (compoundHeadLength > 0 && !wholeWordMatch)
+        {
+            return Pluralize(word[..compoundHeadLength], inputIsKnownToBeSingular) + word[compoundHeadLength..];
+        }
 
         if (inputIsKnownToBeSingular)
         {
@@ -132,7 +151,13 @@ public partial class Vocabulary
             return s;
         }
 
-        var result = ApplyRules(singulars, word, skipSimpleWords);
+        var result = ApplyRules(singulars, word, skipSimpleWords, out var wholeWordMatch);
+
+        var compoundHeadLength = CompoundHeadLength(word);
+        if (compoundHeadLength > 0 && !wholeWordMatch)
+        {
+            return Singularize(word[..compoundHeadLength], inputIsKnownToBePlural, skipSimpleWords) + word[compoundHeadLength..];
+        }
 
         if (inputIsKnownToBePlural)
         {
@@ -159,6 +184,13 @@ public partial class Vocabulary
 
     string? ApplyRules(IList<Rule> rules, string? word, bool skipFirstRule)
     {
+        return ApplyRules(rules, word, skipFirstRule, out _);
+    }
+
+    string? ApplyRules(IList<Rule> rules, string? word, bool skipFirstRule, out bool wholeWordMatch)
+    {
+        wholeWordMatch = false;
+
         if (word == null)
         {
             return null;
@@ -171,6 +203,7 @@ public partial class Vocabulary
 
         if (IsUncountable(word))
         {
+            wholeWordMatch = true;
             return word;
         }
 
@@ -178,7 +211,7 @@ public partial class Vocabulary
         var end = skipFirstRule ? 1 : 0;
         for (var i = rules.Count - 1; i >= end; i--)
         {
-            if ((result = rules[i].Apply(word)) != null)
+            if ((result = rules[i].Apply(word, out wholeWordMatch)) != null)
             {
                 break;
             }
@@ -194,6 +227,49 @@ public partial class Vocabulary
 
     bool IsUncountable(string word) =>
         uncountables.Contains(word);
+
+    static int CompoundHeadLength(string word)
+    {
+        for (var i = 1; i < word.Length - 3; i++)
+        {
+            if (!IsHorizontalWhitespace(word[i - 1]) ||
+                word[i] is not ('p' or 'P') ||
+                word[i + 1] is not ('e' or 'E') ||
+                word[i + 2] is not ('r' or 'R') ||
+                !IsHorizontalWhitespace(word[i + 3]))
+            {
+                continue;
+            }
+
+            var headLength = i - 1;
+            while (headLength > 0 && IsHorizontalWhitespace(word[headLength - 1]))
+            {
+                headLength--;
+            }
+
+            var complementStart = i + 4;
+            while (complementStart < word.Length && IsHorizontalWhitespace(word[complementStart]))
+            {
+                complementStart++;
+            }
+
+            if (headLength > 0 && complementStart < word.Length && !EndsWithAs(word, headLength))
+            {
+                return headLength;
+            }
+        }
+
+        return 0;
+    }
+
+    static bool EndsWithAs(string word, int length) =>
+        length >= 2 &&
+        word[length - 2] is 'a' or 'A' &&
+        word[length - 1] is 's' or 'S' &&
+        (length == 2 || IsHorizontalWhitespace(word[length - 3]));
+
+    static bool IsHorizontalWhitespace(char character) =>
+        character is ' ' or '\t';
 
     static string MatchUpperCase(string word, string replacement) =>
         word.Length > 1 && word.Any(char.IsUpper) && !word.Any(char.IsLower)
@@ -215,13 +291,18 @@ public partial class Vocabulary
     {
         readonly Regex regex = new(pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        public string? Apply(string word)
+        public bool IsBuiltIn { get; set; }
+
+        public string? Apply(string word, out bool wholeWordMatch)
         {
-            if (!regex.IsMatch(word))
+            var match = regex.Match(word);
+            if (!match.Success)
             {
+                wholeWordMatch = false;
                 return null;
             }
 
+            wholeWordMatch = !IsBuiltIn && match.Index == 0 && match.Length == word.Length;
             return regex.Replace(word, replacement);
         }
     }

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -79,6 +79,7 @@ public static partial class InflectorExtensions
     /// </returns>
     /// <remarks>
     /// Uses the default vocabulary which includes English pluralization rules and common irregular forms.
+    /// In compound rates separated by the word "per", the numerator is pluralized and the denominator is preserved.
     /// </remarks>
     /// <example>
     /// <code>
@@ -86,6 +87,7 @@ public static partial class InflectorExtensions
     /// "cat".Pluralize() => "cats"
     /// "box".Pluralize() => "boxes"
     /// "man".Pluralize() => "men"
+    /// "meter per second".Pluralize() => "meters per second"
     /// "PERSON".Pluralize() => "PEOPLE"
     /// "cats".Pluralize(inputIsKnownToBeSingular: false) => "cats" (avoids double pluralization)
     /// </code>
@@ -113,6 +115,7 @@ public static partial class InflectorExtensions
     /// </returns>
     /// <remarks>
     /// Uses the default vocabulary which includes English singularization rules and common irregular forms.
+    /// In compound rates separated by the word "per", the numerator is singularized and the denominator is preserved.
     /// </remarks>
     /// <example>
     /// <code>
@@ -120,6 +123,7 @@ public static partial class InflectorExtensions
     /// "cats".Singularize() => "cat"
     /// "boxes".Singularize() => "box"
     /// "men".Singularize() => "man"
+    /// "meters per second".Singularize() => "meter per second"
     /// "PEOPLE".Singularize() => "PERSON"
     /// "person".Singularize(inputIsKnownToBePlural: false) => "person" (avoids incorrect singularization)
     /// </code>

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -46,6 +46,57 @@ public class InflectorTests
         Assert.Equal(singular, plural.Singularize(inputIsKnownToBePlural: false));
     }
 
+    [Theory]
+    [InlineData("meter per second", "meters per second")]
+    [InlineData("nautical mile per hour", "nautical miles per hour")]
+    [InlineData("foot per second", "feet per second")]
+    [InlineData("Foot per Second", "Feet per Second")]
+    [InlineData("FOOT PER SECOND", "FEET PER SECOND")]
+    [InlineData("fish per hour", "fish per hour")]
+    [InlineData("(meter per second).", "(meters per second).")]
+    [InlineData("joule  PER\tmole per kelvin", "joules  PER\tmole per kelvin")]
+    [InlineData("request per customer", "requests per customer")]
+    [InlineData("meter per curves", "meters per curves")]
+    public void InflectsCompoundRates(string singular, string plural)
+    {
+        Assert.Equal(plural, singular.Pluralize());
+        Assert.Equal(singular, plural.Singularize());
+        Assert.Equal(plural, singular.Pluralize(inputIsKnownToBeSingular: false));
+        Assert.Equal(plural, plural.Pluralize(inputIsKnownToBeSingular: false));
+        Assert.Equal(singular, singular.Singularize(inputIsKnownToBePlural: false));
+        Assert.Equal(singular, plural.Singularize(inputIsKnownToBePlural: false));
+    }
+
+    [Theory]
+    [InlineData("as per request", "as per requests")]
+    [InlineData("meter/per/second", "meter/per/seconds")]
+    public void DoesNotTreatUnstructuredPhrasesAsCompoundRates(string singular, string plural)
+    {
+        Assert.Equal(plural, singular.Pluralize());
+        Assert.Equal(singular, plural.Singularize());
+    }
+
+    [Fact]
+    public void ExplicitPhraseRulesOverrideCompoundRateInflection()
+    {
+        var vocabulary = new Vocabulary();
+        vocabulary.AddPlural("meter per second", "meter rate units");
+        vocabulary.AddSingular("meters per second", "meters rate unit");
+
+        Assert.Equal("meter rate units", vocabulary.Pluralize("meter per second"));
+        Assert.Equal("meters rate unit", vocabulary.Singularize("meters per second"));
+    }
+
+    [Fact]
+    public void ExplicitUncountableCompoundRateIsPreserved()
+    {
+        var vocabulary = new Vocabulary();
+        vocabulary.AddUncountable("meter per second");
+
+        Assert.Equal("meter per second", vocabulary.Pluralize("meter per second"));
+        Assert.Equal("meter per second", vocabulary.Singularize("meter per second"));
+    }
+
     [Fact, UseCulture("tr-TR")]
     public void AllCapsInflectionsUseInvariantCasing() =>
         Assert.Equal("CACTI", "CACTUS".Pluralize());

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -55,6 +55,8 @@ public class InflectorTests
     [InlineData("fish per hour", "fish per hour")]
     [InlineData("(meter per second).", "(meters per second).")]
     [InlineData("joule  PER\tmole per kelvin", "joules  PER\tmole per kelvin")]
+    [InlineData("meter\u00A0per\u00A0second", "meters\u00A0per\u00A0second")]
+    [InlineData("foot\u2009per\u2009second", "feet\u2009per\u2009second")]
     [InlineData("request per customer", "requests per customer")]
     [InlineData("meter per curves", "meters per curves")]
     public void InflectsCompoundRates(string singular, string plural)
@@ -70,11 +72,16 @@ public class InflectorTests
     [Theory]
     [InlineData("as per request", "as per requests")]
     [InlineData("meter/per/second", "meter/per/seconds")]
+    [InlineData("meter\nper\nsecond", "meter\nper\nseconds")]
     public void DoesNotTreatUnstructuredPhrasesAsCompoundRates(string singular, string plural)
     {
         Assert.Equal(plural, singular.Pluralize());
         Assert.Equal(singular, plural.Singularize());
     }
+
+    [Fact]
+    public void SingularizingParenthesizedAsPerPhraseIsUnchanged() =>
+        Assert.Equal("(as per requests)", "(as per requests)".Singularize());
 
     [Fact]
     public void ExplicitPhraseRulesOverrideCompoundRateInflection()

--- a/tests/Humanizer.Tests/ToQuantityTests.cs
+++ b/tests/Humanizer.Tests/ToQuantityTests.cs
@@ -30,6 +30,8 @@ public class ToQuantityTests
     [InlineData("slices", -1, "-1 slice")]
     [InlineData("slices", 2, "2 slices")]
     [InlineData("slices", -2, "-2 slices")]
+    [InlineData("meter per second", 2, "2 meters per second")]
+    [InlineData("meters per second", 1, "1 meter per second")]
     public void ToQuantity(string word, int quantity, string expected) =>
         Assert.Equal(expected, word.ToQuantity(quantity));
 
@@ -125,6 +127,7 @@ public class ToQuantityTests
     [InlineData("hour", 1, "1 hour")]
     [InlineData("hour", 0.5, "0.5 hours")]
     [InlineData("hour", 22.4, "22.4 hours")]
+    [InlineData("meter per second", 2.5, "2.5 meters per second")]
     public void ToDoubleQuantityNumeric(string word, double quantity, string expected) =>
         // ReSharper disable once RedundantArgumentDefaultValue
         Assert.Equal(expected, word.ToQuantity(quantity));


### PR DESCRIPTION
## Summary

Compound rates now inflect their numerator, so `meter per second` becomes `meters per second` instead of `meter per seconds`. The denominator, separator whitespace, casing, punctuation, irregular forms, and already-plural inputs are preserved; explicit whole-phrase vocabulary rules and uncountables still take precedence.

Thanks @generateui for the clear report and examples.

Fixes #1020.

## Validation

- [x] .NET 8.0: 57,677 tests passed
- [x] .NET 10.0: 57,677 tests passed
- [x] .NET 11.0: 57,677 tests passed
- [x] Release package built without warnings or errors
- [x] `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`

## Checklist

- [x] Implementation is clean and follows existing coding standards
- [x] No code-analysis warnings
- [x] Focused regression coverage includes regular, irregular, multi-word, casing, punctuation, whitespace, and customization cases
- [x] No copied third-party code
- [x] XML documentation and README examples are updated
- [x] Branch is rebased on current `main`
- [x] Issue-closing reference is included
