### PR TITLE
feat: add compact TimeSpan symbol output

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -353,6 +353,11 @@ If words are preferred to numbers, a `toWords: true` parameter can be set to con
 TimeSpan.FromMilliseconds(1299630020).Humanize(3, toWords: true) => "two weeks, one day, one hour"
 ```
 
+For compact output, `HumanizeToSymbols` uses the existing localized `TimeUnit` symbols:
+```csharp
+TimeSpan.FromMilliseconds(1299630020).HumanizeToSymbols(precision: 5) => "2week, 1d, 1h, 30s, 20ms"
+```
+
 By calling `ToAge`, a `TimeSpan` can also be expressed as an age.
 For cultures that do not define an age expression, the result will be the same as calling `Humanize` _(but with a default `maxUnit` equal to `TimeUnit.Year`)_. 
 

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -28,7 +28,7 @@ public static class TimeSpanHumanizeExtensions
     /// </summary>
     /// <param name="timeSpan">The time span to humanize.</param>
     /// <param name="precision">The maximum number of time units to return.</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="maxUnit">The maximum unit of time to output. The default value is <see cref="TimeUnit.Week"/>.</param>
     /// <param name="minUnit">The minimum unit of time to output.</param>
     /// <param name="collectionSeparator">The separator to use when combining humanized time parts. If null, the default collection formatter for the current culture is used.</param>
@@ -60,7 +60,7 @@ public static class TimeSpanHumanizeExtensions
     /// <param name="timeSpan">The time span to humanize.</param>
     /// <param name="precision">The maximum number of time units to return.</param>
     /// <param name="countEmptyUnits">Controls whether empty time units should be counted towards the maximum number of time units. Leading empty time units never count.</param>
-    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
     /// <param name="maxUnit">The maximum unit of time to output. The default value is <see cref="TimeUnit.Week"/>.</param>
     /// <param name="minUnit">The minimum unit of time to output.</param>
     /// <param name="collectionSeparator">The separator to use when combining humanized time parts. If null, the default collection formatter for the current culture is used.</param>
@@ -300,7 +300,7 @@ public static class TimeSpanHumanizeExtensions
         bool toWords,
         bool toSymbols) =>
         toSymbols
-            ? string.Concat(amount.ToString(culture ?? CultureInfo.CurrentUICulture), cultureFormatter.TimeUnitHumanize(timeUnit))
+            ? string.Concat(amount.ToString(culture ?? CultureInfo.CurrentCulture), cultureFormatter.TimeUnitHumanize(timeUnit))
             : cultureFormatter.TimeSpanHumanize(timeUnit, amount, toWords);
 
     static string HumanizeSinglePart(TimeSpan timeSpan, CultureInfo? culture, TimeUnit maxUnit, TimeUnit minUnit, bool toWords, bool toSymbols)

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -24,6 +24,24 @@ public static class TimeSpanHumanizeExtensions
         Humanize(timeSpan, precision, false, culture, maxUnit, minUnit, collectionSeparator, toWords);
 
     /// <summary>
+    /// Turns a <see cref="TimeSpan"/> into a human readable form using localized unit symbols.
+    /// </summary>
+    /// <param name="timeSpan">The time span to humanize.</param>
+    /// <param name="precision">The maximum number of time units to return.</param>
+    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="maxUnit">The maximum unit of time to output. The default value is <see cref="TimeUnit.Week"/>.</param>
+    /// <param name="minUnit">The minimum unit of time to output.</param>
+    /// <param name="collectionSeparator">The separator to use when combining humanized time parts. If null, the default collection formatter for the current culture is used.</param>
+    public static string HumanizeToSymbols(
+        this TimeSpan timeSpan,
+        int precision = 1,
+        CultureInfo? culture = null,
+        TimeUnit maxUnit = TimeUnit.Week,
+        TimeUnit minUnit = TimeUnit.Millisecond,
+        string? collectionSeparator = ", ") =>
+        Humanize(timeSpan, precision, false, culture, maxUnit, minUnit, collectionSeparator, false, true);
+
+    /// <summary>
     /// Turns a TimeSpan into a human readable form. E.g. 1 day.
     /// </summary>
     /// <param name="precision">The maximum number of time units to return.</param>
@@ -34,13 +52,45 @@ public static class TimeSpanHumanizeExtensions
     /// <param name="collectionSeparator">The separator to use when combining humanized time parts. If null, the default collection formatter for the current culture is used.</param>
     /// <param name="toWords">Uses words instead of numbers if true. E.g. one day.</param>
     public static string Humanize(this TimeSpan timeSpan, int precision, bool countEmptyUnits, CultureInfo? culture = null, TimeUnit maxUnit = TimeUnit.Week, TimeUnit minUnit = TimeUnit.Millisecond, string? collectionSeparator = ", ", bool toWords = false)
+        => Humanize(timeSpan, precision, countEmptyUnits, culture, maxUnit, minUnit, collectionSeparator, toWords, false);
+
+    /// <summary>
+    /// Turns a <see cref="TimeSpan"/> into a human readable form using localized unit symbols.
+    /// </summary>
+    /// <param name="timeSpan">The time span to humanize.</param>
+    /// <param name="precision">The maximum number of time units to return.</param>
+    /// <param name="countEmptyUnits">Controls whether empty time units should be counted towards the maximum number of time units. Leading empty time units never count.</param>
+    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+    /// <param name="maxUnit">The maximum unit of time to output. The default value is <see cref="TimeUnit.Week"/>.</param>
+    /// <param name="minUnit">The minimum unit of time to output.</param>
+    /// <param name="collectionSeparator">The separator to use when combining humanized time parts. If null, the default collection formatter for the current culture is used.</param>
+    public static string HumanizeToSymbols(
+        this TimeSpan timeSpan,
+        int precision,
+        bool countEmptyUnits,
+        CultureInfo? culture = null,
+        TimeUnit maxUnit = TimeUnit.Week,
+        TimeUnit minUnit = TimeUnit.Millisecond,
+        string? collectionSeparator = ", ") =>
+        Humanize(timeSpan, precision, countEmptyUnits, culture, maxUnit, minUnit, collectionSeparator, false, true);
+
+    static string Humanize(
+        TimeSpan timeSpan,
+        int precision,
+        bool countEmptyUnits,
+        CultureInfo? culture,
+        TimeUnit maxUnit,
+        TimeUnit minUnit,
+        string? collectionSeparator,
+        bool toWords,
+        bool toSymbols)
     {
         if (precision == 1 && !countEmptyUnits)
         {
-            return HumanizeSinglePart(timeSpan, culture, maxUnit, minUnit, toWords);
+            return HumanizeSinglePart(timeSpan, culture, maxUnit, minUnit, toWords, toSymbols);
         }
 
-        var timeParts = CreatePrecisionLimitedTimeParts(timeSpan, culture, maxUnit, minUnit, precision, countEmptyUnits, toWords);
+        var timeParts = CreatePrecisionLimitedTimeParts(timeSpan, culture, maxUnit, minUnit, precision, countEmptyUnits, toWords, toSymbols);
 
         return ConcatenateTimeSpanParts(timeParts, culture, collectionSeparator);
     }
@@ -85,7 +135,8 @@ public static class TimeSpanHumanizeExtensions
         TimeUnit minUnit,
         int precision,
         bool countEmptyUnits,
-        bool toWords = false)
+        bool toWords,
+        bool toSymbols)
     {
         if (precision <= 0)
         {
@@ -99,7 +150,7 @@ public static class TimeSpanHumanizeExtensions
 
         foreach (var timeUnit in TimeUnits)
         {
-            var timePart = GetTimeUnitPart(timeUnit, timespan, maxUnit, minUnit, cultureFormatter, toWords);
+            var timePart = GetTimeUnitPart(timeUnit, timespan, maxUnit, minUnit, cultureFormatter, culture, toWords, toSymbols);
 
             if (timePart == null && !firstValueFound)
             {
@@ -132,21 +183,31 @@ public static class TimeSpanHumanizeExtensions
 
         if (timeParts.Count == 0)
         {
-            var noTimeValueCultureFormatted = toWords
-                ? cultureFormatter.TimeSpanHumanize_Zero()
-                : cultureFormatter.TimeSpanHumanize(minUnit, 0);
+            var noTimeValueCultureFormatted = toSymbols
+                ? FormatTimePart(cultureFormatter, minUnit, 0, culture, false, true)
+                : toWords
+                    ? cultureFormatter.TimeSpanHumanize_Zero()
+                    : cultureFormatter.TimeSpanHumanize(minUnit, 0);
             timeParts.Add(noTimeValueCultureFormatted);
         }
 
         return timeParts;
     }
 
-    static string? GetTimeUnitPart(TimeUnit timeUnitToGet, TimeSpan timespan, TimeUnit maximumTimeUnit, TimeUnit minimumTimeUnit, IFormatter cultureFormatter, bool toWords = false)
+    static string? GetTimeUnitPart(
+        TimeUnit timeUnitToGet,
+        TimeSpan timespan,
+        TimeUnit maximumTimeUnit,
+        TimeUnit minimumTimeUnit,
+        IFormatter cultureFormatter,
+        CultureInfo? culture,
+        bool toWords,
+        bool toSymbols)
     {
         if (timeUnitToGet <= maximumTimeUnit && timeUnitToGet >= minimumTimeUnit)
         {
             var numberOfTimeUnits = GetTimeUnitNumericalValue(timeUnitToGet, timespan, maximumTimeUnit);
-            return BuildFormatTimePart(cultureFormatter, timeUnitToGet, numberOfTimeUnits, toWords);
+            return BuildFormatTimePart(cultureFormatter, timeUnitToGet, numberOfTimeUnits, culture, toWords, toSymbols);
         }
 
         return null;
@@ -219,27 +280,46 @@ public static class TimeSpanHumanizeExtensions
         return timeNumberOfUnits;
     }
 
-    static string? BuildFormatTimePart(IFormatter cultureFormatter, TimeUnit timeUnitType, int amountOfTimeUnits, bool toWords = false) =>
+    static string? BuildFormatTimePart(
+        IFormatter cultureFormatter,
+        TimeUnit timeUnitType,
+        int amountOfTimeUnits,
+        CultureInfo? culture,
+        bool toWords,
+        bool toSymbols) =>
         // Always use positive units to account for negative timespans
         amountOfTimeUnits != 0
-            ? cultureFormatter.TimeSpanHumanize(timeUnitType, Math.Abs(amountOfTimeUnits), toWords)
+            ? FormatTimePart(cultureFormatter, timeUnitType, Math.Abs(amountOfTimeUnits), culture, toWords, toSymbols)
             : null;
 
-    static string HumanizeSinglePart(TimeSpan timeSpan, CultureInfo? culture, TimeUnit maxUnit, TimeUnit minUnit, bool toWords)
+    static string FormatTimePart(
+        IFormatter cultureFormatter,
+        TimeUnit timeUnit,
+        int amount,
+        CultureInfo? culture,
+        bool toWords,
+        bool toSymbols) =>
+        toSymbols
+            ? string.Concat(amount.ToString(culture ?? CultureInfo.CurrentUICulture), cultureFormatter.TimeUnitHumanize(timeUnit))
+            : cultureFormatter.TimeSpanHumanize(timeUnit, amount, toWords);
+
+    static string HumanizeSinglePart(TimeSpan timeSpan, CultureInfo? culture, TimeUnit maxUnit, TimeUnit minUnit, bool toWords, bool toSymbols)
     {
         var cultureFormatter = Configurator.GetFormatter(culture);
         foreach (var timeUnit in TimeUnits)
         {
-            var timePart = GetTimeUnitPart(timeUnit, timeSpan, maxUnit, minUnit, cultureFormatter, toWords);
+            var timePart = GetTimeUnitPart(timeUnit, timeSpan, maxUnit, minUnit, cultureFormatter, culture, toWords, toSymbols);
             if (timePart is not null)
             {
                 return timePart;
             }
         }
 
-        return toWords
-            ? cultureFormatter.TimeSpanHumanize_Zero()
-            : cultureFormatter.TimeSpanHumanize(minUnit, 0);
+        return toSymbols
+            ? FormatTimePart(cultureFormatter, minUnit, 0, culture, false, true)
+            : toWords
+                ? cultureFormatter.TimeSpanHumanize_Zero()
+                : cultureFormatter.TimeSpanHumanize(minUnit, 0);
     }
 
     static string ConcatenateTimeSpanParts(List<string> timeSpanParts, CultureInfo? culture, string? collectionSeparator)

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -1930,6 +1930,8 @@ namespace Humanizer
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }
         public static string Humanize(this System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }
+        public static string HumanizeToSymbols(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ") { }
+        public static string HumanizeToSymbols(this System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ") { }
         public static string ToAge(this System.TimeSpan timeSpan, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 7, bool toWords = false) { }
     }
     public enum TimeUnit

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -1930,6 +1930,8 @@ namespace Humanizer
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }
         public static string Humanize(this System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }
+        public static string HumanizeToSymbols(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ") { }
+        public static string HumanizeToSymbols(this System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ") { }
         public static string ToAge(this System.TimeSpan timeSpan, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 7, bool toWords = false) { }
     }
     public enum TimeUnit

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -1929,6 +1929,8 @@ namespace Humanizer
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }
         public static string Humanize(this System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }
+        public static string HumanizeToSymbols(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ") { }
+        public static string HumanizeToSymbols(this System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ") { }
         public static string ToAge(this System.TimeSpan timeSpan, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 7, bool toWords = false) { }
     }
     public enum TimeUnit

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -1259,6 +1259,8 @@ namespace Humanizer
     {
         public static string Humanize(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }
         public static string Humanize(this System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ", bool toWords = false) { }
+        public static string HumanizeToSymbols(this System.TimeSpan timeSpan, int precision = 1, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ") { }
+        public static string HumanizeToSymbols(this System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 5, Humanizer.TimeUnit minUnit = 0, string? collectionSeparator = ", ") { }
         public static string ToAge(this System.TimeSpan timeSpan, System.Globalization.CultureInfo? culture = null, Humanizer.TimeUnit maxUnit = 7, bool toWords = false) { }
     }
     public enum TimeUnit

--- a/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
@@ -573,23 +573,11 @@ public class TimeSpanHumanizeTests
     [Fact]
     public void SymbolsUseCurrentCultureWhenCultureIsNotSpecified()
     {
-        var currentCulture = CultureInfo.CurrentCulture;
-        var currentUICulture = CultureInfo.CurrentUICulture;
+        using var _ = new Humanizer.Tests.Localisation.DistinctCultureSwap(new("ka"), new("en-US"));
 
-        try
-        {
-            CultureInfo.CurrentCulture = new("ka");
-            CultureInfo.CurrentUICulture = new("en-US");
+        var actual = TimeSpan.FromMinutes(2).HumanizeToSymbols();
 
-            var actual = TimeSpan.FromMinutes(2).HumanizeToSymbols();
-
-            Assert.Equal("2წთ", actual);
-        }
-        finally
-        {
-            CultureInfo.CurrentCulture = currentCulture;
-            CultureInfo.CurrentUICulture = currentUICulture;
-        }
+        Assert.Equal("2წთ", actual);
     }
 
     [Fact]

--- a/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
@@ -512,4 +512,71 @@ public class TimeSpanHumanizeTests
         var actual = TimeSpan.FromDays(days).Humanize(precision, maxUnit: maxUnit, minUnit: TimeUnit.Week);
         Assert.Equal(expected, actual);
     }
+
+    [Theory]
+    [InlineData(3, "1week, 1d, 1h")]
+    [InlineData(6, "1week, 1d, 1h, 2min, 3s, 4ms")]
+    public void CanUseLocalizedSymbolsWithPrecision(int precision, string expected)
+    {
+        var timeSpan = new TimeSpan(8, 1, 2, 3, 4);
+
+        var actual = timeSpan.HumanizeToSymbols(precision);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void SymbolsUseInclusiveMonthToWeekBounds()
+    {
+        var actual = TimeSpan.FromDays(109).HumanizeToSymbols(
+            precision: 2,
+            maxUnit: TimeUnit.Month,
+            minUnit: TimeUnit.Week);
+
+        Assert.Equal("3mo, 2week", actual);
+    }
+
+    [Fact]
+    public void SymbolZeroUsesMinimumUnit()
+    {
+        var actual = TimeSpan.Zero.HumanizeToSymbols(minUnit: TimeUnit.Second);
+
+        Assert.Equal("0s", actual);
+    }
+
+    [Theory]
+    [InlineData(3723004)]
+    [InlineData(-3723004)]
+    public void SymbolsPreserveNegativeSymmetry(long milliseconds)
+    {
+        var actual = TimeSpan.FromMilliseconds(milliseconds).HumanizeToSymbols(precision: 4);
+
+        Assert.Equal("1h, 2min, 3s, 4ms", actual);
+    }
+
+    [Fact]
+    public void DefaultOutputIsUnchangedWhenSymbolsAreNotRequested()
+    {
+        var actual = new TimeSpan(0, 1, 2, 3).Humanize(precision: 3);
+
+        Assert.Equal("1 hour, 2 minutes, 3 seconds", actual);
+    }
+
+    [Fact]
+    public void SymbolsUseTheRequestedCulture()
+    {
+        var actual = TimeSpan.FromMinutes(2).HumanizeToSymbols(culture: new("ka"));
+
+        Assert.Equal("2წთ", actual);
+    }
+
+    [Fact]
+    public void SymbolsCanCountEmptyUnits()
+    {
+        var actual = TimeSpan.FromMilliseconds(3600020).HumanizeToSymbols(
+            precision: 3,
+            countEmptyUnits: true);
+
+        Assert.Equal("1h", actual);
+    }
 }

--- a/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
@@ -571,6 +571,28 @@ public class TimeSpanHumanizeTests
     }
 
     [Fact]
+    public void SymbolsUseCurrentCultureWhenCultureIsNotSpecified()
+    {
+        var currentCulture = CultureInfo.CurrentCulture;
+        var currentUICulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = new("ka");
+            CultureInfo.CurrentUICulture = new("en-US");
+
+            var actual = TimeSpan.FromMinutes(2).HumanizeToSymbols();
+
+            Assert.Equal("2წთ", actual);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = currentCulture;
+            CultureInfo.CurrentUICulture = currentUICulture;
+        }
+    }
+
+    [Fact]
     public void SymbolsCanCountEmptyUnits()
     {
         var actual = TimeSpan.FromMilliseconds(3600020).HumanizeToSymbols(


### PR DESCRIPTION
## Summary

`TimeSpan` values can now opt into compact, localized unit symbols without changing any existing `Humanize` overload or default output. `HumanizeToSymbols` uses the same precision, empty-unit counting, separators, and inclusive `maxUnit`/`minUnit` decomposition as full-word output, including Week remainders below Month and Year.

The renderer reuses the existing `TimeUnit` symbol registry exactly. For example, English Week remains `week`; this change does not invent a new abbreviation layer.

Fixes #571 (reported by @rlightner).

Builds on the localized `TimeUnit` symbols introduced by @hangy in #1106. Thanks to @Yomodo for the duplicate report in #969, and to @mr-aboutin (#990) and @neilboyd (#1183) for the earlier compact-format implementations and design exploration.

## Validation

- Final focused `TimeSpanHumanizeTests` on net8.0: 322 passed
- Final public API approval check on net8.0: passed
- Full net8.0 suite: 57,669 passed
- Full net10.0 suite: passed
- Full net11.0 suite: passed
- Release package: created warning-free for net48, netstandard2.0, net8.0, net10.0, and net11.0
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`: clean

## Checklist

- [x] Implementation is clean
- [x] Code follows the existing coding standards
- [x] No code-analysis warnings
- [x] Focused and full test coverage passes
- [x] No implementation code was copied from external sources
- [x] Comments remain limited to required XML documentation
- [x] XML documentation is included for the new public API
- [x] Rebased onto current `main`
- [x] Issue closure reference included
- [x] README updated
- [x] Repository validation completed
