### PR TITLE
feat: parse invariant TimeSpan durations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -364,6 +364,16 @@ TimeSpan.FromDays(750).ToAge() => "2 years old"
 TimeSpan.FromDays(750).ToAge() => "2 ans"
 ```
 
+### Dehumanize TimeSpan
+
+Standard invariant `TimeSpan` text and compact duration tokens can be parsed with `DehumanizeTimeSpan` or `TryDehumanizeTimeSpan`:
+
+```csharp
+"3h18m".DehumanizeTimeSpan() => TimeSpan.FromHours(3) + TimeSpan.FromMinutes(18)
+"1.5w 2d".TryDehumanizeTimeSpan(out var duration) => true
+```
+
+Compact parsing accepts the invariant symbols `ms`, `s`, `m`, `h`, `d`, and `w`, with one week equal to seven days. Colon-separated values use the standard invariant `TimeSpan` interpretation. Localized phrases, number words, months, and years are not supported.
 
 ### Humanize Collections
 

--- a/src/Humanizer/TimeSpanDehumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeExtensions.cs
@@ -28,9 +28,7 @@ public static class TimeSpanDehumanizeExtensions
         ArgumentNullException.ThrowIfNull(input);
 
         if (TryDehumanizeTimeSpan(input, out var result))
-        {
             return result;
-        }
 
         throw new FormatException("Value is not a supported TimeSpan format.");
     }
@@ -52,14 +50,10 @@ public static class TimeSpanDehumanizeExtensions
     {
         result = default;
         if (input is null)
-        {
             return false;
-        }
 
         if (TimeSpan.TryParse(input, CultureInfo.InvariantCulture, out result))
-        {
             return true;
-        }
 
         return TryParseCompact(input, out result);
     }
@@ -105,21 +99,15 @@ public static class TimeSpanDehumanizeExtensions
             }
 
             if (digitCount == 0)
-            {
                 return false;
-            }
 
             var numberEnd = index;
             SkipWhitespace(input, ref index);
             if (!TryReadUnit(input, ref index, out var ticksPerUnit))
-            {
                 return false;
-            }
 
             if (!TryGetExactTicks(input, numberStart, numberEnd, fractionStart, ticksPerUnit, out var tokenTicks))
-            {
                 return false;
-            }
 
             ticks += tokenTicks;
             parsedToken = true;
@@ -128,9 +116,7 @@ public static class TimeSpanDehumanizeExtensions
 
         var limit = negative ? NegativeTickLimit : new BigInteger(long.MaxValue);
         if (!parsedToken || ticks > limit)
-        {
             return false;
-        }
 
         if (negative && ticks == NegativeTickLimit)
         {
@@ -147,9 +133,7 @@ public static class TimeSpanDehumanizeExtensions
     {
         ticksPerUnit = 0;
         if (index >= input.Length)
-        {
             return false;
-        }
 
         switch (input[index++])
         {
@@ -204,9 +188,7 @@ public static class TimeSpanDehumanizeExtensions
         }
 
         if (fractionStart >= 0 && normalizedEnd - fractionStart > 28)
-        {
             return false;
-        }
 
         BigInteger coefficient = 0;
         var significantDigits = 0;
@@ -215,15 +197,11 @@ public static class TimeSpanDehumanizeExtensions
         {
             var value = input[index];
             if (value == '.')
-            {
                 continue;
-            }
 
             foundNonZero |= value != '0';
             if (foundNonZero && ++significantDigits > 28)
-            {
                 return false;
-            }
 
             coefficient = coefficient * 10 + (value - '0');
         }

--- a/src/Humanizer/TimeSpanDehumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeExtensions.cs
@@ -99,6 +99,9 @@ public static class TimeSpanDehumanizeExtensions
                     index++;
                     digitCount++;
                 }
+
+                if (fractionStart == index)
+                    return false;
             }
 
             if (digitCount == 0)

--- a/src/Humanizer/TimeSpanDehumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanDehumanizeExtensions.cs
@@ -1,0 +1,235 @@
+using System.Numerics;
+
+namespace Humanizer;
+
+/// <summary>
+/// Contains extension methods for parsing invariant duration text into a <see cref="TimeSpan"/>.
+/// </summary>
+public static class TimeSpanDehumanizeExtensions
+{
+    static readonly BigInteger NegativeTickLimit = BigInteger.One << 63;
+
+    /// <summary>
+    /// Parses a standard invariant <see cref="TimeSpan"/> value or compact duration tokens using
+    /// <c>ms</c>, <c>s</c>, <c>m</c>, <c>h</c>, <c>d</c>, and <c>w</c>.
+    /// </summary>
+    /// <param name="input">The duration text to parse.</param>
+    /// <returns>The parsed duration.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="input"/> is null.</exception>
+    /// <exception cref="FormatException">Thrown when <paramref name="input"/> is not a supported duration.</exception>
+    /// <remarks>
+    /// Compact tokens are culture-invariant, may be separated by whitespace, and may have one leading sign.
+    /// Units may repeat and appear in any order; their values are added. Each token must resolve to whole ticks.
+    /// A week is seven days.
+    /// Colon-separated values use the standard invariant <see cref="TimeSpan"/> interpretation.
+    /// </remarks>
+    public static TimeSpan DehumanizeTimeSpan(this string input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        if (TryDehumanizeTimeSpan(input, out var result))
+        {
+            return result;
+        }
+
+        throw new FormatException("Value is not a supported TimeSpan format.");
+    }
+
+    /// <summary>
+    /// Tries to parse a standard invariant <see cref="TimeSpan"/> value or compact duration tokens using
+    /// <c>ms</c>, <c>s</c>, <c>m</c>, <c>h</c>, <c>d</c>, and <c>w</c>.
+    /// </summary>
+    /// <param name="input">The duration text to parse.</param>
+    /// <param name="result">The parsed duration, or <see cref="TimeSpan.Zero"/> when parsing fails.</param>
+    /// <returns><see langword="true"/> when parsing succeeds; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// Compact tokens are culture-invariant, may be separated by whitespace, and may have one leading sign.
+    /// Units may repeat and appear in any order; their values are added. Each token must resolve to whole ticks.
+    /// A week is seven days.
+    /// Colon-separated values use the standard invariant <see cref="TimeSpan"/> interpretation.
+    /// </remarks>
+    public static bool TryDehumanizeTimeSpan(this string? input, out TimeSpan result)
+    {
+        result = default;
+        if (input is null)
+        {
+            return false;
+        }
+
+        if (TimeSpan.TryParse(input, CultureInfo.InvariantCulture, out result))
+        {
+            return true;
+        }
+
+        return TryParseCompact(input, out result);
+    }
+
+    static bool TryParseCompact(string input, out TimeSpan result)
+    {
+        result = default;
+        var index = 0;
+        SkipWhitespace(input, ref index);
+
+        var negative = false;
+        if (index < input.Length && input[index] is '+' or '-')
+        {
+            negative = input[index++] == '-';
+            SkipWhitespace(input, ref index);
+        }
+
+        var parsedToken = false;
+        BigInteger ticks = 0;
+        while (index < input.Length)
+        {
+            var numberStart = index;
+            var digitCount = 0;
+            var fractionStart = -1;
+            while (index < input.Length && IsAsciiDigit(input[index]))
+            {
+                index++;
+                digitCount++;
+            }
+
+            if (index < input.Length && input[index] == '.')
+            {
+                index++;
+                fractionStart = index;
+                while (index < input.Length && IsAsciiDigit(input[index]))
+                {
+                    index++;
+                    digitCount++;
+                }
+            }
+
+            if (digitCount == 0)
+            {
+                return false;
+            }
+
+            var numberEnd = index;
+            SkipWhitespace(input, ref index);
+            if (!TryReadUnit(input, ref index, out var ticksPerUnit))
+            {
+                return false;
+            }
+
+            if (!TryGetExactTicks(input, numberStart, numberEnd, fractionStart, ticksPerUnit, out var tokenTicks))
+            {
+                return false;
+            }
+
+            ticks += tokenTicks;
+            parsedToken = true;
+            SkipWhitespace(input, ref index);
+        }
+
+        var limit = negative ? NegativeTickLimit : new BigInteger(long.MaxValue);
+        if (!parsedToken || ticks > limit)
+        {
+            return false;
+        }
+
+        if (negative && ticks == NegativeTickLimit)
+        {
+            result = TimeSpan.MinValue;
+            return true;
+        }
+
+        var signedTicks = (long)ticks;
+        result = TimeSpan.FromTicks(negative ? -signedTicks : signedTicks);
+        return true;
+    }
+
+    static bool TryReadUnit(string input, ref int index, out long ticksPerUnit)
+    {
+        ticksPerUnit = 0;
+        if (index >= input.Length)
+        {
+            return false;
+        }
+
+        switch (input[index++])
+        {
+            case 'm' when index < input.Length && input[index] == 's':
+                index++;
+                ticksPerUnit = TimeSpan.TicksPerMillisecond;
+                return true;
+            case 's':
+                ticksPerUnit = TimeSpan.TicksPerSecond;
+                return true;
+            case 'm':
+                ticksPerUnit = TimeSpan.TicksPerMinute;
+                return true;
+            case 'h':
+                ticksPerUnit = TimeSpan.TicksPerHour;
+                return true;
+            case 'd':
+                ticksPerUnit = TimeSpan.TicksPerDay;
+                return true;
+            case 'w':
+                ticksPerUnit = 7 * TimeSpan.TicksPerDay;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    static void SkipWhitespace(string input, ref int index)
+    {
+        while (index < input.Length && char.IsWhiteSpace(input[index]))
+        {
+            index++;
+        }
+    }
+
+    static bool IsAsciiDigit(char value) =>
+        value is >= '0' and <= '9';
+
+    static bool TryGetExactTicks(
+        string input,
+        int start,
+        int end,
+        int fractionStart,
+        long ticksPerUnit,
+        out BigInteger ticks)
+    {
+        ticks = 0;
+        var normalizedEnd = end;
+        while (fractionStart >= 0 && normalizedEnd > fractionStart && input[normalizedEnd - 1] == '0')
+        {
+            normalizedEnd--;
+        }
+
+        if (fractionStart >= 0 && normalizedEnd - fractionStart > 28)
+        {
+            return false;
+        }
+
+        BigInteger coefficient = 0;
+        var significantDigits = 0;
+        var foundNonZero = false;
+        for (var index = start; index < normalizedEnd; index++)
+        {
+            var value = input[index];
+            if (value == '.')
+            {
+                continue;
+            }
+
+            foundNonZero |= value != '0';
+            if (foundNonZero && ++significantDigits > 28)
+            {
+                return false;
+            }
+
+            coefficient = coefficient * 10 + (value - '0');
+        }
+
+        var scale = fractionStart < 0 ? 0 : normalizedEnd - fractionStart;
+        ticks = BigInteger.DivRem(
+            coefficient * ticksPerUnit,
+            BigInteger.Pow(10, scale),
+            out var remainder);
+        return remainder.IsZero;
+    }
+}

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -1926,6 +1926,11 @@ namespace Humanizer
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive = 0) { }
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive, System.Globalization.CultureInfo culture) { }
     }
+    public static class TimeSpanDehumanizeExtensions
+    {
+        public static System.TimeSpan DehumanizeTimeSpan(this string input) { }
+        public static bool TryDehumanizeTimeSpan(this string? input, out System.TimeSpan result) { }
+    }
     public static class TimeSpanHumanizeExtensions
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -1926,6 +1926,11 @@ namespace Humanizer
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive = 0) { }
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive, System.Globalization.CultureInfo culture) { }
     }
+    public static class TimeSpanDehumanizeExtensions
+    {
+        public static System.TimeSpan DehumanizeTimeSpan(this string input) { }
+        public static bool TryDehumanizeTimeSpan(this string? input, out System.TimeSpan result) { }
+    }
     public static class TimeSpanHumanizeExtensions
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -1925,6 +1925,11 @@ namespace Humanizer
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive = 0) { }
         public static string ToClockNotation(this System.TimeOnly input, Humanizer.ClockNotationRounding roundToNearestFive, System.Globalization.CultureInfo culture) { }
     }
+    public static class TimeSpanDehumanizeExtensions
+    {
+        public static System.TimeSpan DehumanizeTimeSpan(this string input) { }
+        public static bool TryDehumanizeTimeSpan(this string? input, out System.TimeSpan result) { }
+    }
     public static class TimeSpanHumanizeExtensions
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -1255,6 +1255,11 @@ namespace Humanizer
         Future = 0,
         Past = 1,
     }
+    public static class TimeSpanDehumanizeExtensions
+    {
+        public static System.TimeSpan DehumanizeTimeSpan(this string input) { }
+        public static bool TryDehumanizeTimeSpan(this string? input, out System.TimeSpan result) { }
+    }
     public static class TimeSpanHumanizeExtensions
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }

--- a/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
@@ -1,0 +1,94 @@
+public class TimeSpanDehumanizeTests
+{
+    [Theory]
+    [InlineData("50ms", 500000)]
+    [InlineData("1.5s", 15000000)]
+    [InlineData(".5m", 300000000)]
+    [InlineData("2h", 72000000000)]
+    [InlineData("1d", 864000000000)]
+    [InlineData("1w", 6048000000000)]
+    [InlineData("1h30m15.25s", 54152500000)]
+    [InlineData("  - 1 h 30 m  ", -54000000000)]
+    [InlineData("+1h", 36000000000)]
+    [InlineData("1s 2h 1s", 72020000000)]
+    [InlineData("-922337203685477.5808ms", long.MinValue)]
+    public void ParsesCompactDurations(string input, long expectedTicks) =>
+        Assert.Equal(TimeSpan.FromTicks(expectedTicks), input.DehumanizeTimeSpan());
+
+    [Theory]
+    [InlineData("15:10", 546000000000)]
+    [InlineData("00:15:10", 9100000000)]
+    [InlineData("1.02:03:04.0050060", 937840050060)]
+    public void UsesStandardTimeSpanInterpretation(string input, long expectedTicks) =>
+        Assert.Equal(TimeSpan.FromTicks(expectedTicks), input.DehumanizeTimeSpan());
+
+    [Fact]
+    public void StandardTimeSpanRoundTrips()
+    {
+        TimeSpan[] values =
+        [
+            TimeSpan.Zero,
+            new(1, 2, 3, 4, 5, 6),
+            TimeSpan.FromTicks(-123456789),
+            TimeSpan.MaxValue,
+            TimeSpan.MinValue
+        ];
+
+        foreach (var value in values)
+        {
+            var text = value.ToString("c", CultureInfo.InvariantCulture);
+            Assert.Equal(value, text.DehumanizeTimeSpan());
+        }
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("1.00000001ms")]
+    [InlineData("1,5h")]
+    [InlineData("1e3s")]
+    [InlineData("1M")]
+    [InlineData("1mo")]
+    [InlineData("1y")]
+    [InlineData("1 hour")]
+    [InlineData("one hour")]
+    [InlineData("1h, 2m")]
+    [InlineData("1h-2m")]
+    [InlineData("--1h")]
+    [InlineData("9223372036854775808s")]
+    [InlineData("922337203685477.5808ms")]
+    [InlineData("0.00000010000000000000000000001s")]
+    [InlineData("0.00000000000000000000000000001ms")]
+    [InlineData("922337203685.47758070000000000001s")]
+    [InlineData("-922337203685.47758080000000000001s")]
+    [InlineData("922337203685.4775807s 0.0000000000000000000000000001s")]
+    [InlineData("-922337203685.4775808s 0.0000000000000000000000000001s")]
+    [InlineData("999999.999999999994708994709w")]
+    [InlineData("-999999.999999999994708994709w")]
+    [InlineData("9999999.99999999997337962963d")]
+    public void RejectsUnsupportedDurations(string input)
+    {
+        Assert.False(input.TryDehumanizeTimeSpan(out var result));
+        Assert.Equal(default, result);
+        Assert.Throws<FormatException>(() => input.DehumanizeTimeSpan());
+    }
+
+    [Fact]
+    public void TryReturnsFalseForNull()
+    {
+        Assert.False(((string?)null).TryDehumanizeTimeSpan(out var result));
+        Assert.Equal(default, result);
+    }
+
+    [Fact]
+    public void ThrowingApiRejectsNull() =>
+        Assert.Throws<ArgumentNullException>(() => ((string)null!).DehumanizeTimeSpan());
+
+    [Fact]
+    [UseCulture("de-DE")]
+    public void CompactDecimalsAreInvariant()
+    {
+        Assert.Equal(TimeSpan.FromMinutes(90), "1.5h".DehumanizeTimeSpan());
+        Assert.False("1,5h".TryDehumanizeTimeSpan(out _));
+    }
+}

--- a/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanDehumanizeTests.cs
@@ -28,7 +28,7 @@ public class TimeSpanDehumanizeTests
         TimeSpan[] values =
         [
             TimeSpan.Zero,
-            new(1, 2, 3, 4, 5, 6),
+            new(1, 2, 3, 4, 5),
             TimeSpan.FromTicks(-123456789),
             TimeSpan.MaxValue,
             TimeSpan.MinValue
@@ -44,6 +44,8 @@ public class TimeSpanDehumanizeTests
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
+    [InlineData("1.h")]
+    [InlineData("1.ms")]
     [InlineData("1.00000001ms")]
     [InlineData("1,5h")]
     [InlineData("1e3s")]


### PR DESCRIPTION
## Summary

Applications can now parse standard invariant `TimeSpan` text and compact durations such as `3h18m` or `1.5w 2d` through throwing and `Try` APIs. Standard colon forms retain the BCL's invariant interpretation; compact parsing accepts only `ms`, `s`, `m`, `h`, `d`, and `w`, applies one leading sign to the whole duration, and uses exact tick arithmetic at overflow boundaries.

This first slice deliberately excludes alternate colon interpretations, localized phrases, number words, months, and years. Thanks to @pengowray for the original report and use cases, and to @wyf027 for the implementation exploration in #1800 and #1801 that informed the compatible API names and edge-case coverage.

## Validation

- Focused `TimeSpanDehumanizeTests` on net10.0: 44 passed
- Full `Humanizer.Tests` suite on net8.0, net10.0, and net11.0: 57,717 passed on each target
- Release pack across netstandard2.0, net48, net8.0, net10.0, and net11.0: succeeded without warnings
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity minimal --no-restore`: passed
- Independent 25,000-case exact-arithmetic fuzz comparison: no mismatches
- Linux cannot execute net48 tests; Windows CI remains authoritative for net48 compilation and test execution

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or another OSS implementation
- [x] Comments are limited to XML documentation
- [x] XML documentation is included for the new public APIs
- [x] Rebased on the latest `main`
- [x] README documents the supported contract
- [x] Repository tests and release packing pass

Fixes #691
