### PR TITLE
fix: preserve enum metadata casing

### DIFF
--- a/src/Humanizer/EnumCache.cs
+++ b/src/Humanizer/EnumCache.cs
@@ -38,9 +38,6 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
     public static FrozenDictionary<string, T> GetDehumanized() =>
         Info.Dehumanized;
 
-    public static bool IsMetadata(T input) =>
-        Info.Humanized.TryGetValue(input, out var humanized) && humanized.IsMetadata;
-
     public static bool TreatAsFlags(T input)
     {
         if (!Info.IsBitFieldEnum)

--- a/src/Humanizer/EnumCache.cs
+++ b/src/Humanizer/EnumCache.cs
@@ -7,20 +7,20 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
 {
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
     static readonly Type TypeOfT = typeof(T);
-    static readonly (T Zero, FrozenDictionary<T, string> Humanized, FrozenDictionary<string, T> Dehumanized, FrozenSet<T> Values, bool IsBitFieldEnum) Info = CreateInfo();
+    static readonly (T Zero, FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized, FrozenDictionary<string, T> Dehumanized, FrozenSet<T> Values, bool IsBitFieldEnum) Info = CreateInfo();
 
-    private static (T Zero, FrozenDictionary<T, string> Humanized, FrozenDictionary<string, T> Dehumanized, FrozenSet<T> Values, bool IsBitFieldEnum) CreateInfo()
+    private static (T Zero, FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized, FrozenDictionary<string, T> Dehumanized, FrozenSet<T> Values, bool IsBitFieldEnum) CreateInfo()
     {
         var valuesArray = Enum.GetValues<T>();
         var zero = (T)Convert.ChangeType(Enum.ToObject(TypeOfT, 0), TypeOfT);
         var count = valuesArray.Length;
-        var humanized = new Dictionary<T, string>(count);
+        var humanized = new Dictionary<T, (string Text, bool IsMetadata)>(count);
         var dehumanized = new Dictionary<string, T>(count, StringComparer.OrdinalIgnoreCase);
         foreach (var value in valuesArray)
         {
             var description = GetDescription(value);
             humanized[value] = description;
-            dehumanized[description] = value;
+            dehumanized[description.Text] = value;
         }
 
         var isBitFieldEnum = TypeOfT.GetCustomAttribute<FlagsAttribute>() != null;
@@ -32,11 +32,14 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
             isBitFieldEnum);
     }
 
-    public static (T Zero, FrozenDictionary<T, string> Humanized, FrozenSet<T> Values) GetInfo() =>
+    public static (T Zero, FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized, FrozenSet<T> Values) GetInfo() =>
         (Info.Zero, Info.Humanized, Info.Values);
 
     public static FrozenDictionary<string, T> GetDehumanized() =>
         Info.Dehumanized;
+
+    public static bool IsMetadata(T input) =>
+        Info.Humanized.TryGetValue(input, out var humanized) && humanized.IsMetadata;
 
     public static bool TreatAsFlags(T input)
     {
@@ -48,7 +51,7 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
         return !Enum.IsDefined(TypeOfT, input);
     }
 
-    static string GetDescription(T input)
+    static (string Text, bool IsMetadata) GetDescription(T input)
     {
 #if NET5_0_OR_GREATER
         var caseName = Enum.GetName(input)!;
@@ -59,10 +62,10 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
 
         if (TryGetDescription(member, out var description))
         {
-            return description;
+            return (description, true);
         }
 
-        return caseName.Humanize();
+        return (caseName.Humanize(), false);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Reflection over attribute properties is intentional and documented.")]

--- a/src/Humanizer/EnumHumanizeExtensions.cs
+++ b/src/Humanizer/EnumHumanizeExtensions.cs
@@ -105,11 +105,20 @@ public static class EnumHumanizeExtensions
     /// </code>
     /// </example>
     public static string Humanize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(this T input)
+        where T : struct, Enum =>
+        Humanize(input, null);
+
+    static string Humanize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(T input, LetterCasing? casing)
         where T : struct, Enum
     {
         var (zero, humanized, values) = EnumCache<T>.GetInfo();
         if (EnumCache<T>.TreatAsFlags(input))
         {
+            if (casing is { } flagsCasing && !Enum.IsDefined(flagsCasing))
+            {
+                throw new ArgumentOutOfRangeException(nameof(casing));
+            }
+
             // Avoid LINQ allocations by manually iterating and building the list
             List<string>? flagValues = null;
             foreach (var value in values)
@@ -117,14 +126,26 @@ public static class EnumHumanizeExtensions
                 if (value.CompareTo(zero) != 0 && input.HasFlag(value))
                 {
                     flagValues ??= new List<string>();
-                    flagValues.Add(humanized[value].Text);
+                    var flag = humanized[value];
+                    flagValues.Add(casing is { } flagCasing && !flag.IsMetadata ? flag.Text.ApplyCase(flagCasing) : flag.Text);
                 }
             }
 
             return flagValues?.Humanize() ?? string.Empty;
         }
 
-        return humanized[input].Text;
+        var humanizedEnum = humanized[input];
+        if (casing is not { } enumCasing)
+        {
+            return humanizedEnum.Text;
+        }
+
+        if (!Enum.IsDefined(enumCasing))
+        {
+            throw new ArgumentOutOfRangeException(nameof(casing));
+        }
+
+        return humanizedEnum.IsMetadata ? humanizedEnum.Text : humanizedEnum.Text.ApplyCase(enumCasing);
     }
 
 
@@ -152,13 +173,5 @@ public static class EnumHumanizeExtensions
     /// </example>
     public static string Humanize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(this T input, LetterCasing casing)
         where T : struct, Enum
-    {
-        var humanizedEnum = Humanize(input);
-        if (!Enum.IsDefined(casing))
-        {
-            throw new ArgumentOutOfRangeException(nameof(casing));
-        }
-
-        return EnumCache<T>.IsMetadata(input) ? humanizedEnum : humanizedEnum.ApplyCase(casing);
-    }
+        => Humanize(input, (LetterCasing?)casing);
 }

