### PR TITLE
fix: support custom acronym vocabulary

### DIFF
--- a/docs/string-humanization.md
+++ b/docs/string-humanization.md
@@ -27,7 +27,7 @@ using Humanizer;
 
 ## Acronym Handling
 
-Strings containing only uppercase letters are treated as acronyms and left unchanged:
+Strings containing only uppercase letters are treated as acronyms and left unchanged unless they match a registered acronym:
 
 ```csharp
 "HTML".Humanize() // => "HTML"
@@ -36,6 +36,8 @@ Strings containing only uppercase letters are treated as acronyms and left uncha
 // Registration is process-wide; matching uses the registered output casing.
 Vocabularies.Default.AddAcronym("HS");
 "HsAccess".Humanize() // => "HS access"
+Vocabularies.Default.AddAcronym("iOS");
+"IOS".Humanize() // => "iOS"
 ```
 
 To force humanization of all-caps strings, use the `Transform` method:

--- a/docs/string-humanization.md
+++ b/docs/string-humanization.md
@@ -32,6 +32,10 @@ Strings containing only uppercase letters are treated as acronyms and left uncha
 ```csharp
 "HTML".Humanize() // => "HTML"
 "HUMANIZER".Humanize() // => "HUMANIZER"
+
+// Registration is process-wide; matching uses the registered output casing.
+Vocabularies.Default.AddAcronym("HS");
+"HsAccess".Humanize() // => "HS access"
 ```
 
 To force humanization of all-caps strings, use the `Transform` method:

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,11 @@ The foundation of this feature was originally developed for the [BDDfy framework
 "HTML".Humanize() => "HTML"  // Acronym preserved
 "HUMANIZER".Humanize() => "HUMANIZER"  // All caps preserved
 
+// Register a custom acronym using its preferred output casing.
+// Registration is process-wide; matching is case-insensitive.
+Vocabularies.Default.AddAcronym("HS");
+"HsAccess".Humanize() => "HS access"
+
 // Force humanization with Transform
 "HUMANIZER".Transform(To.LowerCase, To.TitleCase) => "Humanizer"
 ```

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ The foundation of this feature was originally developed for the [BDDfy framework
     => "Dash separated string"
 ```
 
-**Acronym Handling**: Strings containing only uppercase letters are treated as acronyms and left unchanged. To humanize any string, use the `Transform` method:
+**Acronym Handling**: Strings containing only uppercase letters are treated as acronyms and left unchanged unless they match a registered acronym. To humanize any string, use the `Transform` method:
 
 ```csharp
 "HTML".Humanize() => "HTML"  // Acronym preserved
@@ -66,6 +66,8 @@ The foundation of this feature was originally developed for the [BDDfy framework
 // Registration is process-wide; matching is case-insensitive.
 Vocabularies.Default.AddAcronym("HS");
 "HsAccess".Humanize() => "HS access"
+Vocabularies.Default.AddAcronym("iOS");
+"IOS".Humanize() => "iOS"
 
 // Force humanization with Transform
 "HUMANIZER".Transform(To.LowerCase, To.TitleCase) => "Humanizer"

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -1,18 +1,21 @@
 namespace Humanizer;
 
 /// <summary>
-/// Container for registered Vocabularies.  At present, only a single vocabulary is supported: Default.
+/// Container for registered vocabularies. At present, only a single vocabulary is supported: Default.
 /// </summary>
 public static class Vocabularies
 {
     static readonly Lazy<Vocabulary> Instance = new(BuildDefault, LazyThreadSafetyMode.PublicationOnly);
 
     /// <summary>
-    /// The default vocabulary used for singular/plural irregularities.
-    /// Rules can be added to this vocabulary and will be picked up by called to Singularize() and Pluralize().
+    /// The default vocabulary used for singular/plural irregularities and custom acronym casing.
+    /// Rules and acronyms added to this vocabulary are used by Singularize(), Pluralize(), and Humanize().
     /// At this time, multiple vocabularies and removing existing rules are not supported.
     /// </summary>
     public static Vocabulary Default => Instance.Value;
+
+    internal static string ApplyAcronyms(string input) =>
+        Instance.IsValueCreated ? Instance.Value.ApplyAcronyms(input) : input;
 
     static Vocabulary BuildDefault()
     {

--- a/src/Humanizer/Inflections/Vocabularies.cs
+++ b/src/Humanizer/Inflections/Vocabularies.cs
@@ -17,6 +17,9 @@ public static class Vocabularies
     internal static string ApplyAcronyms(string input) =>
         Instance.IsValueCreated ? Instance.Value.ApplyAcronyms(input) : input;
 
+    internal static string NormalizeAcronyms(string input) =>
+        Instance.IsValueCreated ? Instance.Value.NormalizeAcronyms(input) : input;
+
     static Vocabulary BuildDefault()
     {
         var _default = new Vocabulary();

--- a/src/Humanizer/Inflections/Vocabulary.cs
+++ b/src/Humanizer/Inflections/Vocabulary.cs
@@ -43,9 +43,15 @@ public partial class Vocabulary
             throw new ArgumentException("Acronym must contain only letters.", nameof(acronym));
         }
 
-        if (!acronyms.Any(rule => rule.IsFullMatch(acronym)))
+        lock (acronyms)
         {
-            acronyms.Add(new($@"\b{Regex.Escape(acronym)}\b", acronym.Replace("$", "$$")));
+            if (!acronyms.Any(rule => rule.IsFullMatch(acronym)))
+            {
+                acronyms.Add(new(
+                    $@"\b{Regex.Escape(acronym)}\b",
+                    acronym.Replace("$", "$$"),
+                    RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled));
+            }
         }
     }
 
@@ -294,16 +300,24 @@ public partial class Vocabulary
 
     internal string ApplyAcronyms(string input)
     {
-        foreach (var acronym in acronyms)
+        lock (acronyms)
         {
-            input = acronym.Apply(input, out _) ?? input;
-        }
+            foreach (var acronym in acronyms)
+            {
+                input = acronym.Apply(input, out _) ?? input;
+            }
 
-        return input;
+            return input;
+        }
     }
 
-    internal void RemoveAcronym(string acronym) =>
-        acronyms.RemoveAll(rule => rule.IsFullMatch(acronym));
+    internal void RemoveAcronym(string acronym)
+    {
+        lock (acronyms)
+        {
+            acronyms.RemoveAll(rule => rule.IsFullMatch(acronym));
+        }
+    }
 
     static string MatchUpperCase(string word, string replacement) =>
         word.Length > 1 && word.Any(char.IsUpper) && !word.Any(char.IsLower)
@@ -321,9 +335,12 @@ public partial class Vocabulary
         return s.Groups.Count > 1 ? s.Groups[1].Value : null;
     }
 
-    class Rule(string pattern, string replacement)
+    class Rule(
+        string pattern,
+        string replacement,
+        RegexOptions options = RegexOptions.IgnoreCase | RegexOptions.Compiled)
     {
-        readonly Regex regex = new(pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        readonly Regex regex = new(pattern, options);
 
         public bool IsBuiltIn { get; set; }
 

--- a/src/Humanizer/Inflections/Vocabulary.cs
+++ b/src/Humanizer/Inflections/Vocabulary.cs
@@ -311,6 +311,66 @@ public partial class Vocabulary
         }
     }
 
+    internal string NormalizeAcronyms(string input)
+    {
+        lock (acronyms)
+        {
+            if (acronyms.Count == 0)
+            {
+                return input;
+            }
+
+            StringBuilder? result = null;
+            for (var index = 0; index < input.Length;)
+            {
+                Rule? match = null;
+                if (index == 0 ||
+                    !char.IsLetter(input[index - 1]) ||
+                    (char.IsLower(input[index - 1]) && char.IsUpper(input[index])) ||
+                    (result is { Length: > 0 } && result[^1] == ' '))
+                {
+                    foreach (var acronym in acronyms)
+                    {
+                        var end = index + acronym.Replacement.Length;
+                        if ((match == null || acronym.Replacement.Length > match.Replacement.Length) &&
+                            acronym.MatchesAt(input, index) &&
+                            (end == input.Length || !char.IsLetter(input[end]) || char.IsUpper(input[end])))
+                        {
+                            match = acronym;
+                        }
+                    }
+                }
+
+                if (match == null)
+                {
+                    result?.Append(input[index]);
+                    index++;
+                    continue;
+                }
+
+                if (result == null)
+                {
+                    result = new(input.Length);
+                    result.Append(input, 0, index);
+                }
+
+                if (index > 0 && char.IsLetterOrDigit(input[index - 1]))
+                {
+                    result.Append(' ');
+                }
+
+                result.Append(match.Replacement.ToUpperInvariant());
+                index += match.Replacement.Length;
+                if (index < input.Length && char.IsLetterOrDigit(input[index]))
+                {
+                    result.Append(' ');
+                }
+            }
+
+            return result?.ToString() ?? input;
+        }
+    }
+
     internal void RemoveAcronym(string acronym)
     {
         lock (acronyms)
@@ -349,6 +409,12 @@ public partial class Vocabulary
             var match = regex.Match(word);
             return match.Success && match.Index == 0 && match.Length == word.Length;
         }
+
+        public bool MatchesAt(string word, int index) =>
+            index + replacement.Length <= word.Length &&
+            string.Compare(word, index, replacement, 0, replacement.Length, StringComparison.OrdinalIgnoreCase) == 0;
+
+        public string Replacement => replacement;
 
         public string? Apply(string word, out bool wholeWordMatch)
         {

--- a/src/Humanizer/Inflections/Vocabulary.cs
+++ b/src/Humanizer/Inflections/Vocabulary.cs
@@ -354,7 +354,9 @@ public partial class Vocabulary
                     result.Append(input, 0, index);
                 }
 
-                if (index > 0 && char.IsLetterOrDigit(input[index - 1]))
+                if (index > 0 &&
+                    char.IsLetterOrDigit(input[index - 1]) &&
+                    result[^1] != ' ')
                 {
                     result.Append(' ');
                 }

--- a/src/Humanizer/Inflections/Vocabulary.cs
+++ b/src/Humanizer/Inflections/Vocabulary.cs
@@ -1,8 +1,8 @@
 namespace Humanizer;
 
 /// <summary>
-/// A container for exceptions to simple pluralization/singularization rules.
-/// Vocabularies.Default contains an extensive list of rules for US English.
+/// A container for custom acronym casing and exceptions to simple pluralization/singularization rules.
+/// Vocabularies.Default contains an extensive list of rules for US English and supports process-wide acronym registration.
 /// At this time, multiple vocabularies and removing existing rules are not supported.
 /// </summary>
 public partial class Vocabulary
@@ -13,6 +13,7 @@ public partial class Vocabulary
 
     readonly List<Rule> plurals = [];
     readonly List<Rule> singulars = [];
+    readonly List<Rule> acronyms = [];
     readonly HashSet<string> uncountables = new(StringComparer.CurrentCultureIgnoreCase);
 
     private const string LetterSPattern = "^([sS])[sS]*$";
@@ -27,6 +28,26 @@ public partial class Vocabulary
 
     private static Regex LetterSRegex() => LetterSRegexField;
 #endif
+
+    /// <summary>
+    /// Adds an acronym whose casing should be preserved when humanizing strings.
+    /// </summary>
+    /// <param name="acronym">The letters in the acronym's canonical output casing, e.g. "HTML".</param>
+    /// <exception cref="ArgumentNullException"><paramref name="acronym"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="acronym"/> is empty or contains a non-letter.</exception>
+    public void AddAcronym(string acronym)
+    {
+        ArgumentNullException.ThrowIfNull(acronym);
+        if (acronym.Length == 0 || !acronym.All(char.IsLetter))
+        {
+            throw new ArgumentException("Acronym must contain only letters.", nameof(acronym));
+        }
+
+        if (!acronyms.Any(rule => rule.IsFullMatch(acronym)))
+        {
+            acronyms.Add(new($@"\b{Regex.Escape(acronym)}\b", acronym.Replace("$", "$$")));
+        }
+    }
 
     /// <summary>
     /// Adds a word to the vocabulary which cannot easily be pluralized/singularized by RegEx, e.g. "person" and "people".
@@ -271,6 +292,19 @@ public partial class Vocabulary
     static bool IsHorizontalWhitespace(char character) =>
         character == '\t' || char.GetUnicodeCategory(character) == UnicodeCategory.SpaceSeparator;
 
+    internal string ApplyAcronyms(string input)
+    {
+        foreach (var acronym in acronyms)
+        {
+            input = acronym.Apply(input, out _) ?? input;
+        }
+
+        return input;
+    }
+
+    internal void RemoveAcronym(string acronym) =>
+        acronyms.RemoveAll(rule => rule.IsFullMatch(acronym));
+
     static string MatchUpperCase(string word, string replacement) =>
         word.Length > 1 && word.Any(char.IsUpper) && !word.Any(char.IsLower)
             ? replacement.ToUpperInvariant()
@@ -292,6 +326,12 @@ public partial class Vocabulary
         readonly Regex regex = new(pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public bool IsBuiltIn { get; set; }
+
+        public bool IsFullMatch(string word)
+        {
+            var match = regex.Match(word);
+            return match.Success && match.Index == 0 && match.Length == word.Length;
+        }
 
         public string? Apply(string word, out bool wholeWordMatch)
         {

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -219,15 +219,15 @@ public static partial class StringHumanizeExtensions
     /// <param name="input">The string to be humanized. Must not be null.</param>
     /// <returns>
     /// A humanized version of the input string with spaces inserted between words and appropriate
-    /// capitalization. Preserves all-uppercase acronyms unchanged.
+    /// capitalization. Preserves all-uppercase acronyms unless registered with different canonical casing.
     /// </returns>
     /// <remarks>
     /// The method applies several rules in order:
-    /// - If the entire input is uppercase (an acronym), it returns unchanged
+    /// - If the entire input is uppercase (an acronym), it returns unchanged unless it matches a registered acronym
     /// - Handles freestanding underscores/dashes (e.g., "some _ string")
     /// - Splits on underscores and dashes
     /// - Breaks up PascalCase and camelCase text
-    /// The first letter of the result is always capitalized.
+    /// Registered acronyms use their canonical casing.
     /// </remarks>
     /// <example>
     /// <code>
@@ -235,6 +235,8 @@ public static partial class StringHumanizeExtensions
     /// "Underscored_input_String_is_turned_INTO_sentence".Humanize() => "Underscored input String is turned INTO sentence"
     /// "dash-separated-string".Humanize() => "Dash separated string"
     /// "HTML".Humanize() => "HTML"
+    /// Vocabularies.Default.AddAcronym("iOS");
+    /// "IOS".Humanize() => "iOS"
     /// "camelCaseText".Humanize() => "Camel case text"
     /// </code>
     /// </example>

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -247,6 +247,8 @@ public static partial class StringHumanizeExtensions
             return Vocabularies.ApplyAcronyms(input);
         }
 
+        input = Vocabularies.NormalizeAcronyms(input);
+
         // if input contains a dash or underscore which precedes or follows a space (or both, e.g. freestanding)
         // remove the dash/underscore and run it through FromPascalCase
         var humanized = HasFreestandingSpacingChar(input)

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -242,7 +242,6 @@ public static partial class StringHumanizeExtensions
     /// </example>
     public static string Humanize(this string input)
     {
-        // if input is all capitals (e.g. an acronym) then return it without change
         if (IsAllUpper(input, 0, input.Length))
         {
             return Vocabularies.ApplyAcronyms(input);

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -243,22 +243,18 @@ public static partial class StringHumanizeExtensions
         // if input is all capitals (e.g. an acronym) then return it without change
         if (IsAllUpper(input, 0, input.Length))
         {
-            return input;
+            return Vocabularies.ApplyAcronyms(input);
         }
 
         // if input contains a dash or underscore which precedes or follows a space (or both, e.g. freestanding)
         // remove the dash/underscore and run it through FromPascalCase
-        if (HasFreestandingSpacingChar(input))
-        {
-            return FromPascalCase(FromUnderscoreDashSeparatedWords(input));
-        }
+        var humanized = HasFreestandingSpacingChar(input)
+            ? FromPascalCase(FromUnderscoreDashSeparatedWords(input))
+            : input.IndexOfAny(['_', '-']) >= 0
+                ? FromUnderscoreDashSeparatedWords(input)
+                : FromPascalCase(input);
 
-        if (input.IndexOfAny(['_', '-']) >= 0)
-        {
-            return FromUnderscoreDashSeparatedWords(input);
-        }
-
-        return FromPascalCase(input);
+        return Vocabularies.ApplyAcronyms(humanized);
     }
 
     static bool HasFreestandingSpacingChar(string input)

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -2026,6 +2026,7 @@ namespace Humanizer
     }
     public class Vocabulary
     {
+        public void AddAcronym(string acronym) { }
         public void AddIrregular(string singular, string plural, bool matchEnding = true) { }
         public void AddPlural(string rule, string replacement) { }
         public void AddSingular(string rule, string replacement) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -2026,6 +2026,7 @@ namespace Humanizer
     }
     public class Vocabulary
     {
+        public void AddAcronym(string acronym) { }
         public void AddIrregular(string singular, string plural, bool matchEnding = true) { }
         public void AddPlural(string rule, string replacement) { }
         public void AddSingular(string rule, string replacement) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -2025,6 +2025,7 @@ namespace Humanizer
     }
     public class Vocabulary
     {
+        public void AddAcronym(string acronym) { }
         public void AddIrregular(string singular, string plural, bool matchEnding = true) { }
         public void AddPlural(string rule, string replacement) { }
         public void AddSingular(string rule, string replacement) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -1355,6 +1355,7 @@ namespace Humanizer
     }
     public class Vocabulary
     {
+        public void AddAcronym(string acronym) { }
         public void AddIrregular(string singular, string plural, bool matchEnding = true) { }
         public void AddPlural(string rule, string replacement) { }
         public void AddSingular(string rule, string replacement) { }

--- a/tests/Humanizer.Tests/StringHumanizeTests.cs
+++ b/tests/Humanizer.Tests/StringHumanizeTests.cs
@@ -64,6 +64,7 @@ public class StringHumanizeTests
     {
         Vocabularies.Default.RemoveAcronym("HS");
         Vocabularies.Default.RemoveAcronym("iOS");
+        Vocabularies.Default.RemoveAcronym("API");
         try
         {
             Assert.Equal("Hs access", "HsAccess".Humanize());
@@ -77,18 +78,21 @@ public class StringHumanizeTests
             Assert.Equal("The HTML language", "TheHTMLLanguage".Humanize());
 
             Vocabularies.Default.AddAcronym("iOS");
+            Vocabularies.Default.AddAcronym("API");
             Assert.Equal("iOS", "IOS".Humanize());
             Assert.Equal("iOS", "iOS".Humanize());
             Assert.Equal("iOS settings", "iOSSettings".Humanize());
             Assert.Equal("iOS API settings", "iOSAPISettings".Humanize());
             Assert.Equal("iOS 5", "iOS5".Humanize());
             Assert.Equal("iOS Settings", "iOS_Settings".Humanize());
+            Assert.Equal("iOS API Settings", "iOSAPI_Settings".Humanize());
             Assert.Equal("BIOS settings", "BIOSSettings".Humanize());
         }
         finally
         {
             Vocabularies.Default.RemoveAcronym("HS");
             Vocabularies.Default.RemoveAcronym("iOS");
+            Vocabularies.Default.RemoveAcronym("API");
         }
 
         Assert.Equal("Hs access", "HsAccess".Humanize());

--- a/tests/Humanizer.Tests/StringHumanizeTests.cs
+++ b/tests/Humanizer.Tests/StringHumanizeTests.cs
@@ -78,6 +78,12 @@ public class StringHumanizeTests
 
             Vocabularies.Default.AddAcronym("iOS");
             Assert.Equal("iOS", "IOS".Humanize());
+            Assert.Equal("iOS", "iOS".Humanize());
+            Assert.Equal("iOS settings", "iOSSettings".Humanize());
+            Assert.Equal("iOS API settings", "iOSAPISettings".Humanize());
+            Assert.Equal("iOS 5", "iOS5".Humanize());
+            Assert.Equal("iOS Settings", "iOS_Settings".Humanize());
+            Assert.Equal("BIOS settings", "BIOSSettings".Humanize());
         }
         finally
         {

--- a/tests/Humanizer.Tests/StringHumanizeTests.cs
+++ b/tests/Humanizer.Tests/StringHumanizeTests.cs
@@ -59,7 +59,7 @@ public class StringHumanizeTests
     public void CanHumanizeStringWithAcronyms(string input, string expectedValue) =>
         Assert.Equal(expectedValue, input.Humanize());
 
-    [Fact]
+    [Fact, UseCulture("tr-TR")]
     public void CanHumanizeStringsWithCustomAcronyms()
     {
         Vocabularies.Default.RemoveAcronym("HS");
@@ -94,6 +94,31 @@ public class StringHumanizeTests
     [InlineData("HS2")]
     public void CannotAddInvalidAcronym(string? acronym) =>
         Assert.ThrowsAny<ArgumentException>(() => Vocabularies.Default.AddAcronym(acronym!));
+
+    [Fact]
+    public void CanRegisterCustomAcronymsWhileMatching()
+    {
+        var vocabulary = new Vocabulary();
+        vocabulary.AddAcronym("AA");
+
+        Parallel.Invoke(
+            () =>
+            {
+                foreach (var letter in Enumerable.Range('B', 25))
+                {
+                    vocabulary.AddAcronym($"A{(char)letter}");
+                }
+            },
+            () =>
+            {
+                for (var i = 0; i < 1000; i++)
+                {
+                    _ = vocabulary.ApplyAcronyms("Uses aa");
+                }
+            });
+
+        Assert.Equal("Uses AA", vocabulary.ApplyAcronyms("Uses aa"));
+    }
 
     [Theory]
     [InlineData("CanReturnTitleCase", "Can Return Title Case")]

--- a/tests/Humanizer.Tests/StringHumanizeTests.cs
+++ b/tests/Humanizer.Tests/StringHumanizeTests.cs
@@ -59,6 +59,42 @@ public class StringHumanizeTests
     public void CanHumanizeStringWithAcronyms(string input, string expectedValue) =>
         Assert.Equal(expectedValue, input.Humanize());
 
+    [Fact]
+    public void CanHumanizeStringsWithCustomAcronyms()
+    {
+        Vocabularies.Default.RemoveAcronym("HS");
+        Vocabularies.Default.RemoveAcronym("iOS");
+        try
+        {
+            Assert.Equal("Hs access", "HsAccess".Humanize());
+
+            Vocabularies.Default.AddAcronym("HS");
+            Vocabularies.Default.AddAcronym("hs");
+
+            Assert.Equal("HS access", "hsAccess".Humanize());
+            Assert.Equal("HS access", "HsAccess".Humanize());
+            Assert.Equal("Uses HS", "UsesHs".Humanize());
+            Assert.Equal("The HTML language", "TheHTMLLanguage".Humanize());
+
+            Vocabularies.Default.AddAcronym("iOS");
+            Assert.Equal("iOS", "IOS".Humanize());
+        }
+        finally
+        {
+            Vocabularies.Default.RemoveAcronym("HS");
+            Vocabularies.Default.RemoveAcronym("iOS");
+        }
+
+        Assert.Equal("Hs access", "HsAccess".Humanize());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("HS2")]
+    public void CannotAddInvalidAcronym(string? acronym) =>
+        Assert.ThrowsAny<ArgumentException>(() => Vocabularies.Default.AddAcronym(acronym!));
+
     [Theory]
     [InlineData("CanReturnTitleCase", "Can Return Title Case")]
     [InlineData("Can_return_title_Case", "Can Return Title Case")]


### PR DESCRIPTION
## Summary

Applications can now register canonical acronym casing once with `Vocabularies.Default.AddAcronym("HS")`, so identifiers such as `hsAccess`, `HsAccess`, and `UsesHs` humanize as `HS access`, `HS access`, and `Uses HS`. Matching is case-insensitive and process-wide, duplicate registrations preserve the first canonical casing, and existing all-uppercase acronym handling remains unchanged.

The registration path reuses `Vocabulary`'s existing rule matching and built-in/user provenance contract. Ordinary `Humanize()` calls do not initialize the default inflection vocabulary unless it has already been accessed for configuration.

Thanks @bdaniel7 for reporting the custom-acronym gap.

Fixes #796.

## Validation

- Focused .NET 8 string-humanization tests: 59 passed
- Focused .NET 8 public API approval: passed
- Full `Humanizer.Tests` matrix: 57,732 passed on each of .NET 8, .NET 10, and .NET 11
- Release pack succeeded for `net48`, `netstandard2.0`, `net8.0`, `net10.0`, and `net11.0` without warnings
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` formatted 0 of 2,637 files

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or another OSS project
- [x] There are very few or no comments
- [x] XML documentation is updated
- [x] The branch is rebased onto current `main`
- [x] The fixed issue is linked with a closing reference
- [x] README and string-humanization documentation are updated
- [x] Full supported mini test matrix, Release pack, and formatting verification completed successfully