### PR TITLE
feat: add English decimal word parsing

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -88,9 +88,17 @@ using System.Globalization;
     .ToNumber(new CultureInfo("en-IN"));
 // => 123456789
 
+"one hundred and five point zero two"
+    .ToDecimalNumber(new CultureInfo("en"));
+// => 105.02m
+
 123456789.ToWords(new CultureInfo("en-GB"));
 // => "one hundred and twenty-three million four hundred and fifty-six thousand seven hundred and eighty-nine"
 ```
+
+English decimal phrases use a separate `decimal`-returning API. The fractional part is parsed
+digit by digit and retains its authored scale. Use `TryToDecimalNumber` when input may be malformed
+or outside the `decimal` range.
 
 ### Fluent Dates
 

--- a/readme.md
+++ b/readme.md
@@ -713,6 +713,23 @@ if (!"tenn".TryToNumber(out var invalid, new CultureInfo("en"), out var badWord)
 >
 > **Breaking change:** `ToNumber` now returns `long`. Code that previously stored the result in `int` must either switch to `long` or add an explicit checked cast.
 
+English decimal number words use a separate `decimal`-returning API, leaving the integer API unchanged:
+
+```csharp
+"one point two".ToDecimalNumber(new CultureInfo("en")) => 1.2m
+"minus point zero five".ToDecimalNumber(new CultureInfo("en")) => -0.05m
+
+if ("one point five zero".TryToDecimalNumber(out var amount, new CultureInfo("en")))
+    Console.WriteLine(amount); // Outputs: 1.50
+```
+
+The phrase must contain exactly one `point`. Its fractional part accepts one to 28 digit words
+(`zero` through `nine`) and preserves leading and trailing zeroes. `minus` or `negative` may prefix
+the complete phrase; `and` remains available to the integer grammar but is rejected after `point`.
+Malformed input, decimal overflow, and non-English cultures return `false` from
+`TryToDecimalNumber`; `ToDecimalNumber` throws `FormatException` for invalid English phrases and
+`NotSupportedException` for unsupported cultures.
+
 ### DateTime to ordinal words
 
 Convert dates to ordinal word format:

--- a/src/Humanizer/Configuration/Configurator.cs
+++ b/src/Humanizer/Configuration/Configurator.cs
@@ -26,6 +26,12 @@ public static partial class Configurator
     private static LocaliserRegistry<IWordsToNumberConverter> WordsToNumberConverters { get; } = new WordsToNumberConverterRegistry();
 
     /// <summary>
+    /// A registry of converters that transform decimal number words into numeric values for the active locale.
+    /// </summary>
+    private static LocaliserRegistry<IWordsToDecimalNumberConverter> WordsToDecimalNumberConverters { get; } =
+        new WordsToDecimalNumberConverterRegistry();
+
+    /// <summary>
     /// A registry of ordinalizers used to localise Ordinalize method
     /// </summary>
     public static LocaliserRegistry<IOrdinalizer> Ordinalizers { get; } = new OrdinalizerRegistry();
@@ -65,6 +71,9 @@ public static partial class Configurator
 
     internal static IWordsToNumberConverter GetWordsToNumberConverter(CultureInfo culture) =>
         WordsToNumberConverters.ResolveForCulture(culture);
+
+    internal static IWordsToDecimalNumberConverter GetWordsToDecimalNumberConverter(CultureInfo culture) =>
+        WordsToDecimalNumberConverters.ResolveForCulture(culture);
 
 
 

--- a/src/Humanizer/Configuration/WordsToDecimalNumberConverterRegistry.cs
+++ b/src/Humanizer/Configuration/WordsToDecimalNumberConverterRegistry.cs
@@ -1,0 +1,8 @@
+namespace Humanizer;
+
+internal sealed class WordsToDecimalNumberConverterRegistry : LocaliserRegistry<IWordsToDecimalNumberConverter>
+{
+    public WordsToDecimalNumberConverterRegistry()
+        : base(UnsupportedWordsToDecimalNumberConverter.Instance) =>
+        Register("en", static culture => new EnglishWordsToDecimalNumberConverter(culture));
+}

--- a/src/Humanizer/Localisation/WordsToNumber/EnglishWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/EnglishWordsToDecimalNumberConverter.cs
@@ -50,9 +50,9 @@ internal sealed class EnglishWordsToDecimalNumberConverter(CultureInfo culture) 
     public bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber)
     {
         parsedValue = default;
-        unrecognizedNumber = words;
+        unrecognizedNumber = words ?? string.Empty;
 
-        if (string.IsNullOrWhiteSpace(words))
+        if (words is null || string.IsNullOrWhiteSpace(words))
         {
             return false;
         }
@@ -119,7 +119,7 @@ internal sealed class EnglishWordsToDecimalNumberConverter(CultureInfo culture) 
                 NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint,
                 CultureInfo.InvariantCulture,
                 out parsedValue) ||
-            (decimal.GetBits(parsedValue)[3] >> 16 & 0x7F) != fraction.Length)
+            (decimal.GetBits(parsedValue)[3] >> 16 & 0xFF) != fraction.Length)
         {
             parsedValue = default;
             unrecognizedNumber = words;

--- a/src/Humanizer/Localisation/WordsToNumber/EnglishWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/EnglishWordsToDecimalNumberConverter.cs
@@ -83,7 +83,7 @@ internal sealed class EnglishWordsToDecimalNumberConverter(CultureInfo culture) 
         }
 
         var fraction = new StringBuilder();
-        foreach (var token in fractionWords.Split([' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        foreach (var token in fractionWords.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
         {
             if (!FractionalDigits.TryGetValue(token, out var digit))
             {
@@ -136,7 +136,7 @@ internal sealed class EnglishWordsToDecimalNumberConverter(CultureInfo culture) 
             }
 
             var initialUnrecognizedNumber = unrecognizedNumber;
-            var tokens = words.Split([' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+            var tokens = words.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
 
             for (var index = tokens.Length - 1; index > 0; index--)
             {

--- a/src/Humanizer/Localisation/WordsToNumber/EnglishWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/EnglishWordsToDecimalNumberConverter.cs
@@ -12,10 +12,6 @@ internal sealed class EnglishWordsToDecimalNumberConverter(CultureInfo culture) 
         @"(?<!\S)point(?!\S)",
         RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
-    static readonly Regex QuintillionMarker = new(
-        @"(?<!\S)quintillion(?!\S)",
-        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
-
     static readonly FrozenDictionary<string, char> FractionalDigits =
         new Dictionary<string, char>(StringComparer.OrdinalIgnoreCase)
         {
@@ -139,51 +135,43 @@ internal sealed class EnglishWordsToDecimalNumberConverter(CultureInfo culture) 
                 return true;
             }
 
-            var markers = QuintillionMarker.Matches(words);
-            if (markers.Count != 1)
+            var initialUnrecognizedNumber = unrecognizedNumber;
+            var tokens = words.Split([' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+
+            for (var index = tokens.Length - 1; index > 0; index--)
             {
-                digits = string.Empty;
-                return false;
+                if (!integerConverter.TryConvert(tokens[index], out var scale, out _) ||
+                    !TryGetScaleDigits(scale, out var scaleDigits))
+                {
+                    continue;
+                }
+
+                var highWords = string.Join(" ", tokens, 0, index);
+                if (!integerConverter.TryConvert(highWords, out var high, out _) || high <= 0)
+                {
+                    continue;
+                }
+
+                var lowWords = string.Join(" ", tokens, index + 1, tokens.Length - index - 1);
+                var low = 0L;
+                if (lowWords.Length > 0 &&
+                    !integerConverter.TryConvert(lowWords, out low, out _) ||
+                    low < 0 ||
+                    low >= scale)
+                {
+                    continue;
+                }
+
+                digits = string.Concat(
+                    high.ToString(CultureInfo.InvariantCulture),
+                    low.ToString($"D{scaleDigits}", CultureInfo.InvariantCulture));
+                unrecognizedNumber = null;
+                return true;
             }
 
-            var marker = markers[0];
-            var highWords = words[..marker.Index].Trim();
-            var lowWords = words[(marker.Index + marker.Length)..].Trim();
-
-            if (highWords.Length == 0 ||
-                !integerConverter.TryConvert(highWords, out var high, out unrecognizedNumber))
-            {
-                digits = string.Empty;
-                return false;
-            }
-
-            if (high <= 0)
-            {
-                digits = string.Empty;
-                unrecognizedNumber = highWords;
-                return false;
-            }
-
-            var low = 0L;
-            if (lowWords.Length > 0 &&
-                !integerConverter.TryConvert(lowWords, out low, out unrecognizedNumber))
-            {
-                digits = string.Empty;
-                return false;
-            }
-
-            if (low is < 0 or >= 1_000_000_000_000_000_000L)
-            {
-                digits = string.Empty;
-                unrecognizedNumber = lowWords;
-                return false;
-            }
-
-            digits = string.Concat(
-                high.ToString(CultureInfo.InvariantCulture),
-                low.ToString("D18", CultureInfo.InvariantCulture));
-            unrecognizedNumber = null;
-            return true;
+            digits = string.Empty;
+            unrecognizedNumber = initialUnrecognizedNumber;
+            return false;
         }
         catch (OverflowException)
         {
@@ -191,6 +179,23 @@ internal sealed class EnglishWordsToDecimalNumberConverter(CultureInfo culture) 
             unrecognizedNumber = words;
             return false;
         }
+    }
+
+    static bool TryGetScaleDigits(long value, out int digits)
+    {
+        digits = 0;
+        if (value < 1000)
+        {
+            return false;
+        }
+
+        while (value % 10 == 0)
+        {
+            value /= 10;
+            digits++;
+        }
+
+        return value == 1;
     }
 
     static string? StripNegativePrefix(ref string words)

--- a/src/Humanizer/Localisation/WordsToNumber/EnglishWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/EnglishWordsToDecimalNumberConverter.cs
@@ -12,6 +12,10 @@ internal sealed class EnglishWordsToDecimalNumberConverter(CultureInfo culture) 
         @"(?<!\S)point(?!\S)",
         RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    static readonly Regex QuintillionMarker = new(
+        @"(?<!\S)quintillion(?!\S)",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     static readonly FrozenDictionary<string, char> FractionalDigits =
         new Dictionary<string, char>(StringComparer.OrdinalIgnoreCase)
         {
@@ -75,12 +79,9 @@ internal sealed class EnglishWordsToDecimalNumberConverter(CultureInfo culture) 
             return false;
         }
 
-        var integerValue = 0L;
+        var integerDigits = "0";
         if (integerWords.Length > 0 &&
-            !integerConverter.TryConvert(
-                negativePrefix is null ? integerWords : $"{negativePrefix} {integerWords}",
-                out integerValue,
-                out unrecognizedNumber))
+            !TryConvertIntegerPart(integerWords, out integerDigits, out unrecognizedNumber))
         {
             return false;
         }
@@ -109,9 +110,7 @@ internal sealed class EnglishWordsToDecimalNumberConverter(CultureInfo culture) 
             return false;
         }
 
-        var signedInteger = negativePrefix is not null && integerValue == 0
-            ? "-0"
-            : integerValue.ToString(CultureInfo.InvariantCulture);
+        var signedInteger = negativePrefix is null ? integerDigits : $"-{integerDigits}";
         var invariantValue = $"{signedInteger}.{fraction}";
 
         if (!decimal.TryParse(
@@ -128,6 +127,70 @@ internal sealed class EnglishWordsToDecimalNumberConverter(CultureInfo culture) 
 
         unrecognizedNumber = null;
         return true;
+    }
+
+    bool TryConvertIntegerPart(string words, out string digits, out string? unrecognizedNumber)
+    {
+        try
+        {
+            if (integerConverter.TryConvert(words, out var value, out unrecognizedNumber))
+            {
+                digits = value.ToString(CultureInfo.InvariantCulture);
+                return true;
+            }
+
+            var markers = QuintillionMarker.Matches(words);
+            if (markers.Count != 1)
+            {
+                digits = string.Empty;
+                return false;
+            }
+
+            var marker = markers[0];
+            var highWords = words[..marker.Index].Trim();
+            var lowWords = words[(marker.Index + marker.Length)..].Trim();
+
+            if (highWords.Length == 0 ||
+                !integerConverter.TryConvert(highWords, out var high, out unrecognizedNumber))
+            {
+                digits = string.Empty;
+                return false;
+            }
+
+            if (high <= 0)
+            {
+                digits = string.Empty;
+                unrecognizedNumber = highWords;
+                return false;
+            }
+
+            var low = 0L;
+            if (lowWords.Length > 0 &&
+                !integerConverter.TryConvert(lowWords, out low, out unrecognizedNumber))
+            {
+                digits = string.Empty;
+                return false;
+            }
+
+            if (low is < 0 or >= 1_000_000_000_000_000_000L)
+            {
+                digits = string.Empty;
+                unrecognizedNumber = lowWords;
+                return false;
+            }
+
+            digits = string.Concat(
+                high.ToString(CultureInfo.InvariantCulture),
+                low.ToString("D18", CultureInfo.InvariantCulture));
+            unrecognizedNumber = null;
+            return true;
+        }
+        catch (OverflowException)
+        {
+            digits = string.Empty;
+            unrecognizedNumber = words;
+            return false;
+        }
     }
 
     static string? StripNegativePrefix(ref string words)

--- a/src/Humanizer/Localisation/WordsToNumber/EnglishWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/EnglishWordsToDecimalNumberConverter.cs
@@ -1,0 +1,149 @@
+namespace Humanizer;
+
+/// <summary>
+/// Parses English decimal number words while delegating the integer part to the existing
+/// words-to-number converter.
+/// </summary>
+internal sealed class EnglishWordsToDecimalNumberConverter(CultureInfo culture) : IWordsToDecimalNumberConverter
+{
+    const int MaxDecimalScale = 28;
+
+    static readonly Regex DecimalMarker = new(
+        @"(?<!\S)point(?!\S)",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    static readonly FrozenDictionary<string, char> FractionalDigits =
+        new Dictionary<string, char>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["zero"] = '0',
+            ["one"] = '1',
+            ["two"] = '2',
+            ["three"] = '3',
+            ["four"] = '4',
+            ["five"] = '5',
+            ["six"] = '6',
+            ["seven"] = '7',
+            ["eight"] = '8',
+            ["nine"] = '9'
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    readonly IWordsToNumberConverter integerConverter = Configurator.GetWordsToNumberConverter(culture);
+
+    /// <inheritdoc />
+    public decimal Convert(string words)
+    {
+        ArgumentNullException.ThrowIfNull(words);
+
+        if (!TryConvert(words, out var parsedValue, out var unrecognizedNumber))
+        {
+            throw new FormatException($"Unrecognized decimal number word: {unrecognizedNumber}");
+        }
+
+        return parsedValue;
+    }
+
+    /// <inheritdoc />
+    public bool TryConvert(string words, out decimal parsedValue) =>
+        TryConvert(words, out parsedValue, out _);
+
+    /// <inheritdoc />
+    public bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber)
+    {
+        parsedValue = default;
+        unrecognizedNumber = words;
+
+        if (string.IsNullOrWhiteSpace(words))
+        {
+            return false;
+        }
+
+        var markers = DecimalMarker.Matches(words);
+        if (markers.Count != 1)
+        {
+            unrecognizedNumber = markers.Count > 1 ? "point" : words;
+            return false;
+        }
+
+        var marker = markers[0];
+        var integerWords = words[..marker.Index].Trim();
+        var fractionWords = words[(marker.Index + marker.Length)..].Trim();
+        var negativePrefix = StripNegativePrefix(ref integerWords);
+
+        if (fractionWords.Length == 0)
+        {
+            unrecognizedNumber = "point";
+            return false;
+        }
+
+        var integerValue = 0L;
+        if (integerWords.Length > 0 &&
+            !integerConverter.TryConvert(
+                negativePrefix is null ? integerWords : $"{negativePrefix} {integerWords}",
+                out integerValue,
+                out unrecognizedNumber))
+        {
+            return false;
+        }
+
+        var fraction = new StringBuilder();
+        foreach (var token in fractionWords.Split([' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!FractionalDigits.TryGetValue(token, out var digit))
+            {
+                unrecognizedNumber = token;
+                return false;
+            }
+
+            if (fraction.Length == MaxDecimalScale)
+            {
+                unrecognizedNumber = token;
+                return false;
+            }
+
+            fraction.Append(digit);
+        }
+
+        if (fraction.Length == 0)
+        {
+            unrecognizedNumber = "point";
+            return false;
+        }
+
+        var signedInteger = negativePrefix is not null && integerValue == 0
+            ? "-0"
+            : integerValue.ToString(CultureInfo.InvariantCulture);
+        var invariantValue = $"{signedInteger}.{fraction}";
+
+        if (!decimal.TryParse(
+                invariantValue,
+                NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint,
+                CultureInfo.InvariantCulture,
+                out parsedValue) ||
+            (decimal.GetBits(parsedValue)[3] >> 16 & 0x7F) != fraction.Length)
+        {
+            parsedValue = default;
+            unrecognizedNumber = words;
+            return false;
+        }
+
+        unrecognizedNumber = null;
+        return true;
+    }
+
+    static string? StripNegativePrefix(ref string words)
+    {
+        foreach (var prefix in new[] { "minus", "negative" })
+        {
+            if (!words.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ||
+                words.Length > prefix.Length && !char.IsWhiteSpace(words[prefix.Length]))
+            {
+                continue;
+            }
+
+            words = words[prefix.Length..].TrimStart();
+            return prefix;
+        }
+
+        return null;
+    }
+}

--- a/src/Humanizer/Localisation/WordsToNumber/IWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/IWordsToDecimalNumberConverter.cs
@@ -1,0 +1,35 @@
+namespace Humanizer;
+
+/// <summary>
+/// Converts localized decimal number words into <see cref="decimal"/> values.
+/// </summary>
+public interface IWordsToDecimalNumberConverter
+{
+    /// <summary>
+    /// Converts <paramref name="words"/> into a decimal value.
+    /// </summary>
+    /// <param name="words">The localized decimal number phrase to convert.</param>
+    /// <returns>The parsed decimal value.</returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="words"/> is <c>null</c>.</exception>
+    /// <exception cref="FormatException">If <paramref name="words"/> is malformed or outside the supported <see cref="decimal"/> range.</exception>
+    /// <exception cref="NotSupportedException">If decimal word parsing is not supported for the converter's locale.</exception>
+    decimal Convert(string words);
+
+    /// <summary>
+    /// Attempts to convert <paramref name="words"/> into a decimal value.
+    /// </summary>
+    /// <param name="words">The localized decimal number phrase to convert.</param>
+    /// <param name="parsedValue">When this method returns, contains the parsed value if successful; otherwise, zero.</param>
+    /// <returns><c>true</c> if the phrase was parsed successfully; otherwise, <c>false</c>.</returns>
+    bool TryConvert(string words, out decimal parsedValue);
+
+    /// <summary>
+    /// Attempts to convert <paramref name="words"/> into a decimal value and reports the first
+    /// unrecognized token when parsing fails.
+    /// </summary>
+    /// <param name="words">The localized decimal number phrase to convert.</param>
+    /// <param name="parsedValue">When this method returns, contains the parsed value if successful; otherwise, zero.</param>
+    /// <param name="unrecognizedNumber">When parsing fails, the best-effort unrecognized token or phrase.</param>
+    /// <returns><c>true</c> if the phrase was parsed successfully; otherwise, <c>false</c>.</returns>
+    bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+}

--- a/src/Humanizer/Localisation/WordsToNumber/UnsupportedWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/UnsupportedWordsToDecimalNumberConverter.cs
@@ -12,8 +12,11 @@ internal sealed class UnsupportedWordsToDecimalNumberConverter : IWordsToDecimal
     }
 
     /// <inheritdoc />
-    public decimal Convert(string words) =>
+    public decimal Convert(string words)
+    {
+        ArgumentNullException.ThrowIfNull(words);
         throw new NotSupportedException("Decimal word parsing is not supported for the requested culture.");
+    }
 
     /// <inheritdoc />
     public bool TryConvert(string words, out decimal parsedValue)
@@ -26,7 +29,7 @@ internal sealed class UnsupportedWordsToDecimalNumberConverter : IWordsToDecimal
     public bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber)
     {
         parsedValue = default;
-        unrecognizedNumber = words;
+        unrecognizedNumber = words ?? string.Empty;
         return false;
     }
 }

--- a/src/Humanizer/Localisation/WordsToNumber/UnsupportedWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/UnsupportedWordsToDecimalNumberConverter.cs
@@ -1,0 +1,32 @@
+namespace Humanizer;
+
+/// <summary>
+/// Fallback converter used when a locale does not support decimal word parsing.
+/// </summary>
+internal sealed class UnsupportedWordsToDecimalNumberConverter : IWordsToDecimalNumberConverter
+{
+    internal static UnsupportedWordsToDecimalNumberConverter Instance { get; } = new();
+
+    UnsupportedWordsToDecimalNumberConverter()
+    {
+    }
+
+    /// <inheritdoc />
+    public decimal Convert(string words) =>
+        throw new NotSupportedException("Decimal word parsing is not supported for the requested culture.");
+
+    /// <inheritdoc />
+    public bool TryConvert(string words, out decimal parsedValue)
+    {
+        parsedValue = default;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber)
+    {
+        parsedValue = default;
+        unrecognizedNumber = words;
+        return false;
+    }
+}

--- a/src/Humanizer/WordsToDecimalNumberExtension.cs
+++ b/src/Humanizer/WordsToDecimalNumberExtension.cs
@@ -1,0 +1,55 @@
+namespace Humanizer;
+
+/// <summary>
+/// Converts English decimal number words into <see cref="decimal"/> values.
+/// </summary>
+public static class WordsToDecimalNumberExtension
+{
+    /// <summary>
+    /// Converts English decimal number words containing one <c>point</c> marker to a decimal value.
+    /// </summary>
+    /// <param name="words">The decimal number words to convert.</param>
+    /// <param name="culture">The English culture to use for parsing.</param>
+    /// <returns>The parsed decimal value, including its authored fractional scale.</returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="words"/> is <c>null</c>.</exception>
+    /// <exception cref="FormatException">If the phrase is malformed or outside the supported <see cref="decimal"/> range.</exception>
+    /// <exception cref="NotSupportedException">If <paramref name="culture"/> is not an English culture.</exception>
+    /// <remarks>
+    /// The integer part uses the existing English words-to-number grammar. The fractional part
+    /// requires one to 28 digit words (<c>zero</c> through <c>nine</c>); conjunctions are not
+    /// accepted after <c>point</c>. A leading <c>minus</c> or <c>negative</c> applies to the
+    /// complete value. The integer part may be omitted, as in <c>point five</c>.
+    /// A decimal marker and at least one fractional digit word are required.
+    /// </remarks>
+    public static decimal ToDecimalNumber(this string words, CultureInfo culture)
+    {
+        ArgumentNullException.ThrowIfNull(words);
+        return Configurator.GetWordsToDecimalNumberConverter(culture).Convert(words);
+    }
+
+    /// <summary>
+    /// Attempts to convert English decimal number words without throwing for malformed input,
+    /// unsupported cultures, or values outside the supported <see cref="decimal"/> range.
+    /// </summary>
+    /// <param name="words">The decimal number words to convert.</param>
+    /// <param name="parsedNumber">When this method returns, contains the parsed value if successful; otherwise, zero.</param>
+    /// <param name="culture">The English culture to use for parsing.</param>
+    /// <returns><c>true</c> if conversion succeeded; otherwise, <c>false</c>.</returns>
+    public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, CultureInfo culture) =>
+        Configurator.GetWordsToDecimalNumberConverter(culture).TryConvert(words, out parsedNumber);
+
+    /// <summary>
+    /// Attempts to convert English decimal number words and reports the first unrecognized token.
+    /// </summary>
+    /// <param name="words">The decimal number words to convert.</param>
+    /// <param name="parsedNumber">When this method returns, contains the parsed value if successful; otherwise, zero.</param>
+    /// <param name="culture">The English culture to use for parsing.</param>
+    /// <param name="unrecognizedWord">When conversion fails, the best-effort unrecognized token or phrase.</param>
+    /// <returns><c>true</c> if conversion succeeded; otherwise, <c>false</c>.</returns>
+    public static bool TryToDecimalNumber(
+        this string words,
+        out decimal parsedNumber,
+        CultureInfo culture,
+        out string? unrecognizedWord) =>
+        Configurator.GetWordsToDecimalNumberConverter(culture).TryConvert(words, out parsedNumber, out unrecognizedWord);
+}

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -462,6 +462,12 @@ namespace Humanizer
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("value")]
         string? Truncate(string? value, int length, string? truncationString, Humanizer.TruncateFrom truncateFrom = 1);
     }
+    public interface IWordsToDecimalNumberConverter
+    {
+        decimal Convert(string words);
+        bool TryConvert(string words, out decimal parsedValue);
+        bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+    }
     public interface IWordsToNumberConverter
     {
         long Convert(string words);
@@ -2048,6 +2054,12 @@ namespace Humanizer
         Normal = 0,
         Abbreviation = 1,
         Eifeler = 2,
+    }
+    public static class WordsToDecimalNumberExtension
+    {
+        public static decimal ToDecimalNumber(this string words, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
     }
     public static class WordsToNumberExtension
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -462,6 +462,12 @@ namespace Humanizer
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("value")]
         string? Truncate(string? value, int length, string? truncationString, Humanizer.TruncateFrom truncateFrom = 1);
     }
+    public interface IWordsToDecimalNumberConverter
+    {
+        decimal Convert(string words);
+        bool TryConvert(string words, out decimal parsedValue);
+        bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+    }
     public interface IWordsToNumberConverter
     {
         long Convert(string words);
@@ -2048,6 +2054,12 @@ namespace Humanizer
         Normal = 0,
         Abbreviation = 1,
         Eifeler = 2,
+    }
+    public static class WordsToDecimalNumberExtension
+    {
+        public static decimal ToDecimalNumber(this string words, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
     }
     public static class WordsToNumberExtension
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -461,6 +461,12 @@ namespace Humanizer
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("value")]
         string? Truncate(string? value, int length, string? truncationString, Humanizer.TruncateFrom truncateFrom = 1);
     }
+    public interface IWordsToDecimalNumberConverter
+    {
+        decimal Convert(string words);
+        bool TryConvert(string words, out decimal parsedValue);
+        bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+    }
     public interface IWordsToNumberConverter
     {
         long Convert(string words);
@@ -2047,6 +2053,12 @@ namespace Humanizer
         Normal = 0,
         Abbreviation = 1,
         Eifeler = 2,
+    }
+    public static class WordsToDecimalNumberExtension
+    {
+        public static decimal ToDecimalNumber(this string words, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
     }
     public static class WordsToNumberExtension
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -415,6 +415,12 @@ namespace Humanizer
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("value")]
         string? Truncate(string? value, int length, string? truncationString, Humanizer.TruncateFrom truncateFrom = 1);
     }
+    public interface IWordsToDecimalNumberConverter
+    {
+        decimal Convert(string words);
+        bool TryConvert(string words, out decimal parsedValue);
+        bool TryConvert(string words, out decimal parsedValue, out string? unrecognizedNumber);
+    }
     public interface IWordsToNumberConverter
     {
         long Convert(string words);
@@ -1377,6 +1383,12 @@ namespace Humanizer
         Normal = 0,
         Abbreviation = 1,
         Eifeler = 2,
+    }
+    public static class WordsToDecimalNumberExtension
+    {
+        public static decimal ToDecimalNumber(this string words, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture) { }
+        public static bool TryToDecimalNumber(this string words, out decimal parsedNumber, System.Globalization.CultureInfo culture, out string? unrecognizedWord) { }
     }
     public static class WordsToNumberExtension
     {

--- a/tests/Humanizer.Tests/Localisation/en/WordsToDecimalNumberTests.cs
+++ b/tests/Humanizer.Tests/Localisation/en/WordsToDecimalNumberTests.cs
@@ -23,6 +23,14 @@ public class WordsToDecimalNumberTests
         Assert.Equal(expected, parsed.ToString(CultureInfo.InvariantCulture));
     }
 
+    [Fact]
+    public void ParsesLocaleSpecificScaleBeyondLongRange()
+    {
+        var parsed = "ninety-three shankh point one".ToDecimalNumber(new("en-IN"));
+
+        Assert.Equal("9300000000000000000.1", parsed.ToString(CultureInfo.InvariantCulture));
+    }
+
     [Theory]
     [InlineData("one", "one")]
     [InlineData("one point", "point")]

--- a/tests/Humanizer.Tests/Localisation/en/WordsToDecimalNumberTests.cs
+++ b/tests/Humanizer.Tests/Localisation/en/WordsToDecimalNumberTests.cs
@@ -12,6 +12,9 @@ public class WordsToDecimalNumberTests
     [InlineData("minus zero point five", "-0.5")]
     [InlineData("negative point zero five", "-0.05")]
     [InlineData("one hundred and five point zero", "105.0")]
+    [InlineData("ten quintillion point one", "10000000000000000000.1")]
+    [InlineData("ten quintillion one point two", "10000000000000000001.2")]
+    [InlineData("negative ten quintillion point one", "-10000000000000000000.1")]
     [InlineData("point five", "0.5")]
     public void ParsesEnglishDecimalPhrasesAndPreservesScale(string words, string expected)
     {

--- a/tests/Humanizer.Tests/Localisation/en/WordsToDecimalNumberTests.cs
+++ b/tests/Humanizer.Tests/Localisation/en/WordsToDecimalNumberTests.cs
@@ -1,4 +1,4 @@
-namespace Humanizer.Tests;
+namespace Humanizer.Tests.Localisation.en;
 
 [UseCulture("en-US")]
 public class WordsToDecimalNumberTests
@@ -62,6 +62,21 @@ public class WordsToDecimalNumberTests
     }
 
     [Fact]
+    public void DirectConvertersHonorNullInputContract()
+    {
+        var english = new EnglishWordsToDecimalNumberConverter(CultureInfo.CurrentCulture);
+        var unsupported = UnsupportedWordsToDecimalNumberConverter.Instance;
+
+        Assert.False(english.TryConvert(null!, out _, out var englishUnrecognizedNumber));
+        Assert.Equal(string.Empty, englishUnrecognizedNumber);
+        Assert.True(english.TryConvert("one point two", out _, out var recognizedNumber));
+        Assert.Null(recognizedNumber);
+        Assert.False(unsupported.TryConvert(null!, out _, out var unsupportedUnrecognizedNumber));
+        Assert.Equal(string.Empty, unsupportedUnrecognizedNumber);
+        Assert.Throws<ArgumentNullException>(() => unsupported.Convert(null!));
+    }
+
+    [Fact]
     public void RejectsFractionBeyondDecimalScale()
     {
         var words = $"zero point {string.Join(" ", Enumerable.Repeat("one", 29))}";
@@ -90,7 +105,7 @@ public class WordsToDecimalNumberTests
         var parsed = "minus zero point zero".ToDecimalNumber(CultureInfo.CurrentCulture);
         var bits = decimal.GetBits(parsed);
 
-        Assert.Equal(1, bits[3] >> 16 & 0x7F);
+        Assert.Equal(1, bits[3] >> 16 & 0xFF);
         Assert.NotEqual(0, bits[3] & int.MinValue);
     }
 

--- a/tests/Humanizer.Tests/Localisation/en/WordsToDecimalNumberTests.cs
+++ b/tests/Humanizer.Tests/Localisation/en/WordsToDecimalNumberTests.cs
@@ -6,6 +6,7 @@ public class WordsToDecimalNumberTests
     [Theory]
     [InlineData("one point two", "1.2")]
     [InlineData("three point one four", "3.14")]
+    [InlineData("one point two\u00A0three", "1.23")]
     [InlineData("zero point zero five", "0.05")]
     [InlineData("one point five zero", "1.50")]
     [InlineData("minus two point five", "-2.5")]

--- a/tests/Humanizer.Tests/WordsToDecimalNumberTests.cs
+++ b/tests/Humanizer.Tests/WordsToDecimalNumberTests.cs
@@ -1,0 +1,121 @@
+namespace Humanizer.Tests;
+
+[UseCulture("en-US")]
+public class WordsToDecimalNumberTests
+{
+    [Theory]
+    [InlineData("one point two", "1.2")]
+    [InlineData("three point one four", "3.14")]
+    [InlineData("zero point zero five", "0.05")]
+    [InlineData("one point five zero", "1.50")]
+    [InlineData("minus two point five", "-2.5")]
+    [InlineData("minus zero point five", "-0.5")]
+    [InlineData("negative point zero five", "-0.05")]
+    [InlineData("one hundred and five point zero", "105.0")]
+    [InlineData("point five", "0.5")]
+    public void ParsesEnglishDecimalPhrasesAndPreservesScale(string words, string expected)
+    {
+        var parsed = words.ToDecimalNumber(CultureInfo.CurrentCulture);
+
+        Assert.Equal(expected, parsed.ToString(CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
+    [InlineData("one", "one")]
+    [InlineData("one point", "point")]
+    [InlineData("point", "point")]
+    [InlineData("one point two point three", "point")]
+    [InlineData("one point two and three", "and")]
+    [InlineData("one point ten", "ten")]
+    [InlineData("one point 2", "2")]
+    [InlineData("one dot two", "one dot two")]
+    public void RejectsMalformedDecimalPhrases(string words, string expectedUnrecognizedWord)
+    {
+        var success = words.TryToDecimalNumber(
+            out var parsed,
+            CultureInfo.CurrentCulture,
+            out var unrecognizedWord);
+
+        Assert.False(success);
+        Assert.Equal(0m, parsed);
+        Assert.Equal(expectedUnrecognizedWord, unrecognizedWord);
+        Assert.Throws<FormatException>(() => words.ToDecimalNumber(CultureInfo.CurrentCulture));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryToDecimalNumberReturnsFalseForEmptyInput(string words)
+    {
+        Assert.False(words.TryToDecimalNumber(out var parsed, CultureInfo.CurrentCulture));
+        Assert.Equal(0m, parsed);
+    }
+
+    [Fact]
+    public void NullInputUsesTryAndThrowConventions()
+    {
+        string words = null!;
+
+        Assert.False(words.TryToDecimalNumber(out var parsed, CultureInfo.CurrentCulture));
+        Assert.Equal(0m, parsed);
+        Assert.Throws<ArgumentNullException>(() => words.ToDecimalNumber(CultureInfo.CurrentCulture));
+    }
+
+    [Fact]
+    public void RejectsFractionBeyondDecimalScale()
+    {
+        var words = $"zero point {string.Join(" ", Enumerable.Repeat("one", 29))}";
+
+        Assert.False(words.TryToDecimalNumber(
+            out var parsed,
+            CultureInfo.CurrentCulture,
+            out var unrecognizedWord));
+        Assert.Equal(0m, parsed);
+        Assert.Equal("one", unrecognizedWord);
+    }
+
+    [Fact]
+    public void RejectsValueThatCannotPreserveItsAuthoredScale()
+    {
+        var words = $"{long.MaxValue.ToWords(CultureInfo.CurrentCulture)} point one two three four five six seven eight nine zero";
+
+        Assert.False(words.TryToDecimalNumber(out var parsed, CultureInfo.CurrentCulture));
+        Assert.Equal(0m, parsed);
+        Assert.Throws<FormatException>(() => words.ToDecimalNumber(CultureInfo.CurrentCulture));
+    }
+
+    [Fact]
+    public void PreservesNegativeZeroSignAndScale()
+    {
+        var parsed = "minus zero point zero".ToDecimalNumber(CultureInfo.CurrentCulture);
+        var bits = decimal.GetBits(parsed);
+
+        Assert.Equal(1, bits[3] >> 16 & 0x7F);
+        Assert.NotEqual(0, bits[3] & int.MinValue);
+    }
+
+    [Fact]
+    public void UnsupportedCultureUsesTryAndThrowConventions()
+    {
+        var culture = new CultureInfo("fr-FR");
+
+        Assert.False("one point two".TryToDecimalNumber(
+            out var parsed,
+            culture,
+            out var unrecognizedWord));
+        Assert.Equal(0m, parsed);
+        Assert.Equal("one point two", unrecognizedWord);
+        Assert.Throws<NotSupportedException>(() => "one point two".ToDecimalNumber(culture));
+    }
+
+    [Fact]
+    public void IntegerToNumberSemanticsRemainUnchanged()
+    {
+        Assert.False("one point two".TryToNumber(
+            out var parsed,
+            CultureInfo.CurrentCulture,
+            out var unrecognizedWord));
+        Assert.Equal(0L, parsed);
+        Assert.Equal("point", unrecognizedWord);
+    }
+}


### PR DESCRIPTION
## Summary

English decimal number phrases such as `one point two` can now be parsed exactly into `decimal` values without changing the existing `long`-returning `ToNumber` contract. The new API requires one `point`, parses one to 28 fractional digit words, preserves leading/trailing zero scale and negative zero, and returns a clean Try failure for malformed, overflowing, or non-English input.

This is intentionally the English MVP: Spanish, Portuguese, Hindi, Urdu, the decimal-to-words direction, and `double` parsing remain out of scope. The implementation reuses the API direction and valuable review work from #1796; thank you to @wyf027, whose authorship is preserved in the commit trailers.

Fixes #1739

## Validation

- `dotnet artifacts/bin/Humanizer.Tests/debug_net8.0/Humanizer.Tests.dll` — 57,698 passed
- `dotnet artifacts/bin/Humanizer.Tests/debug_net10.0/Humanizer.Tests.dll` — 57,698 passed
- `dotnet artifacts/bin/Humanizer.Tests/debug_net11.0/Humanizer.Tests.dll` — 57,698 passed
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity minimal`
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp> -m:1`
- .NET Framework 4.8 runtime tests skipped on Linux; the Release pack built the `net48` target successfully.

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] Reused contributor work is disclosed and credited
- [x] There are very few or no comments
- [x] XML documentation is added for the public API
- [x] The PR is rebased on the latest `main`
- [x] The fixed issue is linked with `Fixes #1739`
- [x] Readme and quick-start documentation are updated
- [x] Supported .NET test suites and package build pass