--- a/src/Humanizer/EnumHumanizeExtensions.cs
+++ b/src/Humanizer/EnumHumanizeExtensions.cs
@@ -10,16 +10,38 @@ public static class EnumHumanizeExtensions
     [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "The method is only used by Humanize which already has RequiresUnreferencedCode")]
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "The method is only used by Humanize which already has RequiresDynamicCode")]
 #endif
-    static MethodInfo GetGenericHumanizeMethodInfo() =>
+    static MethodInfo GetGenericHumanizeMethodInfo(int parameterCount) =>
         typeof(EnumHumanizeExtensions)
             .GetMethods()
             .Single(method =>
                 method.Name == nameof(Humanize) &&
                 method.IsGenericMethodDefinition &&
-                method.GetParameters().Length == 1 &&
+                method.GetParameters().Length == parameterCount &&
                 method.GetGenericArguments().Length == 1);
 
-    static readonly Lazy<MethodInfo> GenericHumanizeMethod = new(GetGenericHumanizeMethodInfo);
+    static readonly Lazy<MethodInfo> GenericHumanizeMethod = new(() => GetGenericHumanizeMethodInfo(1));
+    static readonly Lazy<MethodInfo> GenericHumanizeWithCasingMethod = new(() => GetGenericHumanizeMethodInfo(2));
+
+#if NET6_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2060", Justification = "The method is only used by Humanize which preserves the generic methods with DynamicDependency")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The method is only used by Humanize which already has RequiresUnreferencedCode")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "The method is only used by Humanize which already has RequiresDynamicCode")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(EnumHumanizeExtensions))]
+#endif
+    static string InvokeGenericHumanize(Enum input, Lazy<MethodInfo> method, params object[] arguments)
+    {
+        try
+        {
+            return (string)method.Value
+                .MakeGenericMethod(input.GetType())
+                .Invoke(null, arguments)!;
+        }
+        catch (TargetInvocationException exception) when (exception.InnerException is not null)
+        {
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+            throw;
+        }
+    }
 
     /// <summary>
     /// Converts an enum value to a human-readable string when the concrete enum type is only known at runtime.
