### PR TITLE
feat: add supported culture check

### DIFF
--- a/docs/localization.md
+++ b/docs/localization.md
@@ -36,6 +36,16 @@ date.Humanize(culture: new CultureInfo("es"));
 1234.ToNumber(new CultureInfo("es"));
 ```
 
+To choose a fallback before humanizing, check whether the culture or one of its named parents has a complete generated Humanizer locale. This does not report support solely because Humanizer can use its default English fallback:
+
+```csharp
+var culture = new CultureInfo("fr-FR");
+if (Configurator.IsCultureSupported(culture))
+{
+    return date.Humanize(culture: culture);
+}
+```
+
 ## Grammatical Features
 
 Some languages require additional grammatical information:

--- a/src/Humanizer.SourceGenerators/Generators/LocaleRegistryInput.cs
+++ b/src/Humanizer.SourceGenerators/Generators/LocaleRegistryInput.cs
@@ -142,7 +142,62 @@ public sealed partial class HumanizerSourceGenerator
                 context.AddSource(helperName + ".g.cs", SourceText.From(builder.ToString(), Encoding.UTF8));
             }
 
+            EmitSupportedCultureApi(context);
             EmitNumberFormattingOverrides(context);
+        }
+
+        void EmitSupportedCultureApi(SourceProductionContext context)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("using System;");
+            builder.AppendLine("using System.Collections.Generic;");
+            builder.AppendLine("using System.Globalization;");
+            builder.AppendLine();
+            builder.AppendLine("namespace Humanizer;");
+            builder.AppendLine();
+            builder.AppendLine("public static partial class Configurator");
+            builder.AppendLine("{");
+            builder.AppendLine("    /// <summary>");
+            builder.AppendLine("    /// Determines whether Humanizer includes complete generated locale support for the specified culture.");
+            builder.AppendLine("    /// </summary>");
+            builder.AppendLine("    /// <param name=\"culture\">The culture to check.</param>");
+            builder.AppendLine("    /// <returns><see langword=\"true\"/> when the culture or one of its named parents has generated locale support; otherwise, <see langword=\"false\"/>.</returns>");
+            builder.AppendLine("    /// <remarks>");
+            builder.AppendLine("    /// This considers parent-culture fallback, but does not report support merely because Humanizer can fall back to its default English localizers.");
+            builder.AppendLine("    /// </remarks>");
+            builder.AppendLine("    /// <exception cref=\"ArgumentNullException\">Thrown when <paramref name=\"culture\"/> is <c>null</c>.</exception>");
+            builder.AppendLine("    public static bool IsCultureSupported(CultureInfo culture)");
+            builder.AppendLine("    {");
+            builder.AppendLine("        if (culture is null)");
+            builder.AppendLine("        {");
+            builder.AppendLine("            throw new ArgumentNullException(nameof(culture));");
+            builder.AppendLine("        }");
+            builder.AppendLine();
+            builder.AppendLine("        for (var current = culture; !string.IsNullOrEmpty(current.Name); current = current.Parent)");
+            builder.AppendLine("        {");
+            builder.AppendLine("            if (SupportedLocaleCodes.Contains(current.Name))");
+            builder.AppendLine("            {");
+            builder.AppendLine("                return true;");
+            builder.AppendLine("            }");
+            builder.AppendLine("        }");
+            builder.AppendLine();
+            builder.AppendLine("        return false;");
+            builder.AppendLine("    }");
+            builder.AppendLine();
+            builder.AppendLine("    static readonly HashSet<string> SupportedLocaleCodes = new(StringComparer.OrdinalIgnoreCase)");
+            builder.AppendLine("    {");
+
+            foreach (var locale in locales.OrderBy(static locale => locale.LocaleCode, StringComparer.Ordinal))
+            {
+                builder.Append("        \"");
+                builder.Append(locale.LocaleCode);
+                builder.AppendLine("\",");
+            }
+
+            builder.AppendLine("    };");
+            builder.AppendLine("}");
+
+            context.AddSource("Configurator.SupportedCultures.g.cs", SourceText.From(builder.ToString(), Encoding.UTF8));
         }
 
         void EmitNumberFormattingOverrides(SourceProductionContext context)

--- a/src/Humanizer/Configuration/Configurator.cs
+++ b/src/Humanizer/Configuration/Configurator.cs
@@ -3,7 +3,7 @@ namespace Humanizer;
 /// <summary>
 /// Provides a configuration point for Humanizer
 /// </summary>
-public static class Configurator
+public static partial class Configurator
 {
     /// <summary>
     /// A registry of formatters used to format collections based on the current locale

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -220,6 +220,7 @@ namespace Humanizer
         public static Humanizer.LocaliserRegistry<Humanizer.IOrdinalizer> Ordinalizers { get; }
         public static Humanizer.ITimeOnlyHumanizeStrategy TimeOnlyHumanizeStrategy { get; set; }
         public static Humanizer.LocaliserRegistry<Humanizer.ITimeOnlyToClockNotationConverter> TimeOnlyToClockNotationConverters { get; }
+        public static bool IsCultureSupported(System.Globalization.CultureInfo culture) { }
         public static void UseEnumDescriptionPropertyLocator(System.Func<System.Reflection.PropertyInfo, bool> func) { }
     }
     public enum DataUnit

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -220,6 +220,7 @@ namespace Humanizer
         public static Humanizer.LocaliserRegistry<Humanizer.IOrdinalizer> Ordinalizers { get; }
         public static Humanizer.ITimeOnlyHumanizeStrategy TimeOnlyHumanizeStrategy { get; set; }
         public static Humanizer.LocaliserRegistry<Humanizer.ITimeOnlyToClockNotationConverter> TimeOnlyToClockNotationConverters { get; }
+        public static bool IsCultureSupported(System.Globalization.CultureInfo culture) { }
         public static void UseEnumDescriptionPropertyLocator(System.Func<System.Reflection.PropertyInfo, bool> func) { }
     }
     public enum DataUnit

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -219,6 +219,7 @@ namespace Humanizer
         public static Humanizer.LocaliserRegistry<Humanizer.IOrdinalizer> Ordinalizers { get; }
         public static Humanizer.ITimeOnlyHumanizeStrategy TimeOnlyHumanizeStrategy { get; set; }
         public static Humanizer.LocaliserRegistry<Humanizer.ITimeOnlyToClockNotationConverter> TimeOnlyToClockNotationConverters { get; }
+        public static bool IsCultureSupported(System.Globalization.CultureInfo culture) { }
         public static void UseEnumDescriptionPropertyLocator(System.Func<System.Reflection.PropertyInfo, bool> func) { }
     }
     public enum DataUnit

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -214,6 +214,7 @@ namespace Humanizer
         public static Humanizer.LocaliserRegistry<Humanizer.IFormatter> Formatters { get; }
         public static Humanizer.LocaliserRegistry<Humanizer.INumberToWordsConverter> NumberToWordsConverters { get; }
         public static Humanizer.LocaliserRegistry<Humanizer.IOrdinalizer> Ordinalizers { get; }
+        public static bool IsCultureSupported(System.Globalization.CultureInfo culture) { }
         public static void UseEnumDescriptionPropertyLocator(System.Func<System.Reflection.PropertyInfo, bool> func) { }
     }
     public enum DataUnit

--- a/tests/Humanizer.Tests/Localisation/SupportedCultureTests.cs
+++ b/tests/Humanizer.Tests/Localisation/SupportedCultureTests.cs
@@ -1,0 +1,36 @@
+namespace Humanizer.Tests.Localisation;
+
+public class SupportedCultureTests
+{
+    [Fact]
+    public void IsCultureSupportedReturnsTrueForGeneratedLocale()
+    {
+        Assert.True(Configurator.IsCultureSupported(new CultureInfo("fr")));
+    }
+
+    [Fact]
+    public void IsCultureSupportedReturnsTrueWhenParentHasGeneratedLocaleSupport()
+    {
+        Assert.True(Configurator.IsCultureSupported(new CultureInfo("fr-FR")));
+    }
+
+    [Theory]
+    [MemberData(nameof(UnsupportedCultures))]
+    public void IsCultureSupportedReturnsFalseWithoutGeneratedLocaleSupport(CultureInfo culture)
+    {
+        Assert.False(Configurator.IsCultureSupported(culture));
+    }
+
+    [Fact]
+    public void IsCultureSupportedThrowsForNullCulture()
+    {
+        Assert.Throws<ArgumentNullException>(() => Configurator.IsCultureSupported(null!));
+    }
+
+    public static TheoryData<CultureInfo> UnsupportedCultures =>
+        new()
+        {
+            CultureInfo.InvariantCulture,
+            new CultureInfo("eo")
+        };
+}


### PR DESCRIPTION
## Summary

Applications can now distinguish a generated Humanizer locale from fallback behavior before formatting. `Configurator.IsCultureSupported` follows named parent cultures, rejects invariant and unsupported cultures, and does not count default-English resolution as support.

Fixes #1257

## Validation

- [x] Focused `SupportedCultureTests` and public-API approval checks passed on net8.0, net10.0, and net11.0
- [x] Source-generator suite passed (86 tests)
- [x] `dotnet format Humanizer.slnx --verify-no-changes --verbosity minimal`
- [x] `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o /tmp/humanizer-supported-cultures-pack --no-restore`
- [ ] Full target matrix is serialized with the delivery monitor

Here is a checklist you should tick through before submitting a pull request:

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or OSS
- [x] XML documentation is added for the public API
- [x] The PR is rebased on the latest `main`
- [x] The issue is linked above
- [x] Localization documentation is updated
