### PR TITLE
feat: add lower IEC ByteSize units

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -776,6 +776,10 @@ fileSize.Terabytes => 9.31322575e-9
 fileSize.Petabytes => 1.024e-11
 fileSize.Exabytes  => 1.024e-14
 fileSize.Pebibytes => 9.09494702e-12
+fileSize.Kibibytes => 10
+fileSize.Mebibytes => 0.009765625
+fileSize.Gibibytes => 9.53674316e-6
+fileSize.Tebibytes => 9.31322575e-9
 ```
 
 There are a few extension methods that allow you to turn a number into a ByteSize instance:
@@ -821,7 +825,7 @@ If you want a string representation you can call `ToString` or `Humanize` interc
 ```
 
 You can also optionally provide a format for the expected string representation.
-The formatter can contain the symbol of the value to display: `b`, `B`, `KB`, `MB`, `GB`, `TB`, `PB`, `EB`, `PiB`.
+The formatter can contain the symbol of the value to display: `b`, `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `EB`, `PiB`.
 The formatter uses the built in [`double.ToString` method](https://docs.microsoft.com/dotnet/api/system.double.tostring) with `#.##` as the default format which rounds the number to two decimal places:
 
 ```csharp
@@ -849,8 +853,11 @@ b.Humanize("#.## B");     // 10757.12 B
 (`EB`, 10<sup>18</sup> bytes), plus IEC pebibytes (`PiB`, 2<sup>50</sup>
 bytes). Exbibytes are not supported because one `EiB` is 2<sup>63</sup> bits,
 outside the existing `long`-valued `Bits` range. The older `KB` through `TB`
-APIs retain their historical binary scaling for compatibility; use an explicit
-`PiB` format when IEC provenance matters.
+APIs retain their historical binary scaling for compatibility. The explicit
+`FromKibibytes`, `FromMebibytes`, `FromGibibytes`, and `FromTebibytes`
+factories use those same binary factors with standards-compliant IEC names.
+Use an explicit `KiB`, `MiB`, `GiB`, `TiB`, or `PiB` format when IEC
+provenance matters; default formatting continues to use the historical labels.
 
 The existing `double` byte storage does not retain one-bit increments at these
 magnitudes. The new large-unit factories and `AddPetabytes`, `AddExabytes`, and

--- a/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/LocalePhraseTableCatalogInput.cs
+++ b/src/Humanizer.SourceGenerators/Generators/ProfileCatalogs/LocalePhraseTableCatalogInput.cs
@@ -32,7 +32,11 @@ public sealed partial class HumanizerSourceGenerator
             "terabyte",
             "petabyte",
             "exabyte",
-            "pebibyte"
+            "pebibyte",
+            "kibibyte",
+            "mebibyte",
+            "gibibyte",
+            "tebibyte"
         ];
 
         readonly ImmutableArray<LocalePhraseCatalog> catalogs = catalogs;

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -346,10 +346,10 @@ public struct ByteSize(double byteSize) :
             provider = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(overrideCulture);
         }
 
-        bool has(string s) => culture.CompareInfo.IndexOf(format, s, CompareOptions.IgnoreCase) != -1;
+        bool has(string s) => format.Contains(s, StringComparison.OrdinalIgnoreCase);
         string replace(string source, string oldValue, string newValue)
         {
-            var index = culture.CompareInfo.IndexOf(source, oldValue, CompareOptions.IgnoreCase);
+            var index = CultureInfo.InvariantCulture.CompareInfo.IndexOf(source, oldValue, CompareOptions.OrdinalIgnoreCase);
             return source.Remove(index, oldValue.Length).Insert(index, newValue);
         }
 

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -40,12 +40,24 @@ public struct ByteSize(double byteSize) :
 
     public const long BitsInByte = 8;
     public const long BytesInKilobyte = 1024;
+    /// <summary>
+    /// The number of bytes in a kibibyte, equivalent to the established kilobyte factor.
+    /// </summary>
     public const long BytesInKibibyte = BytesInKilobyte;
     public const long BytesInMegabyte = 1048576;
+    /// <summary>
+    /// The number of bytes in a mebibyte, equivalent to the established megabyte factor.
+    /// </summary>
     public const long BytesInMebibyte = BytesInMegabyte;
     public const long BytesInGigabyte = 1073741824;
+    /// <summary>
+    /// The number of bytes in a gibibyte, equivalent to the established gigabyte factor.
+    /// </summary>
     public const long BytesInGibibyte = BytesInGigabyte;
     public const long BytesInTerabyte = 1099511627776;
+    /// <summary>
+    /// The number of bytes in a tebibyte, equivalent to the established terabyte factor.
+    /// </summary>
     public const long BytesInTebibyte = BytesInTerabyte;
     public const long BytesInPetabyte = 1000000000000000;
     public const long BytesInExabyte = 1000000000000000000;
@@ -57,19 +69,43 @@ public struct ByteSize(double byteSize) :
     public const string Byte = "byte";
     public const string KilobyteSymbol = "KB";
     public const string Kilobyte = "kilobyte";
+    /// <summary>
+    /// The symbol for a kibibyte.
+    /// </summary>
     public const string KibibyteSymbol = "KiB";
+    /// <summary>
+    /// The name of a kibibyte.
+    /// </summary>
     public const string Kibibyte = "kibibyte";
     public const string MegabyteSymbol = "MB";
     public const string Megabyte = "megabyte";
+    /// <summary>
+    /// The symbol for a mebibyte.
+    /// </summary>
     public const string MebibyteSymbol = "MiB";
+    /// <summary>
+    /// The name of a mebibyte.
+    /// </summary>
     public const string Mebibyte = "mebibyte";
     public const string GigabyteSymbol = "GB";
     public const string Gigabyte = "gigabyte";
+    /// <summary>
+    /// The symbol for a gibibyte.
+    /// </summary>
     public const string GibibyteSymbol = "GiB";
+    /// <summary>
+    /// The name of a gibibyte.
+    /// </summary>
     public const string Gibibyte = "gibibyte";
     public const string TerabyteSymbol = "TB";
     public const string Terabyte = "terabyte";
+    /// <summary>
+    /// The symbol for a tebibyte.
+    /// </summary>
     public const string TebibyteSymbol = "TiB";
+    /// <summary>
+    /// The name of a tebibyte.
+    /// </summary>
     public const string Tebibyte = "tebibyte";
     public const string PetabyteSymbol = "PB";
     public const string Petabyte = "petabyte";
@@ -81,12 +117,24 @@ public struct ByteSize(double byteSize) :
     public long Bits { get; } = (long)Math.Ceiling(byteSize * BitsInByte);
     public double Bytes { get; } = byteSize;
     public double Kilobytes { get; } = byteSize / BytesInKilobyte;
+    /// <summary>
+    /// Gets the size in kibibytes.
+    /// </summary>
     public readonly double Kibibytes => Bytes / BytesInKibibyte;
     public double Megabytes { get; } = byteSize / BytesInMegabyte;
+    /// <summary>
+    /// Gets the size in mebibytes.
+    /// </summary>
     public readonly double Mebibytes => Bytes / BytesInMebibyte;
     public double Gigabytes { get; } = byteSize / BytesInGigabyte;
+    /// <summary>
+    /// Gets the size in gibibytes.
+    /// </summary>
     public readonly double Gibibytes => Bytes / BytesInGibibyte;
     public double Terabytes { get; } = byteSize / BytesInTerabyte;
+    /// <summary>
+    /// Gets the size in tebibytes.
+    /// </summary>
     public readonly double Tebibytes => Bytes / BytesInTebibyte;
     public readonly double Petabytes => Bytes / BytesInPetabyte;
     public readonly double Exabytes => Bytes / BytesInExabyte;
@@ -237,26 +285,66 @@ public struct ByteSize(double byteSize) :
     public static ByteSize FromKilobytes(double value) =>
         new(value * BytesInKilobyte);
 
-    public static ByteSize FromKibibytes(double value) =>
-        new(value * BytesInKibibyte);
+    /// <summary>
+    /// Creates a byte size from a number of kibibytes.
+    /// </summary>
+    public static ByteSize FromKibibytes(double value)
+    {
+        if (!IsSupportedUnitValue(value, BytesInKibibyte))
+        {
+            throw new ArgumentOutOfRangeException(nameof(value), "The value must be finite and fit the range supported by ByteSize.Bits.");
+        }
+
+        return new(value * BytesInKibibyte);
+    }
 
     public static ByteSize FromMegabytes(double value) =>
         new(value * BytesInMegabyte);
 
-    public static ByteSize FromMebibytes(double value) =>
-        new(value * BytesInMebibyte);
+    /// <summary>
+    /// Creates a byte size from a number of mebibytes.
+    /// </summary>
+    public static ByteSize FromMebibytes(double value)
+    {
+        if (!IsSupportedUnitValue(value, BytesInMebibyte))
+        {
+            throw new ArgumentOutOfRangeException(nameof(value), "The value must be finite and fit the range supported by ByteSize.Bits.");
+        }
+
+        return new(value * BytesInMebibyte);
+    }
 
     public static ByteSize FromGigabytes(double value) =>
         new(value * BytesInGigabyte);
 
-    public static ByteSize FromGibibytes(double value) =>
-        new(value * BytesInGibibyte);
+    /// <summary>
+    /// Creates a byte size from a number of gibibytes.
+    /// </summary>
+    public static ByteSize FromGibibytes(double value)
+    {
+        if (!IsSupportedUnitValue(value, BytesInGibibyte))
+        {
+            throw new ArgumentOutOfRangeException(nameof(value), "The value must be finite and fit the range supported by ByteSize.Bits.");
+        }
+
+        return new(value * BytesInGibibyte);
+    }
 
     public static ByteSize FromTerabytes(double value) =>
         new(value * BytesInTerabyte);
 
-    public static ByteSize FromTebibytes(double value) =>
-        new(value * BytesInTebibyte);
+    /// <summary>
+    /// Creates a byte size from a number of tebibytes.
+    /// </summary>
+    public static ByteSize FromTebibytes(double value)
+    {
+        if (!IsSupportedUnitValue(value, BytesInTebibyte))
+        {
+            throw new ArgumentOutOfRangeException(nameof(value), "The value must be finite and fit the range supported by ByteSize.Bits.");
+        }
+
+        return new(value * BytesInTebibyte);
+    }
 
     public static ByteSize FromPetabytes(double value)
     {
@@ -689,6 +777,11 @@ public struct ByteSize(double byteSize) :
                 break;
 
             case "KIB":
+                if (!IsSupportedUnitValue(number, BytesInKibibyte))
+                {
+                    return false;
+                }
+
                 result = FromKibibytes(number);
                 break;
 
@@ -697,6 +790,11 @@ public struct ByteSize(double byteSize) :
                 break;
 
             case "MIB":
+                if (!IsSupportedUnitValue(number, BytesInMebibyte))
+                {
+                    return false;
+                }
+
                 result = FromMebibytes(number);
                 break;
 
@@ -705,6 +803,11 @@ public struct ByteSize(double byteSize) :
                 break;
 
             case "GIB":
+                if (!IsSupportedUnitValue(number, BytesInGibibyte))
+                {
+                    return false;
+                }
+
                 result = FromGibibytes(number);
                 break;
 
@@ -713,6 +816,11 @@ public struct ByteSize(double byteSize) :
                 break;
 
             case "TIB":
+                if (!IsSupportedUnitValue(number, BytesInTebibyte))
+                {
+                    return false;
+                }
+
                 result = FromTebibytes(number);
                 break;
 

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -40,9 +40,13 @@ public struct ByteSize(double byteSize) :
 
     public const long BitsInByte = 8;
     public const long BytesInKilobyte = 1024;
+    public const long BytesInKibibyte = BytesInKilobyte;
     public const long BytesInMegabyte = 1048576;
+    public const long BytesInMebibyte = BytesInMegabyte;
     public const long BytesInGigabyte = 1073741824;
+    public const long BytesInGibibyte = BytesInGigabyte;
     public const long BytesInTerabyte = 1099511627776;
+    public const long BytesInTebibyte = BytesInTerabyte;
     public const long BytesInPetabyte = 1000000000000000;
     public const long BytesInExabyte = 1000000000000000000;
     public const long BytesInPebibyte = 1125899906842624;
@@ -53,12 +57,20 @@ public struct ByteSize(double byteSize) :
     public const string Byte = "byte";
     public const string KilobyteSymbol = "KB";
     public const string Kilobyte = "kilobyte";
+    public const string KibibyteSymbol = "KiB";
+    public const string Kibibyte = "kibibyte";
     public const string MegabyteSymbol = "MB";
     public const string Megabyte = "megabyte";
+    public const string MebibyteSymbol = "MiB";
+    public const string Mebibyte = "mebibyte";
     public const string GigabyteSymbol = "GB";
     public const string Gigabyte = "gigabyte";
+    public const string GibibyteSymbol = "GiB";
+    public const string Gibibyte = "gibibyte";
     public const string TerabyteSymbol = "TB";
     public const string Terabyte = "terabyte";
+    public const string TebibyteSymbol = "TiB";
+    public const string Tebibyte = "tebibyte";
     public const string PetabyteSymbol = "PB";
     public const string Petabyte = "petabyte";
     public const string ExabyteSymbol = "EB";
@@ -69,9 +81,13 @@ public struct ByteSize(double byteSize) :
     public long Bits { get; } = (long)Math.Ceiling(byteSize * BitsInByte);
     public double Bytes { get; } = byteSize;
     public double Kilobytes { get; } = byteSize / BytesInKilobyte;
+    public readonly double Kibibytes => Bytes / BytesInKibibyte;
     public double Megabytes { get; } = byteSize / BytesInMegabyte;
+    public readonly double Mebibytes => Bytes / BytesInMebibyte;
     public double Gigabytes { get; } = byteSize / BytesInGigabyte;
+    public readonly double Gibibytes => Bytes / BytesInGibibyte;
     public double Terabytes { get; } = byteSize / BytesInTerabyte;
+    public readonly double Tebibytes => Bytes / BytesInTebibyte;
     public readonly double Petabytes => Bytes / BytesInPetabyte;
     public readonly double Exabytes => Bytes / BytesInExabyte;
     public readonly double Pebibytes => Bytes / BytesInPebibyte;
@@ -221,14 +237,26 @@ public struct ByteSize(double byteSize) :
     public static ByteSize FromKilobytes(double value) =>
         new(value * BytesInKilobyte);
 
+    public static ByteSize FromKibibytes(double value) =>
+        new(value * BytesInKibibyte);
+
     public static ByteSize FromMegabytes(double value) =>
         new(value * BytesInMegabyte);
+
+    public static ByteSize FromMebibytes(double value) =>
+        new(value * BytesInMebibyte);
 
     public static ByteSize FromGigabytes(double value) =>
         new(value * BytesInGigabyte);
 
+    public static ByteSize FromGibibytes(double value) =>
+        new(value * BytesInGibibyte);
+
     public static ByteSize FromTerabytes(double value) =>
         new(value * BytesInTerabyte);
+
+    public static ByteSize FromTebibytes(double value) =>
+        new(value * BytesInTebibyte);
 
     public static ByteSize FromPetabytes(double value)
     {
@@ -333,6 +361,30 @@ public struct ByteSize(double byteSize) :
         {
             format = replace(format, PebibyteSymbol, cultureFormatter.DataUnitHumanize(DataUnit.Pebibyte, Pebibytes, toSymbol));
             return output(Pebibytes);
+        }
+
+        if (has(TebibyteSymbol))
+        {
+            format = replace(format, TebibyteSymbol, cultureFormatter.DataUnitHumanize(DataUnit.Tebibyte, Tebibytes, toSymbol));
+            return output(Tebibytes);
+        }
+
+        if (has(GibibyteSymbol))
+        {
+            format = replace(format, GibibyteSymbol, cultureFormatter.DataUnitHumanize(DataUnit.Gibibyte, Gibibytes, toSymbol));
+            return output(Gibibytes);
+        }
+
+        if (has(MebibyteSymbol))
+        {
+            format = replace(format, MebibyteSymbol, cultureFormatter.DataUnitHumanize(DataUnit.Mebibyte, Mebibytes, toSymbol));
+            return output(Mebibytes);
+        }
+
+        if (has(KibibyteSymbol))
+        {
+            format = replace(format, KibibyteSymbol, cultureFormatter.DataUnitHumanize(DataUnit.Kibibyte, Kibibytes, toSymbol));
+            return output(Kibibytes);
         }
 
         if (has(ExabyteSymbol))
@@ -636,16 +688,32 @@ public struct ByteSize(double byteSize) :
                 result = FromKilobytes(number);
                 break;
 
+            case "KIB":
+                result = FromKibibytes(number);
+                break;
+
             case MegabyteSymbol:
                 result = FromMegabytes(number);
+                break;
+
+            case "MIB":
+                result = FromMebibytes(number);
                 break;
 
             case GigabyteSymbol:
                 result = FromGigabytes(number);
                 break;
 
+            case "GIB":
+                result = FromGibibytes(number);
+                break;
+
             case TerabyteSymbol:
                 result = FromTerabytes(number);
+                break;
+
+            case "TIB":
+                result = FromTebibytes(number);
                 break;
 
             case PetabyteSymbol:

--- a/src/Humanizer/Locales/en.yml
+++ b/src/Humanizer/Locales/en.yml
@@ -211,6 +211,18 @@ surfaces:
       pebibyte:
         forms: 'pebibyte'
         symbol: 'PiB'
+      kibibyte:
+        forms: 'kibibyte'
+        symbol: 'KiB'
+      mebibyte:
+        forms: 'mebibyte'
+        symbol: 'MiB'
+      gibibyte:
+        forms: 'gibibyte'
+        symbol: 'GiB'
+      tebibyte:
+        forms: 'tebibyte'
+        symbol: 'TiB'
     timeUnits:
       millisecond:
         symbol: 'ms'

--- a/src/Humanizer/Locales/fr.yml
+++ b/src/Humanizer/Locales/fr.yml
@@ -257,6 +257,22 @@ surfaces:
         forms:
           default: 'pébioctet'
         symbol: 'Pio'
+      kibibyte:
+        forms:
+          default: 'kibioctet'
+        symbol: 'Kio'
+      mebibyte:
+        forms:
+          default: 'mébioctet'
+        symbol: 'Mio'
+      gibibyte:
+        forms:
+          default: 'gibioctet'
+        symbol: 'Gio'
+      tebibyte:
+        forms:
+          default: 'tébioctet'
+        symbol: 'Tio'
     timeUnits:
       millisecond:
         symbol: 'ms'

--- a/src/Humanizer/Localisation/DataUnit.cs
+++ b/src/Humanizer/Localisation/DataUnit.cs
@@ -48,5 +48,25 @@ public enum DataUnit
     /// <summary>
     /// A pebibyte.
     /// </summary>
-    Pebibyte
+    Pebibyte,
+
+    /// <summary>
+    /// A kibibyte.
+    /// </summary>
+    Kibibyte,
+
+    /// <summary>
+    /// A mebibyte.
+    /// </summary>
+    Mebibyte,
+
+    /// <summary>
+    /// A gibibyte.
+    /// </summary>
+    Gibibyte,
+
+    /// <summary>
+    /// A tebibyte.
+    /// </summary>
+    Tebibyte
 }

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -77,7 +77,8 @@ public class DefaultFormatter : IFormatter
             return generated;
         }
 
-        if (dataUnit is DataUnit.Petabyte or DataUnit.Exabyte or DataUnit.Pebibyte &&
+        if (dataUnit is DataUnit.Petabyte or DataUnit.Exabyte or DataUnit.Pebibyte or
+            DataUnit.Kibibyte or DataUnit.Mebibyte or DataUnit.Gibibyte or DataUnit.Tebibyte &&
             !Culture.Name.Equals("en", StringComparison.OrdinalIgnoreCase))
         {
             return EnglishFallback.DataUnitHumanize(dataUnit, count, toSymbol);

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -26,24 +26,36 @@ namespace Humanizer
         public const string Byte = "byte";
         public const string ByteSymbol = "B";
         public const long BytesInExabyte = 1000000000000000000;
+        public const long BytesInGibibyte = 1073741824;
         public const long BytesInGigabyte = 1073741824;
+        public const long BytesInKibibyte = 1024;
         public const long BytesInKilobyte = 1024;
+        public const long BytesInMebibyte = 1048576;
         public const long BytesInMegabyte = 1048576;
         public const long BytesInPebibyte = 1125899906842624;
         public const long BytesInPetabyte = 1000000000000000;
+        public const long BytesInTebibyte = 1099511627776;
         public const long BytesInTerabyte = 1099511627776;
         public const string Exabyte = "exabyte";
         public const string ExabyteSymbol = "EB";
+        public const string Gibibyte = "gibibyte";
+        public const string GibibyteSymbol = "GiB";
         public const string Gigabyte = "gigabyte";
         public const string GigabyteSymbol = "GB";
+        public const string Kibibyte = "kibibyte";
+        public const string KibibyteSymbol = "KiB";
         public const string Kilobyte = "kilobyte";
         public const string KilobyteSymbol = "KB";
+        public const string Mebibyte = "mebibyte";
+        public const string MebibyteSymbol = "MiB";
         public const string Megabyte = "megabyte";
         public const string MegabyteSymbol = "MB";
         public const string Pebibyte = "pebibyte";
         public const string PebibyteSymbol = "PiB";
         public const string Petabyte = "petabyte";
         public const string PetabyteSymbol = "PB";
+        public const string Tebibyte = "tebibyte";
+        public const string TebibyteSymbol = "TiB";
         public const string Terabyte = "terabyte";
         public const string TerabyteSymbol = "TB";
         public static readonly Humanizer.ByteSize MaxValue;
@@ -52,14 +64,18 @@ namespace Humanizer
         public long Bits { get; }
         public double Bytes { get; }
         public double Exabytes { get; }
+        public double Gibibytes { get; }
         public double Gigabytes { get; }
+        public double Kibibytes { get; }
         public double Kilobytes { get; }
         public string LargestWholeNumberFullWord { get; }
         public string LargestWholeNumberSymbol { get; }
         public double LargestWholeNumberValue { get; }
+        public double Mebibytes { get; }
         public double Megabytes { get; }
         public double Pebibytes { get; }
         public double Petabytes { get; }
+        public double Tebibytes { get; }
         public double Terabytes { get; }
         public Humanizer.ByteSize Add(Humanizer.ByteSize bs) { }
         public Humanizer.ByteSize AddBits(long value) { }
@@ -87,11 +103,15 @@ namespace Humanizer
         public static Humanizer.ByteSize FromBits(long value) { }
         public static Humanizer.ByteSize FromBytes(double value) { }
         public static Humanizer.ByteSize FromExabytes(double value) { }
+        public static Humanizer.ByteSize FromGibibytes(double value) { }
         public static Humanizer.ByteSize FromGigabytes(double value) { }
+        public static Humanizer.ByteSize FromKibibytes(double value) { }
         public static Humanizer.ByteSize FromKilobytes(double value) { }
+        public static Humanizer.ByteSize FromMebibytes(double value) { }
         public static Humanizer.ByteSize FromMegabytes(double value) { }
         public static Humanizer.ByteSize FromPebibytes(double value) { }
         public static Humanizer.ByteSize FromPetabytes(double value) { }
+        public static Humanizer.ByteSize FromTebibytes(double value) { }
         public static Humanizer.ByteSize FromTerabytes(double value) { }
         public static Humanizer.ByteSize Parse(string s) { }
         public static Humanizer.ByteSize Parse(string s, System.IFormatProvider? formatProvider) { }
@@ -233,6 +253,10 @@ namespace Humanizer
         Petabyte = 6,
         Exabyte = 7,
         Pebibyte = 8,
+        Kibibyte = 9,
+        Mebibyte = 10,
+        Gibibyte = 11,
+        Tebibyte = 12,
     }
     public static class DateHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -26,24 +26,36 @@ namespace Humanizer
         public const string Byte = "byte";
         public const string ByteSymbol = "B";
         public const long BytesInExabyte = 1000000000000000000;
+        public const long BytesInGibibyte = 1073741824;
         public const long BytesInGigabyte = 1073741824;
+        public const long BytesInKibibyte = 1024;
         public const long BytesInKilobyte = 1024;
+        public const long BytesInMebibyte = 1048576;
         public const long BytesInMegabyte = 1048576;
         public const long BytesInPebibyte = 1125899906842624;
         public const long BytesInPetabyte = 1000000000000000;
+        public const long BytesInTebibyte = 1099511627776;
         public const long BytesInTerabyte = 1099511627776;
         public const string Exabyte = "exabyte";
         public const string ExabyteSymbol = "EB";
+        public const string Gibibyte = "gibibyte";
+        public const string GibibyteSymbol = "GiB";
         public const string Gigabyte = "gigabyte";
         public const string GigabyteSymbol = "GB";
+        public const string Kibibyte = "kibibyte";
+        public const string KibibyteSymbol = "KiB";
         public const string Kilobyte = "kilobyte";
         public const string KilobyteSymbol = "KB";
+        public const string Mebibyte = "mebibyte";
+        public const string MebibyteSymbol = "MiB";
         public const string Megabyte = "megabyte";
         public const string MegabyteSymbol = "MB";
         public const string Pebibyte = "pebibyte";
         public const string PebibyteSymbol = "PiB";
         public const string Petabyte = "petabyte";
         public const string PetabyteSymbol = "PB";
+        public const string Tebibyte = "tebibyte";
+        public const string TebibyteSymbol = "TiB";
         public const string Terabyte = "terabyte";
         public const string TerabyteSymbol = "TB";
         public static readonly Humanizer.ByteSize MaxValue;
@@ -52,14 +64,18 @@ namespace Humanizer
         public long Bits { get; }
         public double Bytes { get; }
         public double Exabytes { get; }
+        public double Gibibytes { get; }
         public double Gigabytes { get; }
+        public double Kibibytes { get; }
         public double Kilobytes { get; }
         public string LargestWholeNumberFullWord { get; }
         public string LargestWholeNumberSymbol { get; }
         public double LargestWholeNumberValue { get; }
+        public double Mebibytes { get; }
         public double Megabytes { get; }
         public double Pebibytes { get; }
         public double Petabytes { get; }
+        public double Tebibytes { get; }
         public double Terabytes { get; }
         public Humanizer.ByteSize Add(Humanizer.ByteSize bs) { }
         public Humanizer.ByteSize AddBits(long value) { }
@@ -87,11 +103,15 @@ namespace Humanizer
         public static Humanizer.ByteSize FromBits(long value) { }
         public static Humanizer.ByteSize FromBytes(double value) { }
         public static Humanizer.ByteSize FromExabytes(double value) { }
+        public static Humanizer.ByteSize FromGibibytes(double value) { }
         public static Humanizer.ByteSize FromGigabytes(double value) { }
+        public static Humanizer.ByteSize FromKibibytes(double value) { }
         public static Humanizer.ByteSize FromKilobytes(double value) { }
+        public static Humanizer.ByteSize FromMebibytes(double value) { }
         public static Humanizer.ByteSize FromMegabytes(double value) { }
         public static Humanizer.ByteSize FromPebibytes(double value) { }
         public static Humanizer.ByteSize FromPetabytes(double value) { }
+        public static Humanizer.ByteSize FromTebibytes(double value) { }
         public static Humanizer.ByteSize FromTerabytes(double value) { }
         public static Humanizer.ByteSize Parse(string s) { }
         public static Humanizer.ByteSize Parse(string s, System.IFormatProvider? formatProvider) { }
@@ -233,6 +253,10 @@ namespace Humanizer
         Petabyte = 6,
         Exabyte = 7,
         Pebibyte = 8,
+        Kibibyte = 9,
+        Mebibyte = 10,
+        Gibibyte = 11,
+        Tebibyte = 12,
     }
     public static class DateHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -25,24 +25,36 @@ namespace Humanizer
         public const string Byte = "byte";
         public const string ByteSymbol = "B";
         public const long BytesInExabyte = 1000000000000000000;
+        public const long BytesInGibibyte = 1073741824;
         public const long BytesInGigabyte = 1073741824;
+        public const long BytesInKibibyte = 1024;
         public const long BytesInKilobyte = 1024;
+        public const long BytesInMebibyte = 1048576;
         public const long BytesInMegabyte = 1048576;
         public const long BytesInPebibyte = 1125899906842624;
         public const long BytesInPetabyte = 1000000000000000;
+        public const long BytesInTebibyte = 1099511627776;
         public const long BytesInTerabyte = 1099511627776;
         public const string Exabyte = "exabyte";
         public const string ExabyteSymbol = "EB";
+        public const string Gibibyte = "gibibyte";
+        public const string GibibyteSymbol = "GiB";
         public const string Gigabyte = "gigabyte";
         public const string GigabyteSymbol = "GB";
+        public const string Kibibyte = "kibibyte";
+        public const string KibibyteSymbol = "KiB";
         public const string Kilobyte = "kilobyte";
         public const string KilobyteSymbol = "KB";
+        public const string Mebibyte = "mebibyte";
+        public const string MebibyteSymbol = "MiB";
         public const string Megabyte = "megabyte";
         public const string MegabyteSymbol = "MB";
         public const string Pebibyte = "pebibyte";
         public const string PebibyteSymbol = "PiB";
         public const string Petabyte = "petabyte";
         public const string PetabyteSymbol = "PB";
+        public const string Tebibyte = "tebibyte";
+        public const string TebibyteSymbol = "TiB";
         public const string Terabyte = "terabyte";
         public const string TerabyteSymbol = "TB";
         public static readonly Humanizer.ByteSize MaxValue;
@@ -51,14 +63,18 @@ namespace Humanizer
         public long Bits { get; }
         public double Bytes { get; }
         public double Exabytes { get; }
+        public double Gibibytes { get; }
         public double Gigabytes { get; }
+        public double Kibibytes { get; }
         public double Kilobytes { get; }
         public string LargestWholeNumberFullWord { get; }
         public string LargestWholeNumberSymbol { get; }
         public double LargestWholeNumberValue { get; }
+        public double Mebibytes { get; }
         public double Megabytes { get; }
         public double Pebibytes { get; }
         public double Petabytes { get; }
+        public double Tebibytes { get; }
         public double Terabytes { get; }
         public Humanizer.ByteSize Add(Humanizer.ByteSize bs) { }
         public Humanizer.ByteSize AddBits(long value) { }
@@ -86,11 +102,15 @@ namespace Humanizer
         public static Humanizer.ByteSize FromBits(long value) { }
         public static Humanizer.ByteSize FromBytes(double value) { }
         public static Humanizer.ByteSize FromExabytes(double value) { }
+        public static Humanizer.ByteSize FromGibibytes(double value) { }
         public static Humanizer.ByteSize FromGigabytes(double value) { }
+        public static Humanizer.ByteSize FromKibibytes(double value) { }
         public static Humanizer.ByteSize FromKilobytes(double value) { }
+        public static Humanizer.ByteSize FromMebibytes(double value) { }
         public static Humanizer.ByteSize FromMegabytes(double value) { }
         public static Humanizer.ByteSize FromPebibytes(double value) { }
         public static Humanizer.ByteSize FromPetabytes(double value) { }
+        public static Humanizer.ByteSize FromTebibytes(double value) { }
         public static Humanizer.ByteSize FromTerabytes(double value) { }
         public static Humanizer.ByteSize Parse(string s) { }
         public static Humanizer.ByteSize Parse(string s, System.IFormatProvider? formatProvider) { }
@@ -232,6 +252,10 @@ namespace Humanizer
         Petabyte = 6,
         Exabyte = 7,
         Pebibyte = 8,
+        Kibibyte = 9,
+        Mebibyte = 10,
+        Gibibyte = 11,
+        Tebibyte = 12,
     }
     public static class DateHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -24,24 +24,36 @@ namespace Humanizer
         public const string Byte = "byte";
         public const string ByteSymbol = "B";
         public const long BytesInExabyte = 1000000000000000000;
+        public const long BytesInGibibyte = 1073741824;
         public const long BytesInGigabyte = 1073741824;
+        public const long BytesInKibibyte = 1024;
         public const long BytesInKilobyte = 1024;
+        public const long BytesInMebibyte = 1048576;
         public const long BytesInMegabyte = 1048576;
         public const long BytesInPebibyte = 1125899906842624;
         public const long BytesInPetabyte = 1000000000000000;
+        public const long BytesInTebibyte = 1099511627776;
         public const long BytesInTerabyte = 1099511627776;
         public const string Exabyte = "exabyte";
         public const string ExabyteSymbol = "EB";
+        public const string Gibibyte = "gibibyte";
+        public const string GibibyteSymbol = "GiB";
         public const string Gigabyte = "gigabyte";
         public const string GigabyteSymbol = "GB";
+        public const string Kibibyte = "kibibyte";
+        public const string KibibyteSymbol = "KiB";
         public const string Kilobyte = "kilobyte";
         public const string KilobyteSymbol = "KB";
+        public const string Mebibyte = "mebibyte";
+        public const string MebibyteSymbol = "MiB";
         public const string Megabyte = "megabyte";
         public const string MegabyteSymbol = "MB";
         public const string Pebibyte = "pebibyte";
         public const string PebibyteSymbol = "PiB";
         public const string Petabyte = "petabyte";
         public const string PetabyteSymbol = "PB";
+        public const string Tebibyte = "tebibyte";
+        public const string TebibyteSymbol = "TiB";
         public const string Terabyte = "terabyte";
         public const string TerabyteSymbol = "TB";
         public static readonly Humanizer.ByteSize MaxValue;
@@ -50,14 +62,18 @@ namespace Humanizer
         public long Bits { get; }
         public double Bytes { get; }
         public double Exabytes { get; }
+        public double Gibibytes { get; }
         public double Gigabytes { get; }
+        public double Kibibytes { get; }
         public double Kilobytes { get; }
         public string LargestWholeNumberFullWord { get; }
         public string LargestWholeNumberSymbol { get; }
         public double LargestWholeNumberValue { get; }
+        public double Mebibytes { get; }
         public double Megabytes { get; }
         public double Pebibytes { get; }
         public double Petabytes { get; }
+        public double Tebibytes { get; }
         public double Terabytes { get; }
         public Humanizer.ByteSize Add(Humanizer.ByteSize bs) { }
         public Humanizer.ByteSize AddBits(long value) { }
@@ -85,11 +101,15 @@ namespace Humanizer
         public static Humanizer.ByteSize FromBits(long value) { }
         public static Humanizer.ByteSize FromBytes(double value) { }
         public static Humanizer.ByteSize FromExabytes(double value) { }
+        public static Humanizer.ByteSize FromGibibytes(double value) { }
         public static Humanizer.ByteSize FromGigabytes(double value) { }
+        public static Humanizer.ByteSize FromKibibytes(double value) { }
         public static Humanizer.ByteSize FromKilobytes(double value) { }
+        public static Humanizer.ByteSize FromMebibytes(double value) { }
         public static Humanizer.ByteSize FromMegabytes(double value) { }
         public static Humanizer.ByteSize FromPebibytes(double value) { }
         public static Humanizer.ByteSize FromPetabytes(double value) { }
+        public static Humanizer.ByteSize FromTebibytes(double value) { }
         public static Humanizer.ByteSize FromTerabytes(double value) { }
         public static Humanizer.ByteSize Parse(string s) { }
         public static Humanizer.ByteSize Parse(string s, System.IFormatProvider? formatProvider) { }
@@ -227,6 +247,10 @@ namespace Humanizer
         Petabyte = 6,
         Exabyte = 7,
         Pebibyte = 8,
+        Kibibyte = 9,
+        Mebibyte = 10,
+        Gibibyte = 11,
+        Tebibyte = 12,
     }
     public static class DateHumanizeExtensions
     {

--- a/tests/Humanizer.Tests/Bytes/LowerIecDataUnitTests.cs
+++ b/tests/Humanizer.Tests/Bytes/LowerIecDataUnitTests.cs
@@ -31,6 +31,26 @@ public class LowerIecDataUnitTests
     public void FormatsUppercaseIecTokenWithTurkishCulture() =>
         Assert.Equal("1 KiB", ByteSize.FromKibibytes(1).ToString("KIB", new CultureInfo("tr")));
 
+    [Fact]
+    public void RejectsUnsupportedLowerIecFactoryValues()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ByteSize.FromKibibytes(1125899906842624));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ByteSize.FromMebibytes(1099511627776));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ByteSize.FromGibibytes(1073741824));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ByteSize.FromTebibytes(1048576));
+    }
+
+    [Theory]
+    [InlineData("1125899906842624 KiB")]
+    [InlineData("1099511627776 MiB")]
+    [InlineData("1073741824 GiB")]
+    [InlineData("1048576 TiB")]
+    public void TryParseReturnsFalseForUnsupportedLowerIecValues(string input)
+    {
+        Assert.False(ByteSize.TryParse(input, out _));
+        Assert.False(ByteSize.TryParse(input.AsSpan(), out _));
+    }
+
     [Theory]
     [InlineData("1KiB", 1024)]
     [InlineData("1.5 mib", 1572864)]

--- a/tests/Humanizer.Tests/Bytes/LowerIecDataUnitTests.cs
+++ b/tests/Humanizer.Tests/Bytes/LowerIecDataUnitTests.cs
@@ -1,0 +1,65 @@
+[UseCulture("en")]
+public class LowerIecDataUnitTests
+{
+    [Fact]
+    public void CreatesLowerIecUnitsWithExistingBinaryFactors()
+    {
+        var kibibyte = ByteSize.FromKibibytes(1);
+        var mebibyte = ByteSize.FromMebibytes(1);
+        var gibibyte = ByteSize.FromGibibytes(1);
+        var tebibyte = ByteSize.FromTebibytes(1);
+
+        Assert.Equal(ByteSize.BytesInKilobyte, ByteSize.BytesInKibibyte);
+        Assert.Equal(ByteSize.BytesInMegabyte, ByteSize.BytesInMebibyte);
+        Assert.Equal(ByteSize.BytesInGigabyte, ByteSize.BytesInGibibyte);
+        Assert.Equal(ByteSize.BytesInTerabyte, ByteSize.BytesInTebibyte);
+        Assert.Equal(1, kibibyte.Kibibytes);
+        Assert.Equal(1, mebibyte.Mebibytes);
+        Assert.Equal(1, gibibyte.Gibibytes);
+        Assert.Equal(1, tebibyte.Tebibytes);
+    }
+
+    [Theory]
+    [InlineData(1024, "0 KiB", "1 KiB")]
+    [InlineData(1048576, "0 MiB", "1 MiB")]
+    [InlineData(1073741824, "0 GiB", "1 GiB")]
+    [InlineData(1099511627776, "0 TiB", "1 TiB")]
+    public void FormatsExplicitLowerIecUnits(double bytes, string format, string expected) =>
+        Assert.Equal(expected, ByteSize.FromBytes(bytes).ToString(format));
+
+    [Theory]
+    [InlineData("1KiB", 1024)]
+    [InlineData("1.5 mib", 1572864)]
+    [InlineData("1GiB", 1073741824)]
+    [InlineData("1TiB", 1099511627776)]
+    public void ParsesLowerIecUnitsFromStringsAndSpans(string input, double expectedBytes)
+    {
+        Assert.True(ByteSize.TryParse(input, out var parsed));
+        Assert.Equal(expectedBytes, parsed.Bytes);
+
+        Assert.True(ByteSize.TryParse(input.AsSpan(), out parsed));
+        Assert.Equal(expectedBytes, parsed.Bytes);
+    }
+
+    [Fact]
+    public void LocalizesExplicitLowerIecUnits()
+    {
+        var french = new CultureInfo("fr");
+        var spanish = new CultureInfo("es");
+
+        Assert.Equal("1 Kio", ByteSize.FromKibibytes(1).Humanize("KiB", french));
+        Assert.Equal("1 mébioctet", ByteSize.FromMebibytes(1).ToFullWords("MiB", french));
+        Assert.Equal("1 GiB", ByteSize.FromGibibytes(1).Humanize("GiB", spanish));
+        Assert.Equal("1 gibibyte", ByteSize.FromGibibytes(1).ToFullWords("GiB", spanish));
+    }
+
+    [Fact]
+    public void PreservesLegacyDefaultsAndEnumValues()
+    {
+        Assert.Equal("1 KB", ByteSize.FromKibibytes(1).ToString());
+        Assert.Equal(ByteSize.FromKilobytes(1), ByteSize.Parse("1 KB"));
+        Assert.Equal("1 KB/s", ByteSize.FromKibibytes(1).Per(TimeSpan.FromSeconds(1)).Humanize());
+        Assert.Equal(8, (int)DataUnit.Pebibyte);
+        Assert.Equal(9, (int)DataUnit.Kibibyte);
+    }
+}

--- a/tests/Humanizer.Tests/Bytes/LowerIecDataUnitTests.cs
+++ b/tests/Humanizer.Tests/Bytes/LowerIecDataUnitTests.cs
@@ -27,6 +27,10 @@ public class LowerIecDataUnitTests
     public void FormatsExplicitLowerIecUnits(double bytes, string format, string expected) =>
         Assert.Equal(expected, ByteSize.FromBytes(bytes).ToString(format));
 
+    [Fact]
+    public void FormatsUppercaseIecTokenWithTurkishCulture() =>
+        Assert.Equal("1 KiB", ByteSize.FromKibibytes(1).ToString("KIB", new CultureInfo("tr")));
+
     [Theory]
     [InlineData("1KiB", 1024)]
     [InlineData("1.5 mib", 1572864)]


### PR DESCRIPTION
## Summary

Callers can now express binary byte magnitudes with unambiguous `KiB`, `MiB`, `GiB`, and `TiB` names without changing Humanizer's established `KB`–`TB` behavior. The new constants, properties, factories, parser tokens, and explicit formats reuse the existing binary factors; automatic formatting, rate output, public enum values, and the `ByteSize` struct layout remain compatible.

The new factories enforce the existing `ByteSize.Bits` range and their `TryParse` paths reject unsupported values without throwing.

This carries forward the compatibility-safe portion of @CollinAlpert's work in #1413. Collin Alpert is credited as a co-author on the implementation commit.

Fixes #970.

Related: #1413, #592, #657

## Validation

- `net8.0`, `net10.0`, and `net11.0`: 57,640 tests passed per target with zero failures
- Release package built successfully for all library targets
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic --no-restore`

## Checklist

- [x] Implementation is clean and follows existing coding standards
- [x] No code-analysis warnings
- [x] Unit tests cover the new APIs and legacy compatibility
- [x] Adapted contribution is fully attributed
- [x] XML documentation and public API approvals are updated
- [x] Rebased on the latest `main`
- [x] Related issues and prior contributions are linked
- [x] README is updated
- [x] Required repository build and test commands pass