@@ -31,33 +53,22 @@ public static class EnumHumanizeExtensions
     [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(EnumHumanizeExtensions))]
 #endif
-    public static string Humanize(this Enum input)
-    {
-        try
-        {
-            return (string)GenericHumanizeMethod.Value
-                .MakeGenericMethod(input.GetType())
-                .Invoke(null, [input])!;
-        }
-        catch (TargetInvocationException exception) when (exception.InnerException is not null)
-        {
-            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
-            throw;
-        }
-    }
+    public static string Humanize(this Enum input) =>
+        InvokeGenericHumanize(input, GenericHumanizeMethod, input);
 
     /// <summary>
-    /// Converts an enum value to a human-readable string with the specified letter casing when the concrete enum type is only known at runtime.
+    /// Converts an enum value to a human-readable string with the specified letter casing applied to the enum member name
+    /// when the concrete enum type is only known at runtime. Authored metadata on a defined enum value is returned unchanged.
     /// </summary>
     /// <param name="input">The enum value to be humanized.</param>
-    /// <param name="casing">The desired letter casing to apply to the humanized enum value.</param>
-    /// <returns>A human-readable string representation of the enum value with the specified casing applied.</returns>
+    /// <param name="casing">The desired letter casing to apply when humanizing the enum member name.</param>
+    /// <returns>A human-readable string representation of the enum value.</returns>
 #if NET6_0_OR_GREATER
     [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
     [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
 #endif
     public static string Humanize(this Enum input, LetterCasing casing) =>
-        input.Humanize().ApplyCase(casing);
+        InvokeGenericHumanize(input, GenericHumanizeWithCasingMethod, input, casing);
 
     /// <summary>
     /// Converts an enum value to a human-readable string by intelligently formatting the enum member name
@@ -106,30 +117,30 @@ public static class EnumHumanizeExtensions
                 if (value.CompareTo(zero) != 0 && input.HasFlag(value))
                 {
                     flagValues ??= new List<string>();
-                    flagValues.Add(humanized[value]);
+                    flagValues.Add(humanized[value].Text);
                 }
             }
 
             return flagValues?.Humanize() ?? string.Empty;
         }
 
-        return humanized[input];
+        return humanized[input].Text;
     }
 
 
     /// <summary>
-    /// Converts an enum value to a human-readable string with the specified letter casing applied.
-    /// Respects any <see cref="System.ComponentModel.DescriptionAttribute"/> applied to the enum member.
+    /// Converts an enum value to a human-readable string with the specified letter casing applied to the enum member name.
+    /// Authored metadata on a defined enum value is returned unchanged.
     /// </summary>
     /// <typeparam name="T">The enum type. Must be a struct and implement <see cref="Enum"/>.</typeparam>
     /// <param name="input">The enum value to be humanized.</param>
-    /// <param name="casing">The desired letter casing to apply to the humanized enum value.</param>
+    /// <param name="casing">The desired letter casing to apply when humanizing the enum member name.</param>
     /// <returns>
-    /// A human-readable string representation of the enum value with the specified casing applied.
-    /// If a <see cref="System.ComponentModel.DescriptionAttribute"/> is present, its value is used and then cased.
+    /// A human-readable string representation of the enum value.
+    /// If a defined enum value has authored metadata such as <see cref="System.ComponentModel.DescriptionAttribute"/>, its value is returned unchanged.
     /// </returns>
     /// <remarks>
-    /// This is a convenience method that combines <see cref="Humanize{T}(T)"/> with <see cref="CasingExtensions.ApplyCase"/>.
+    /// For a defined enum value, the specified casing is applied only when the output is derived from the enum member name.
     /// </remarks>
     /// <example>
     /// <code>
