### PR TITLE
feat: optionally preserve case when underscoring

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -553,6 +553,7 @@ Transform to common naming conventions:
 ```csharp
 // Underscore: snake_case
 "SomeTitle".Underscore() => "some_title"
+"SomeTitle".Underscore(preserveCase: true) => "Some_Title"
 
 // Dasherize/Hyphenate: Replace underscores with dashes
 "some_title".Dasherize() => "some-title"

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -334,13 +334,36 @@ public static partial class InflectorExtensions
     /// </code>
     /// </example>
     public static string Underscore(this string input) =>
-        TryUnderscoreAscii(input, separator: '_', replaceUnderscore: false, out var result)
-            ? result
-            : UnderscoreRegex3()
-                .Replace(
-                    UnderscoreRegex2().Replace(
-                        UnderscoreRegex1().Replace(input, "$1_$2"), "$1_$2"), "_")
-                .ToLowerInvariant();
+        input.Underscore(preserveCase: false);
+
+    /// <summary>
+    /// Separates words with underscores, optionally preserving the input casing.
+    /// </summary>
+    /// <param name="input">The string to be underscored. Must not be null.</param>
+    /// <param name="preserveCase">
+    /// <see langword="true"/> to preserve the input casing; <see langword="false"/> to convert the result to lowercase.
+    /// </param>
+    /// <returns>A string with words separated by underscores.</returns>
+    /// <remarks>
+    /// Acronyms are split using identifier word boundaries, and lowercasing is culture-invariant.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// "SomePropertyName".Underscore(preserveCase: true) => "Some_Property_Name"
+    /// "HTMLParser".Underscore(preserveCase: true) => "HTML_Parser"
+    /// </code>
+    /// </example>
+    public static string Underscore(this string input, bool preserveCase)
+    {
+        if (TryUnderscoreAscii(input, separator: '_', replaceUnderscore: false, preserveCase: preserveCase, out var result))
+            return result;
+
+        result = UnderscoreRegex3()
+            .Replace(
+                UnderscoreRegex2().Replace(
+                    UnderscoreRegex1().Replace(input, "$1_$2"), "$1_$2"), "_");
+        return preserveCase ? result : result.ToLowerInvariant();
+    }
 
     /// <summary>
     /// Replaces all underscores in the string with dashes (hyphens).
@@ -350,7 +373,7 @@ public static partial class InflectorExtensions
     /// A string with all underscores replaced by dashes.
     /// </returns>
     /// <remarks>
-    /// This is typically used after calling <see cref="Underscore"/> to convert from underscore_case to dash-case (kebab-case).
+    /// This is typically used after calling <see cref="Underscore(string)"/> to convert from underscore_case to dash-case (kebab-case).
     /// </remarks>
     /// <example>
     /// <code>
@@ -389,7 +412,7 @@ public static partial class InflectorExtensions
     /// </returns>
     /// <remarks>
     /// Kebab-case is commonly used for CSS class names, HTML attributes, and URL slugs.
-    /// This is equivalent to calling <see cref="Underscore"/> followed by <see cref="Dasherize"/>.
+    /// This is equivalent to calling <see cref="Underscore(string)"/> followed by <see cref="Dasherize"/>.
     /// Casing is culture-invariant.
     /// </remarks>
     /// <example>
@@ -401,7 +424,7 @@ public static partial class InflectorExtensions
     /// </code>
     /// </example>
     public static string Kebaberize(this string input) =>
-        TryUnderscoreAscii(input, separator: '-', replaceUnderscore: true, out var result)
+        TryUnderscoreAscii(input, separator: '-', replaceUnderscore: true, preserveCase: false, out var result)
             ? result
             : Underscore(input)
                 .Dasherize();
@@ -432,7 +455,12 @@ public static partial class InflectorExtensions
             : StringHumanizeExtensions.Concat(word.AsSpan(), "'s".AsSpan());
     }
 
-    static bool TryUnderscoreAscii(string input, char separator, bool replaceUnderscore, [NotNullWhen(true)] out string? result)
+    static bool TryUnderscoreAscii(
+        string input,
+        char separator,
+        bool replaceUnderscore,
+        bool preserveCase,
+        [NotNullWhen(true)] out string? result)
     {
         result = null;
         if (!IsAscii(input))
@@ -460,11 +488,11 @@ public static partial class InflectorExtensions
                     buffer[pos++] = separator;
                 }
 
-                buffer[pos++] = textInfo.ToLower(c);
+                buffer[pos++] = preserveCase ? c : textInfo.ToLower(c);
                 continue;
             }
 
-            buffer[pos++] = textInfo.ToLower(c);
+            buffer[pos++] = preserveCase ? c : textInfo.ToLower(c);
         }
 
         result = new(buffer, 0, pos);

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -861,6 +861,7 @@ namespace Humanizer
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("word")]
         public static string? ToPossessive(this string? word, bool inputIsPlural = false, bool useApostropheOnlyForSingularWordsEndingInS = false) { }
         public static string Underscore(this string input) { }
+        public static string Underscore(this string input, bool preserveCase) { }
     }
     public enum LetterCasing
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -861,6 +861,7 @@ namespace Humanizer
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("word")]
         public static string? ToPossessive(this string? word, bool inputIsPlural = false, bool useApostropheOnlyForSingularWordsEndingInS = false) { }
         public static string Underscore(this string input) { }
+        public static string Underscore(this string input, bool preserveCase) { }
     }
     public enum LetterCasing
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -860,6 +860,7 @@ namespace Humanizer
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("word")]
         public static string? ToPossessive(this string? word, bool inputIsPlural = false, bool useApostropheOnlyForSingularWordsEndingInS = false) { }
         public static string Underscore(this string input) { }
+        public static string Underscore(this string input, bool preserveCase) { }
     }
     public enum LetterCasing
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -635,6 +635,7 @@ namespace Humanizer
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("word")]
         public static string? ToPossessive(this string? word, bool inputIsPlural = false, bool useApostropheOnlyForSingularWordsEndingInS = false) { }
         public static string Underscore(this string input) { }
+        public static string Underscore(this string input, bool preserveCase) { }
     }
     public enum LetterCasing
     {

--- a/tests/Humanizer.Tests/InflectorTests.cs
+++ b/tests/Humanizer.Tests/InflectorTests.cs
@@ -305,8 +305,19 @@ public class InflectorTests
     [InlineData("SomeTitleThatWillBeUnderscored", "some_title_that_will_be_underscored")]
     [InlineData("SomeForeignWordsLikeÄgyptenÑu", "some_foreign_words_like_ägypten_ñu")]
     [InlineData("Some wordsTo be Underscored", "some_words_to_be_underscored")]
+    [InlineData("HTMLParserName", "html_parser_name")]
     public void Underscore(string input, string expectedOutput) =>
         Assert.Equal(expectedOutput, input.Underscore());
+
+    [Theory]
+    [InlineData("SomeTitle", "Some_Title")]
+    [InlineData("HTMLParserName", "HTML_Parser_Name")]
+    [InlineData("SomeForeignWordsLikeÄgyptenÑu", "Some_Foreign_Words_Like_Ägypten_Ñu")]
+    [InlineData("Some title", "Some_title")]
+    [InlineData("Some-Title", "Some_Title")]
+    [InlineData("Some_Title", "Some_Title")]
+    public void UnderscorePreservesCaseWhenRequested(string input, string expectedOutput) =>
+        Assert.Equal(expectedOutput, input.Underscore(preserveCase: true));
 
     // transform words into lowercase and separate with a -
     [Theory]


### PR DESCRIPTION
## Summary

Adds an explicit `Underscore(preserveCase: true)` option for inserting underscores without changing the input letter casing.

The existing no-argument API remains unchanged and continues to return lowercase output. Acronym and identifier boundaries retain the behavior introduced by #1577.

Fixes #1149.

Thanks to @gordon-matt for reporting this and to @hns258 for identifying the backward-compatibility constraint.

## Validation

- [x] Focused `InflectorTests` on .NET 8: 1,009 passed
- [x] Public API approval on .NET 8: 1 passed
- [x] Full .NET 8 suite: 57,745 passed
- [x] Full .NET 10 suite: 57,745 passed
- [x] Full .NET 11 suite: 57,745 passed
- [x] Release pack across supported targets
- [x] `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate).
- [x] I have added API approval updates for the new public overload.
- [x] I have not introduced unrelated inflection behavior changes.
