### PR TITLE
fix: preserve ampersands when humanizing strings

### DIFF
--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -9,7 +9,7 @@ namespace Humanizer;
 /// </summary>
 public static partial class StringHumanizeExtensions
 {
-    const string PascalCaseWordPartsPattern = @"(\p{Lu}?\p{Ll}+|[0-9]+(?:\.[0-9]+)?\p{Ll}*|\p{Lu}+(?=\p{Lu}|[0-9]|\b)|\p{Lo}+)[,;]?";
+    const string PascalCaseWordPartsPattern = @"(\p{Lu}?\p{Ll}+|[0-9]+(?:\.[0-9]+)?\p{Ll}*|\p{Lu}+(?=\p{Lu}|[0-9]|\b)|\p{Lo}+)[,;]?|&";
 
 #if NET7_0_OR_GREATER
     [GeneratedRegex(PascalCaseWordPartsPattern, RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture)]
@@ -54,7 +54,7 @@ public static partial class StringHumanizeExtensions
                     : value.ToLower();
             }));
 
-        if (result.All(c => c == ' ' || char.IsUpper(c)) && result.Contains(' '))
+        if (result.All(c => c is ' ' or '&' || char.IsUpper(c)) && result.Contains(' '))
         {
             result = result.ToLower();
         }

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -243,7 +243,7 @@ public static partial class StringHumanizeExtensions
     /// - Breaks up PascalCase and camelCase text
     /// - Preserves ampersands as separate tokens in PascalCase and camelCase inputs
     /// Registered acronyms use their canonical casing.
-    /// The first letter of the result is always capitalized.
+    /// If the result begins with a letter, that letter is capitalized.
     /// </remarks>
     /// <example>
     /// <code>

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -243,7 +243,7 @@ public static partial class StringHumanizeExtensions
     /// - Breaks up PascalCase and camelCase text
     /// - Preserves ampersands as separate tokens in PascalCase and camelCase inputs
     /// Registered acronyms use their canonical casing.
-    /// If the result begins with a letter, that letter is capitalized.
+    /// Otherwise, if the result begins with a letter, that letter is capitalized.
     /// </remarks>
     /// <example>
     /// <code>

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -227,7 +227,9 @@ public static partial class StringHumanizeExtensions
     /// - Handles freestanding underscores/dashes (e.g., "some _ string")
     /// - Splits on underscores and dashes
     /// - Breaks up PascalCase and camelCase text
+    /// - Preserves ampersands as separate tokens in PascalCase and camelCase inputs
     /// Registered acronyms use their canonical casing.
+    /// The first letter of the result is always capitalized.
     /// </remarks>
     /// <example>
     /// <code>
@@ -238,6 +240,7 @@ public static partial class StringHumanizeExtensions
     /// Vocabularies.Default.AddAcronym("iOS");
     /// "IOS".Humanize() => "iOS"
     /// "camelCaseText".Humanize() => "Camel case text"
+    /// "Rock&amp;Roll".Humanize() => "Rock &amp; roll"
     /// </code>
     /// </example>
     public static string Humanize(this string input)

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -59,6 +59,20 @@ public static partial class StringHumanizeExtensions
             result = result.ToLower();
         }
 
+        if (result.Length > 0 && result[0] == '&')
+        {
+            var firstWordIndex = 1;
+            while (firstWordIndex < result.Length && result[firstWordIndex] is ' ' or '&')
+                firstWordIndex++;
+
+            if (firstWordIndex < result.Length)
+            {
+                var characters = result.ToCharArray();
+                characters[firstWordIndex] = char.ToUpper(characters[firstWordIndex]);
+                return new(characters);
+            }
+        }
+
         return result.Length > 0
             ? Concat(char.ToUpper(result[0]), result.AsSpan(1, result.Length - 1))
             : result;

--- a/tests/Humanizer.Tests/StringHumanizeTests.cs
+++ b/tests/Humanizer.Tests/StringHumanizeTests.cs
@@ -132,7 +132,8 @@ public class StringHumanizeTests
 
     [Theory]
     [InlineData("Enable & Disable", "Enable & disable")]
