### PR TITLE
fix: support enum dehumanize aliases

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,7 +190,8 @@ Convert humanized strings back to their original enum values:
 ```
 
 The method is case-insensitive and recognizes raw and humanized enum names, `DisplayAttribute` name,
-description, and short-name values, plus configured description attribute values.
+description, and short-name values, plus a configured description attribute value when selected as
+the member's authored description.
 
 
 ### Humanize DateTime

--- a/readme.md
+++ b/readme.md
@@ -189,7 +189,8 @@ Convert humanized strings back to their original enum values:
 "Invalid".DehumanizeTo<UserType>(OnNoMatch.ReturnsNull) => null
 ```
 
-The method honors `DescriptionAttribute` and is case-insensitive.
+The method is case-insensitive and recognizes raw and humanized enum names, `DisplayAttribute` name,
+description, and short-name values, plus configured description attribute values.
 
 
 ### Humanize DateTime

--- a/src/Humanizer/EnumCache.cs
+++ b/src/Humanizer/EnumCache.cs
@@ -38,7 +38,6 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
             isBitFieldEnum);
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Reflection over attribute properties is intentional and documented.")]
     static void AddAliases(Dictionary<string, T> dehumanized, string caseName, T value)
     {
         var member = TypeOfT.GetField(caseName)!;
@@ -51,25 +50,6 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
             AddAlias(displayAttribute.GetName());
             AddAlias(displayAttribute.GetDescription());
             AddAlias(displayAttribute.GetShortName());
-        }
-
-        foreach (var attr in member.GetCustomAttributes())
-        {
-            if (attr is DisplayAttribute)
-            {
-                continue;
-            }
-
-#pragma warning disable IL2072 // Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
-            foreach (var property in attr.GetType().GetRuntimeProperties())
-#pragma warning restore IL2072
-            {
-                if (property.PropertyType == typeof(string) &&
-                    Configurator.EnumDescriptionPropertyLocator(property))
-                {
-                    AddAlias((string?)property.GetValue(attr, null));
-                }
-            }
         }
 
         void AddAlias(string? alias)

--- a/src/Humanizer/EnumCache.cs
+++ b/src/Humanizer/EnumCache.cs
@@ -12,10 +12,16 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
     private static (T Zero, FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized, FrozenDictionary<string, T> Dehumanized, FrozenSet<T> Values, bool IsBitFieldEnum) CreateInfo()
     {
         var valuesArray = Enum.GetValues<T>();
+        var namesArray = Enum.GetNames(TypeOfT);
         var zero = (T)Convert.ChangeType(Enum.ToObject(TypeOfT, 0), TypeOfT);
         var count = valuesArray.Length;
         var humanized = new Dictionary<T, (string Text, bool IsMetadata)>(count);
-        var dehumanized = new Dictionary<string, T>(count, StringComparer.OrdinalIgnoreCase);
+        var dehumanized = new Dictionary<string, T>(count * 6, StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < namesArray.Length; i++)
+        {
+            AddAliases(dehumanized, namesArray[i], valuesArray[i]);
+        }
+
         foreach (var value in valuesArray)
         {
             var description = GetDescription(value);
@@ -30,6 +36,49 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
             dehumanized.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase),
             valuesArray.ToFrozenSet(),
             isBitFieldEnum);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Reflection over attribute properties is intentional and documented.")]
+    static void AddAliases(Dictionary<string, T> dehumanized, string caseName, T value)
+    {
+        var member = TypeOfT.GetField(caseName)!;
+        dehumanized[caseName] = value;
+        dehumanized[caseName.Humanize()] = value;
+
+        var displayAttribute = member.GetCustomAttribute<DisplayAttribute>();
+        if (displayAttribute != null)
+        {
+            AddAlias(displayAttribute.GetName());
+            AddAlias(displayAttribute.GetDescription());
+            AddAlias(displayAttribute.GetShortName());
+        }
+
+        foreach (var attr in member.GetCustomAttributes())
+        {
+            if (attr is DisplayAttribute)
+            {
+                continue;
+            }
+
+#pragma warning disable IL2072 // Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+            foreach (var property in attr.GetType().GetRuntimeProperties())
+#pragma warning restore IL2072
+            {
+                if (property.PropertyType == typeof(string) &&
+                    Configurator.EnumDescriptionPropertyLocator(property))
+                {
+                    AddAlias((string?)property.GetValue(attr, null));
+                }
+            }
+        }
+
+        void AddAlias(string? alias)
+        {
+            if (alias != null)
+            {
+                dehumanized[alias] = value;
+            }
+        }
     }
 
     public static (T Zero, FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized, FrozenSet<T> Values) GetInfo() =>