@@ -143,7 +154,11 @@ public static class EnumHumanizeExtensions
         where T : struct, Enum
     {
         var humanizedEnum = Humanize(input);
+        if (!Enum.IsDefined(casing))
+        {
+            throw new ArgumentOutOfRangeException(nameof(casing));
+        }
 
-        return humanizedEnum.ApplyCase(casing);
+        return EnumCache<T>.IsMetadata(input) ? humanizedEnum : humanizedEnum.ApplyCase(casing);
     }
 }

--- a/tests/Humanizer.Tests/BitFieldEnumHumanizeTests.cs
+++ b/tests/Humanizer.Tests/BitFieldEnumHumanizeTests.cs
@@ -17,6 +17,14 @@ public class BitFieldEnumHumanizeTests
     }
 
     [Fact]
+    public void CasingPreservesMetadataInCompositeBitFieldEnum()
+    {
+        var composite = MixedMetadataBitFieldEnumUnderTest.AuthoredMetadata | MixedMetadataBitFieldEnumUnderTest.NameDerived;
+
+        Assert.Equal("SpaceX and Name Derived", composite.Humanize(LetterCasing.Title));
+    }
+
+    [Fact]
     public void CanHumanizeShortSingleWordDescriptionAttribute() =>
         Assert.Equal(BitFlagEnumTestsResources.MemberWithSingleWordDisplayAttribute, ShortBitFieldEnumUnderTest.RED.Humanize());
 

--- a/tests/Humanizer.Tests/BitFieldEnumUnderTest.cs
+++ b/tests/Humanizer.Tests/BitFieldEnumUnderTest.cs
@@ -20,6 +20,14 @@ public enum ShortBitFieldEnumUnderTest : short
     DARK_GRAY = 2
 }
 
+[Flags]
+public enum MixedMetadataBitFieldEnumUnderTest
+{
+    [Display(Description = "SpaceX")]
+    AuthoredMetadata = 1,
+    NameDerived = 2
+}
+
 public class BitFlagEnumTestsResources
 {
     public const string None = "None";

--- a/tests/Humanizer.Tests/EnumHumanizeTests.cs
+++ b/tests/Humanizer.Tests/EnumHumanizeTests.cs
@@ -6,6 +6,18 @@ public class EnumHumanizeTests
     public void HonorsDescriptionAttribute() =>
         Assert.Equal(EnumTestsResources.MemberWithDescriptionAttribute, EnumUnderTest.MemberWithDescriptionAttribute.Humanize());
 
+    [Theory]
+    [InlineData(LetterCasing.Title)]
+    [InlineData(LetterCasing.AllCaps)]
+    [InlineData(LetterCasing.LowerCase)]
+    [InlineData(LetterCasing.Sentence)]
+    public void CasingPreservesDescriptionAttribute(LetterCasing casing) =>
+        Assert.Equal(EnumTestsResources.MemberWithDescriptionAttribute, EnumUnderTest.MemberWithDescriptionAttribute.Humanize(casing));
+
+    [Fact]
+    public void InvalidCasingStillThrowsForDescriptionAttribute() =>
+        Assert.Throws<ArgumentOutOfRangeException>(() => EnumUnderTest.MemberWithDescriptionAttribute.Humanize((LetterCasing)42));
+
     [Fact]
     public void HonorsDescriptionAttributeSubclasses() =>
         Assert.Equal("Overridden " + EnumTestsResources.MemberWithDescriptionAttributeSubclass, EnumUnderTest.MemberWithDescriptionAttributeSubclass.Humanize());
@@ -33,6 +45,17 @@ public class EnumHumanizeTests
         Assert.Equal(
             EnumTestsResources.MemberWithoutDescriptionAttributeTitle,
             value.Humanize(LetterCasing.Title));
+    }
+
+    [Fact]
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+    public void RuntimeEnumCasingPreservesDescriptionAttribute()
+    {
+        Enum value = EnumUnderTest.MemberWithDescriptionAttribute;
+
+        Assert.Equal(EnumTestsResources.MemberWithDescriptionAttribute, value.Humanize(LetterCasing.Title));
+        Assert.Throws<ArgumentOutOfRangeException>(() => value.Humanize((LetterCasing)42));
     }
 
     [Fact]
