### PR TITLE
Add culture-aware collection Humanize overload

### DIFF
--- a/src/Humanizer/CollectionHumanizeExtensions.cs
+++ b/src/Humanizer/CollectionHumanizeExtensions.cs
@@ -29,6 +29,31 @@ public static class CollectionHumanizeExtensions
         Configurator.CollectionFormatter.Humanize(collection);
 
     /// <summary>
+    /// Transforms a collection into a human-readable string representation using the default separator
+    /// for the specified culture.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the collection.</typeparam>
+    /// <param name="collection">The collection to be humanized. Must not be null.</param>
+    /// <param name="culture">The culture whose collection formatter should be used. Must not be null.</param>
+    /// <returns>
+    /// A formatted string representation of the collection elements separated by culture-specific separators.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="collection"/> or <paramref name="culture"/> is null.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// new[] { 1, 2, 3 }.Humanize(new CultureInfo("en-GB")) => "1, 2 and 3"
+    /// </code>
+    /// </example>
+    public static string Humanize<T>(this IEnumerable<T> collection, CultureInfo culture)
+    {
+        ArgumentNullException.ThrowIfNull(culture);
+
+        return Configurator.CollectionFormatters.ResolveForCulture(culture).Humanize(collection);
+    }
+
+    /// <summary>
     /// Transforms a collection into a human-readable string representation using a custom formatter function
     /// for each element, combined with the default separator for the current culture.
     /// </summary>

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -223,6 +223,7 @@ namespace Humanizer
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, object> displayFormatter) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, string> displayFormatter) { }
+        public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Globalization.CultureInfo culture) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, string separator) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, object> displayFormatter, string separator) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, string> displayFormatter, string separator) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -223,6 +223,7 @@ namespace Humanizer
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, object> displayFormatter) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, string> displayFormatter) { }
+        public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Globalization.CultureInfo culture) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, string separator) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, object> displayFormatter, string separator) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, string> displayFormatter, string separator) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -222,6 +222,7 @@ namespace Humanizer
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, object> displayFormatter) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, string> displayFormatter) { }
+        public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Globalization.CultureInfo culture) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, string separator) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, object> displayFormatter, string separator) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, string> displayFormatter, string separator) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -221,6 +221,7 @@ namespace Humanizer
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, object> displayFormatter) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, string> displayFormatter) { }
+        public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Globalization.CultureInfo culture) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, string separator) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, object> displayFormatter, string separator) { }
         public static string Humanize<T>(this System.Collections.Generic.IEnumerable<T> collection, System.Func<T, string> displayFormatter, string separator) { }

--- a/tests/Humanizer.Tests/CollectionHumanizeTests.cs
+++ b/tests/Humanizer.Tests/CollectionHumanizeTests.cs
@@ -48,6 +48,18 @@ public class CollectionHumanizeTests
     }
 
     [Fact]
+    public void HumanizeUsesSpecifiedCulture() =>
+        Assert.Equal("A, B and C", ThreeStrings.Humanize(new CultureInfo("en-GB")));
+
+    [Fact]
+    public void HumanizeThrowsWhenCultureIsNull()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => ThreeStrings.Humanize((CultureInfo)null!));
+
+        Assert.Equal("culture", exception.ParamName);
+    }
+
+    [Fact]
     public void HumanizeUsesOxfordComma()
     {
         var collection = new List<string>


### PR DESCRIPTION
## Summary

- add `Humanize<T>(IEnumerable<T>, CultureInfo)` for explicitly selecting collection punctuation
- resolve the existing collection formatter through `CollectionFormatters.ResolveForCulture`
- preserve every existing overload and default while rejecting a null explicit culture
- add focused behavior/null coverage and update all public API approvals

Example:

```csharp
new[] { "one", "two", "three" }.Humanize(new CultureInfo("en-GB"));
// "one, two and three"
```

Fixes #1269

## Validation

- focused collection tests on `net11.0` (18 passed)
- focused public API approval on `net11.0` (1 passed)
- full `net8.0` suite (57,784 passed)
- full `net10.0` suite (57,784 passed)
- full `net11.0` suite (57,784 passed)
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` (0 files changed)
- Release pack succeeded and produced `Humanizer.3.5.0-preview.118.g272a903e7a.nupkg`

## Checklist

- [x] Implementation is clean and follows existing coding standards
- [x] No code-analysis or formatting warnings
- [x] Unit-test coverage added
- [x] No copied code
- [x] No explanatory comments needed
- [x] XML documentation added for the new API
- [x] Rebased onto current `main`
- [x] Issue linked with `Fixes #1269`
- [x] README change not needed for this focused overload
- [x] Supported .NET test suites and Release pack completed successfully