--- a/src/Humanizer/EnumDehumanizeExtensions.cs
+++ b/src/Humanizer/EnumDehumanizeExtensions.cs
@@ -20,12 +20,14 @@ public static class EnumDehumanizeExtensions
     /// </exception>
     /// <remarks>
     /// The method attempts to match the input string against:
-    /// 1. The exact enum member name
-    /// 2. The humanized version of the enum member name
-    /// 3. <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.Name"/>,
+    /// <list type="number">
+    /// <item><description>The exact enum member name.</description></item>
+    /// <item><description>The humanized version of the enum member name.</description></item>
+    /// <item><description><see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.Name"/>,
     /// <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.Description"/>, and
-    /// <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.ShortName"/> values
-    /// 4. Any configured description attribute value on the enum member
+    /// <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.ShortName"/> values.</description></item>
+    /// <item><description>The configured description attribute value when selected as the member's authored description.</description></item>
+    /// </list>
     /// Matching is case-insensitive and does not trim whitespace. If aliases collide, later values in the enum's
     /// unsigned numeric order take precedence, while the current humanized representation takes precedence over
     /// supplemental aliases.

--- a/src/Humanizer/EnumDehumanizeExtensions.cs
+++ b/src/Humanizer/EnumDehumanizeExtensions.cs
@@ -6,8 +6,8 @@ namespace Humanizer;
 public static class EnumDehumanizeExtensions
 {
     /// <summary>
-    /// Converts a humanized string back to its original enum value by matching it against enum member names 
-    /// and their humanized representations (including <see cref="System.ComponentModel.DescriptionAttribute"/> values).
+    /// Converts a humanized string back to its original enum value by matching it against enum member names,
+    /// their humanized representations, and configured metadata aliases.
     /// </summary>
     /// <typeparam name="TTargetEnum">The enum type to convert to. Must be a struct and implement <see cref="Enum"/>.</typeparam>
     /// <param name="input">The humanized string to be converted back to an enum value. Must not be null.</param>
@@ -16,15 +16,19 @@ public static class EnumDehumanizeExtensions
     /// </returns>
     /// <exception cref="ArgumentException">Thrown when <typeparamref name="TTargetEnum"/> is not an enum type.</exception>
     /// <exception cref="NoMatchFoundException">
-    /// Thrown when no enum member matches the input string (including checking member names, 
-    /// humanized names, and description attributes).
+    /// Thrown when no enum member matches the input string.
     /// </exception>
     /// <remarks>
     /// The method attempts to match the input string against:
     /// 1. The exact enum member name
     /// 2. The humanized version of the enum member name
-    /// 3. Any <see cref="System.ComponentModel.DescriptionAttribute"/> value on the enum member
-    /// Matching is case-sensitive.
+    /// 3. <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.Name"/>,
+    /// <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.Description"/>, and
+    /// <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.ShortName"/> values
+    /// 4. Any configured description attribute value on the enum member
+    /// Matching is case-insensitive and does not trim whitespace. If aliases collide, later values in the enum's
+    /// unsigned numeric order take precedence, while the current humanized representation takes precedence over
+    /// supplemental aliases.
     /// </remarks>
     /// <example>
     /// <code>

--- a/tests/Humanizer.Tests/EnumHumanizeTests.cs
+++ b/tests/Humanizer.Tests/EnumHumanizeTests.cs
@@ -192,6 +192,8 @@ public class EnumHumanizeTests
     [InlineData(EnumTestsResources.MemberWithoutDescriptionAttributeTitle, EnumUnderTest.MemberWithoutDescriptionAttribute)]
     [InlineData(EnumTestsResources.MemberWithoutDescriptionAttributeLowerCase, EnumUnderTest.MemberWithoutDescriptionAttribute)]
     [InlineData(EnumTestsResources.MemberWithoutDescriptionAttributeSentence, EnumUnderTest.MemberWithoutDescriptionAttribute)]
+    [InlineData(nameof(EnumUnderTest.MemberWithoutDescriptionAttribute), EnumUnderTest.MemberWithoutDescriptionAttribute)]
+    [InlineData("memberwithoutdescriptionattribute", EnumUnderTest.MemberWithoutDescriptionAttribute)]
     [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
     [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
     public void DehumanizeIsCaseInsensitive(string input, EnumUnderTest expectedEnum)
@@ -227,9 +229,128 @@ public class EnumHumanizeTests
         Assert.Equal(EnumUnderTest.MemberWithLocalizedDisplayAttribute, EnumTestsResources.MemberWithLocalizedDisplayAttribute.DehumanizeTo(typeof(EnumUnderTest)));
     }
 
+    [Theory]
+    [InlineData(nameof(EnumAliasesUnderTest.RawEnumName))]
+    [InlineData("Raw enum name")]
+    [InlineData("Display name")]
+    [InlineData("Display description")]
+    [InlineData("Display short name")]
+    [InlineData("Configured description")]
+    [InlineData("display SHORT name")]
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+    public void DehumanizeRecognizesEnumAliases(string input)
+    {
+        Assert.Equal(EnumAliasesUnderTest.RawEnumName, input.DehumanizeTo<EnumAliasesUnderTest>());
+        Assert.Equal(EnumAliasesUnderTest.RawEnumName, input.DehumanizeTo(typeof(EnumAliasesUnderTest)));
+        Assert.Equal("Display description", EnumAliasesUnderTest.RawEnumName.Humanize());
+    }
+
+    [Fact]
+    public void DehumanizeDoesNotTrimAliases() =>
+        Assert.Null(" Display name ".DehumanizeTo<EnumAliasesUnderTest>(OnNoMatch.ReturnsNull));
+
+    [Fact]
+    public void DehumanizeRecognizesShortNameWithoutChangingHumanizeSource()
+    {
+        Assert.Equal(EnumShortNameAliasUnderTest.RawEnumName, "Display short name".DehumanizeTo<EnumShortNameAliasUnderTest>());
+        Assert.Equal("Raw enum name", EnumShortNameAliasUnderTest.RawEnumName.Humanize());
+    }
+
+    [Fact]
+    public void DehumanizeRecognizesConfiguredDescriptionAliasAlongsideDisplayMetadata()
+    {
+        Configurator.ResetUseEnumDescriptionPropertyLocator();
+        Configurator.UseEnumDescriptionPropertyLocator(p => p.Name == "Info");
+        try
+        {
+            Assert.Equal(EnumCustomAliasUnderTest.RawEnumName, "Configured description".DehumanizeTo<EnumCustomAliasUnderTest>());
+            Assert.Equal("Display description", EnumCustomAliasUnderTest.RawEnumName.Humanize());
+        }
+        finally
+        {
+            Configurator.ResetUseEnumDescriptionPropertyLocator();
+        }
+    }
+
+    [Theory]
+    [InlineData(nameof(BitFieldEnumUnderTest.DARK_GRAY))]
+    [InlineData("dark gray")]
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+    public void DehumanizePreservesFlagsAliases(string input)
+    {
+        Assert.Equal(BitFieldEnumUnderTest.DARK_GRAY, input.DehumanizeTo<BitFieldEnumUnderTest>());
+        Assert.Equal(BitFieldEnumUnderTest.DARK_GRAY, input.DehumanizeTo(typeof(BitFieldEnumUnderTest)));
+    }
+
+    [Theory]
+    [InlineData(nameof(EnumAliasCollisionUnderTest.RawName), (int)EnumAliasCollisionUnderTest.MetadataName)]
+    [InlineData("Supplemental collision", (int)EnumAliasCollisionUnderTest.LaterValue)]
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+    public void DehumanizeAliasCollisionsUseExistingCachePrecedence(string input, int expectedValue)
+    {
+        var expected = (EnumAliasCollisionUnderTest)expectedValue;
+        Assert.Equal(expected, input.DehumanizeTo<EnumAliasCollisionUnderTest>());
+        Assert.Equal(expected, input.DehumanizeTo(typeof(EnumAliasCollisionUnderTest)));
+    }
+
+    [Theory]
+    [InlineData(nameof(EnumDuplicateValueAliasesUnderTest.FirstName))]
+    [InlineData(nameof(EnumDuplicateValueAliasesUnderTest.SecondName))]
+    [InlineData("First display name")]
+    [InlineData("Second display name")]
+    public void DehumanizeRecognizesAliasesForDuplicateEnumValues(string input) =>
+        Assert.Equal(EnumDuplicateValueAliasesUnderTest.FirstName, input.DehumanizeTo<EnumDuplicateValueAliasesUnderTest>());
+
     enum DummyEnum
     {
         First,
         Second
     }
+
+    enum EnumAliasesUnderTest
+    {
+        [System.ComponentModel.Description("Configured description")]
+        [System.ComponentModel.DataAnnotations.Display(
+            Name = "Display name",
+            Description = "Display description",
+            ShortName = "Display short name")]
+        RawEnumName
+    }
+
+    enum EnumShortNameAliasUnderTest
+    {
+        [System.ComponentModel.DataAnnotations.Display(ShortName = "Display short name")]
+        RawEnumName
+    }
+
+    enum EnumCustomAliasUnderTest
+    {
+        [CustomProperty("Configured description")]
+        [System.ComponentModel.DataAnnotations.Display(Description = "Display description")]
+        RawEnumName
+    }
+
+    enum EnumAliasCollisionUnderTest
+    {
+        RawName = 0,
+        [System.ComponentModel.Description(nameof(RawName))]
+        MetadataName = 1,
+        [System.ComponentModel.DataAnnotations.Display(Name = "Supplemental collision", Description = "Later canonical")]
+        LaterValue = 3,
+        [System.ComponentModel.DataAnnotations.Display(Name = "Supplemental collision", Description = "Earlier canonical")]
+        EarlierValue = 2
+    }
+
+#pragma warning disable CA1069 // Duplicate values verify aliases for every declared enum name.
+    enum EnumDuplicateValueAliasesUnderTest
+    {
+        [System.ComponentModel.DataAnnotations.Display(Name = "First display name")]
+        FirstName = 0,
+        [System.ComponentModel.DataAnnotations.Display(Name = "Second display name")]
+        SecondName = 0
+    }
+#pragma warning restore CA1069
 }

--- a/tests/Humanizer.Tests/EnumHumanizeTests.cs
+++ b/tests/Humanizer.Tests/EnumHumanizeTests.cs
@@ -235,7 +235,6 @@ public class EnumHumanizeTests
     [InlineData("Display name")]
     [InlineData("Display description")]
     [InlineData("Display short name")]
-    [InlineData("Configured description")]
     [InlineData("display SHORT name")]
     [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
     [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
@@ -258,14 +257,14 @@ public class EnumHumanizeTests
     }
 
     [Fact]
-    public void DehumanizeRecognizesConfiguredDescriptionAliasAlongsideDisplayMetadata()
+    public void DehumanizeRecognizesConfiguredDescriptionAsCanonicalAlias()
     {
         Configurator.ResetUseEnumDescriptionPropertyLocator();
         Configurator.UseEnumDescriptionPropertyLocator(p => p.Name == "Info");
         try
         {
             Assert.Equal(EnumCustomAliasUnderTest.RawEnumName, "Configured description".DehumanizeTo<EnumCustomAliasUnderTest>());
-            Assert.Equal("Display description", EnumCustomAliasUnderTest.RawEnumName.Humanize());
+            Assert.Equal("Configured description", EnumCustomAliasUnderTest.RawEnumName.Humanize());
         }
         finally
         {
@@ -329,7 +328,6 @@ public class EnumHumanizeTests
     enum EnumCustomAliasUnderTest
     {
         [CustomProperty("Configured description")]
-        [System.ComponentModel.DataAnnotations.Display(Description = "Display description")]
         RawEnumName
     }
 


### PR DESCRIPTION
## Summary

Enum values with authored metadata can now be dehumanized from their raw member names as well as their canonical humanized text. Dehumanization also recognizes humanized raw names, `Display.Name`, `Display.Description`, `Display.ShortName`, and configured description values when selected as the canonical description, without changing Humanize output or existing collision winners.

Reported by @parvindsaini. The `Display.ShortName` and normalization acceptance points were contributed by @KillyMXI.

Fixes #700.

## Related

- Related: #1490
- Related: #926 remains the separate Humanize source-selection API request.

## Validation

- Focused net8 enum tests after review fixes: 65 passed
- Focused net8 public API approval: 1 passed
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — 0 files changed
- Full `Humanizer.Tests` net8.0: 57,816 passed
- Full `Humanizer.Tests` net10.0: 57,816 passed
- Full `Humanizer.Tests` net11.0: 57,816 passed
- Release pack after review fixes across net48, netstandard2.0, net8.0, net10.0, and net11.0 succeeded without trim/AOT analyzer warnings

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] Unit tests cover metadata aliases, collisions, casing, flags, duplicate values, and no-metadata compatibility
- [x] No external code was copied
- [x] XML documentation is updated
- [x] Branch is rebased on the latest `main`
- [x] Issue is linked with a closing reference
- [x] README is updated
- [x] Supported test targets and Release pack pass