-    [InlineData("&EnableDisable", "& enable disable")]
+    [InlineData("&EnableDisable", "& Enable disable")]
+    [InlineData("&&EnableDisable", "& & Enable disable")]
     [InlineData("EnableDisable&", "Enable disable &")]
     [InlineData("Enable&Disable", "Enable & disable")]
     [InlineData("HTML&CSS", "Html & css")]
@@ -172,6 +173,7 @@ public class StringHumanizeTests
     [InlineData("Normal; Normal and PascalCase", "Normal; normal and pascal case")]
     [InlineData("I,and No One else", "I, and no one else")]
     [InlineData("first. second", "First second")]
+    [InlineData("&EnableDisable", "& Enable disable")]
     public void CanHumanizeIntoSentenceCase(string input, string expectedResult) =>
         Assert.Equal(expectedResult, input.Humanize(LetterCasing.Sentence));
 

--- a/tests/Humanizer.Tests/StringHumanizeTests.cs
+++ b/tests/Humanizer.Tests/StringHumanizeTests.cs
@@ -131,6 +131,22 @@ public class StringHumanizeTests
     }
 
     [Theory]
+    [InlineData("Enable & Disable", "Enable & disable")]
+    [InlineData("&EnableDisable", "& enable disable")]
+    [InlineData("EnableDisable&", "Enable disable &")]
+    [InlineData("Enable&Disable", "Enable & disable")]
+    [InlineData("HTML&CSS", "Html & css")]
+    [InlineData("TheHTML&CSS", "The HTML & CSS")]
+    public void CanHumanizeStringWithAmpersands(string input, string expectedValue) =>
+        Assert.Equal(expectedValue, input.Humanize());
+
+    [Theory]
+    [InlineData("Enable + Disable", "Enable disable")]
+    [InlineData("Enable / Disable", "Enable disable")]
+    public void OtherPunctuationIsStillRemoved(string input, string expectedValue) =>
+        Assert.Equal(expectedValue, input.Humanize());
+
+    [Theory]
     [InlineData("CanReturnTitleCase", "Can Return Title Case")]
     [InlineData("Can_return_title_Case", "Can Return Title Case")]
     [InlineData("In titles use lower case for prepositions an article or conjunctions", "In Titles Use Lower Case for Prepositions an Article or Conjunctions")]
@@ -138,6 +154,7 @@ public class StringHumanizeTests
     [InlineData("MühldorferStraße23", "Mühldorfer Straße 23")]
     [InlineData("mühldorfer_STRAẞE_23", "Mühldorfer STRAẞE 23")]
     [InlineData("CAN RETURN TITLE CASE", "Can Return Title Case")]
+    [InlineData("Enable & Disable", "Enable & Disable")]
     public void CanHumanizeIntoTitleCase(string input, string expectedResult) =>
         Assert.Equal(expectedResult, input.Humanize(LetterCasing.Title));
 


### PR DESCRIPTION
## Summary

String humanization now preserves ampersands instead of silently dropping them, so `Enable & Disable` humanizes to `Enable & disable` and title-cases to `Enable & Disable`. Other punctuation continues to follow the established removal behavior, while existing acronym normalization is unchanged.

Thanks to @RollsChris for reporting this.

Fixes #1292

## Validation

- [x] Focused net8 caller coverage: 1,122 tests passed
- [x] Full Humanizer.Tests matrix: 57,747 tests passed on each of net8, net10, and net11
- [x] `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
- [x] Release pack succeeded without warnings for net8, net10, net11, net48, and netstandard2.0

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or OSS
- [x] There are very few or no comments
- [x] No public API changed, so XML documentation changes are not required
- [x] The PR is rebased on the latest `main`
- [x] The fixed issue is linked above
- [x] A readme change is not needed for this focused compatibility fix
- [x] The supported test matrix and Release pack completed successfully