@@ -66,6 +89,14 @@ public class EnumHumanizeTests
     [Fact]
     public void HonorsDisplayAttribute() =>
         Assert.Equal(EnumTestsResources.MemberWithDisplayAttribute, EnumUnderTest.MemberWithDisplayAttribute.Humanize());
+
+    [Theory]
+    [InlineData(LetterCasing.Title)]
+    [InlineData(LetterCasing.AllCaps)]
+    [InlineData(LetterCasing.LowerCase)]
+    [InlineData(LetterCasing.Sentence)]
+    public void CasingPreservesDisplayAttribute(LetterCasing casing) =>
+        Assert.Equal(EnumTestsResources.MemberWithDisplayAttribute, EnumUnderTest.MemberWithDisplayAttribute.Humanize(casing));
 
     [Fact]
     public void HandlesDisplayAttributeWithNoDescription() =>

--- a/tests/Humanizer.Tests/EnumUnderTest.cs
+++ b/tests/Humanizer.Tests/EnumUnderTest.cs
@@ -32,7 +32,7 @@ public enum EnumForCustomLocator
 
 public class EnumTestsResources
 {
-    public const string MemberWithDescriptionAttribute = "Some Description";
+    public const string MemberWithDescriptionAttribute = "SpaceX and the Moon";
     public const string MemberWithDescriptionAttributeSubclass = "Description in Description subclass";
     public const string MemberWithCustomDescriptionAttribute = "Description in custom Description attribute";
     public const string MemberWithImposterDescriptionAttribute = "Member with imposter description attribute";
@@ -40,7 +40,7 @@ public class EnumTestsResources
     public const string MemberWithoutDescriptionAttributeSentence = "Member without description attribute";
     public const string MemberWithoutDescriptionAttributeTitle = "Member Without Description Attribute";
     public const string MemberWithoutDescriptionAttributeLowerCase = "member without description attribute";
-    public const string MemberWithDisplayAttribute = "Description from Display attribute";
+    public const string MemberWithDisplayAttribute = "iPhone from NASA";
     public const string MemberWithDisplayAttributeWithoutDescription = "Displayattribute without description";
     public static string MemberWithLocalizedDisplayAttribute => "Localized description from Display attribute";
 }


### PR DESCRIPTION
## Summary

Before this fix, `Humanize(LetterCasing)` recased authored enum metadata, corrupting stylized strings such as “SpaceX” and “iPhone.” Defined enum values now preserve `Description` and `Display` text verbatim, while values derived from enum member names still honor the requested casing.

Mixed `[Flags]` composites apply casing per component: authored metadata remains unchanged, name-derived components are cased, and the existing collection formatter continues to own separators and conjunctions.

Reported by @sid-6581; thank you for the clear reproduction.

Fixes #949.

## Validation

- Focused mixed-flags characterization before the fix: expected `SpaceX and Name Derived`, actual `Spacex and Name Derived`
- Focused `BitFieldEnumHumanizeTests`: 9 passed
- Focused `EnumHumanizeTests`: 37 passed
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 57,681 passed
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 57,681 passed
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 57,681 passed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp>` — succeeded without warnings
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — no changes

## Checklist

- [x] Implementation is clean and follows the existing coding standards
- [x] No code-analysis warnings were introduced
- [x] Focused regression coverage includes `Description`, `Display`, generic, runtime enum, and mixed `[Flags]` paths
- [x] No external code was copied
- [x] XML documentation reflects the behavior change
- [x] The branch is based on the latest `main`
- [x] The issue is linked with a closing reference
- [x] README changes are unnecessary for this bug fix
- [x] Supported test targets and the Release package build pass
