### PR TITLE
feat: add TimeSpan humanization strategy

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -150,10 +150,8 @@ Implement custom date/time/number formatting:
 ```csharp
 public interface IFormatter
 {
-    string DateHumanize(DateTime value, DateTime? comparisonBase, 
-                       CultureInfo culture);
-    string TimeSpanHumanize(TimeSpan timeSpan, int precision, 
-                           CultureInfo culture);
+    string DateHumanize(TimeUnit timeUnit, Tense timeUnitTense, int unit);
+    string TimeSpanHumanize(TimeUnit timeUnit, int unit, bool toWords = false);
     // ... other methods
 }
 ```
@@ -162,6 +160,12 @@ Register your formatter:
 
 ```csharp
 Configurator.Formatters.Register("my-culture", new MyFormatter());
+```
+
+Formatters localize time units after Humanizer selects them. To customize `TimeSpan` decomposition, precision, bounds, separators, or word and symbol selection, implement `ITimeSpanHumanizeStrategy` and register it at application startup:
+
+```csharp
+Configurator.TimeSpanHumanizeStrategy = new MyTimeSpanHumanizeStrategy();
 ```
 
 ## Configuration

--- a/src/Humanizer/Configuration/Configurator.cs
+++ b/src/Humanizer/Configuration/Configurator.cs
@@ -116,6 +116,16 @@ public static partial class Configurator
     /// </remarks>
     public static IDateTimeOffsetHumanizeStrategy DateTimeOffsetHumanizeStrategy { get; set; } = new DefaultDateTimeOffsetHumanizeStrategy();
 
+    /// <summary>
+    /// The strategy to be used for TimeSpan.Humanize and TimeSpan.HumanizeToSymbols
+    /// </summary>
+    /// <remarks>
+    /// This property should be set only once during application startup before any humanization operations occur.
+    /// For thread-safety, use volatile reads or appropriate synchronization when accessing this property in multi-threaded scenarios.
+    /// In production applications, avoid changing this value after the application has started serving requests.
+    /// </remarks>
+    public static ITimeSpanHumanizeStrategy TimeSpanHumanizeStrategy { get; set; } = new DefaultTimeSpanHumanizeStrategy();
+
 #if NET6_0_OR_GREATER
     /// <summary>
     /// The strategy to be used for DateOnly.Humanize

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -21,7 +21,7 @@ public static class TimeSpanHumanizeExtensions
     /// <param name="collectionSeparator">The separator to use when combining humanized time parts. If null, the default collection formatter for the current culture is used.</param>
     /// <param name="toWords">Uses words instead of numbers if true. E.g. one day.</param>
     public static string Humanize(this TimeSpan timeSpan, int precision = 1, CultureInfo? culture = null, TimeUnit maxUnit = TimeUnit.Week, TimeUnit minUnit = TimeUnit.Millisecond, string? collectionSeparator = ", ", bool toWords = false) =>
-        Humanize(timeSpan, precision, false, culture, maxUnit, minUnit, collectionSeparator, toWords);
+        Configurator.TimeSpanHumanizeStrategy.Humanize(timeSpan, precision, false, culture, maxUnit, minUnit, collectionSeparator, toWords, false);
 
     /// <summary>
     /// Turns a <see cref="TimeSpan"/> into a human readable form using localized unit symbols.
@@ -39,7 +39,7 @@ public static class TimeSpanHumanizeExtensions
         TimeUnit maxUnit = TimeUnit.Week,
         TimeUnit minUnit = TimeUnit.Millisecond,
         string? collectionSeparator = ", ") =>
-        Humanize(timeSpan, precision, false, culture, maxUnit, minUnit, collectionSeparator, false, true);
+        Configurator.TimeSpanHumanizeStrategy.Humanize(timeSpan, precision, false, culture, maxUnit, minUnit, collectionSeparator, false, true);
 
     /// <summary>
     /// Turns a TimeSpan into a human readable form. E.g. 1 day.
@@ -52,7 +52,7 @@ public static class TimeSpanHumanizeExtensions
     /// <param name="collectionSeparator">The separator to use when combining humanized time parts. If null, the default collection formatter for the current culture is used.</param>
     /// <param name="toWords">Uses words instead of numbers if true. E.g. one day.</param>
     public static string Humanize(this TimeSpan timeSpan, int precision, bool countEmptyUnits, CultureInfo? culture = null, TimeUnit maxUnit = TimeUnit.Week, TimeUnit minUnit = TimeUnit.Millisecond, string? collectionSeparator = ", ", bool toWords = false)
-        => Humanize(timeSpan, precision, countEmptyUnits, culture, maxUnit, minUnit, collectionSeparator, toWords, false);
+        => Configurator.TimeSpanHumanizeStrategy.Humanize(timeSpan, precision, countEmptyUnits, culture, maxUnit, minUnit, collectionSeparator, toWords, false);
 
     /// <summary>
     /// Turns a <see cref="TimeSpan"/> into a human readable form using localized unit symbols.
@@ -72,9 +72,9 @@ public static class TimeSpanHumanizeExtensions
         TimeUnit maxUnit = TimeUnit.Week,
         TimeUnit minUnit = TimeUnit.Millisecond,
         string? collectionSeparator = ", ") =>
-        Humanize(timeSpan, precision, countEmptyUnits, culture, maxUnit, minUnit, collectionSeparator, false, true);
+        Configurator.TimeSpanHumanizeStrategy.Humanize(timeSpan, precision, countEmptyUnits, culture, maxUnit, minUnit, collectionSeparator, false, true);
 
-    static string Humanize(
+    internal static string DefaultHumanize(
         TimeSpan timeSpan,
         int precision,
         bool countEmptyUnits,

--- a/src/Humanizer/TimeSpanHumanizeStrategy/DefaultTimeSpanHumanizeStrategy.cs
+++ b/src/Humanizer/TimeSpanHumanizeStrategy/DefaultTimeSpanHumanizeStrategy.cs
@@ -1,0 +1,29 @@
+namespace Humanizer;
+
+/// <summary>
+/// The default strategy for converting <see cref="TimeSpan"/> values into human-readable text.
+/// </summary>
+public class DefaultTimeSpanHumanizeStrategy : ITimeSpanHumanizeStrategy
+{
+    /// <inheritdoc />
+    public string Humanize(
+        TimeSpan timeSpan,
+        int precision,
+        bool countEmptyUnits,
+        CultureInfo? culture,
+        TimeUnit maxUnit,
+        TimeUnit minUnit,
+        string? collectionSeparator,
+        bool toWords,
+        bool toSymbols) =>
+        TimeSpanHumanizeExtensions.DefaultHumanize(
+            timeSpan,
+            precision,
+            countEmptyUnits,
+            culture,
+            maxUnit,
+            minUnit,
+            collectionSeparator,
+            toWords,
+            toSymbols);
+}

--- a/src/Humanizer/TimeSpanHumanizeStrategy/ITimeSpanHumanizeStrategy.cs
+++ b/src/Humanizer/TimeSpanHumanizeStrategy/ITimeSpanHumanizeStrategy.cs
@@ -1,0 +1,31 @@
+namespace Humanizer;
+
+/// <summary>
+/// Defines a strategy for converting <see cref="TimeSpan"/> values into human-readable text.
+/// </summary>
+public interface ITimeSpanHumanizeStrategy
+{
+    /// <summary>
+    /// Converts a <see cref="TimeSpan"/> into human-readable text.
+    /// </summary>
+    /// <param name="timeSpan">The time span to humanize.</param>
+    /// <param name="precision">The maximum number of time units to return.</param>
+    /// <param name="countEmptyUnits">Whether empty time units count toward <paramref name="precision"/>.</param>
+    /// <param name="culture">The culture to use. If null, the current culture is used.</param>
+    /// <param name="maxUnit">The maximum unit of time to output.</param>
+    /// <param name="minUnit">The minimum unit of time to output.</param>
+    /// <param name="collectionSeparator">The separator used to combine time parts. If null, the culture's default collection formatter is used.</param>
+    /// <param name="toWords">Whether numbers are rendered as words.</param>
+    /// <param name="toSymbols">Whether time units are rendered as symbols.</param>
+    /// <returns>The human-readable time span.</returns>
+    string Humanize(
+        TimeSpan timeSpan,
+        int precision,
+        bool countEmptyUnits,
+        CultureInfo? culture,
+        TimeUnit maxUnit,
+        TimeUnit minUnit,
+        string? collectionSeparator,
+        bool toWords,
+        bool toSymbols);
+}

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -241,6 +241,7 @@ namespace Humanizer
         public static Humanizer.LocaliserRegistry<Humanizer.IOrdinalizer> Ordinalizers { get; }
         public static Humanizer.ITimeOnlyHumanizeStrategy TimeOnlyHumanizeStrategy { get; set; }
         public static Humanizer.LocaliserRegistry<Humanizer.ITimeOnlyToClockNotationConverter> TimeOnlyToClockNotationConverters { get; }
+        public static Humanizer.ITimeSpanHumanizeStrategy TimeSpanHumanizeStrategy { get; set; }
         public static bool IsCultureSupported(System.Globalization.CultureInfo culture) { }
         public static void UseEnumDescriptionPropertyLocator(System.Func<System.Reflection.PropertyInfo, bool> func) { }
     }
@@ -312,6 +313,11 @@ namespace Humanizer
     {
         public DefaultTimeOnlyHumanizeStrategy() { }
         public string Humanize(System.TimeOnly input, System.TimeOnly comparisonBase, System.Globalization.CultureInfo? culture) { }
+    }
+    public class DefaultTimeSpanHumanizeStrategy : Humanizer.ITimeSpanHumanizeStrategy
+    {
+        public DefaultTimeSpanHumanizeStrategy() { }
+        public string Humanize(System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture, Humanizer.TimeUnit maxUnit, Humanizer.TimeUnit minUnit, string? collectionSeparator, bool toWords, bool toSymbols) { }
     }
     public class DynamicNumberOfCharactersAndPreserveWordsTruncator : Humanizer.ITruncator
     {
@@ -456,6 +462,10 @@ namespace Humanizer
     public interface ITimeOnlyToClockNotationConverter
     {
         string Convert(System.TimeOnly time, Humanizer.ClockNotationRounding roundToNearestFive);
+    }
+    public interface ITimeSpanHumanizeStrategy
+    {
+        string Humanize(System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture, Humanizer.TimeUnit maxUnit, Humanizer.TimeUnit minUnit, string? collectionSeparator, bool toWords, bool toSymbols);
     }
     public interface ITruncator
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -241,6 +241,7 @@ namespace Humanizer
         public static Humanizer.LocaliserRegistry<Humanizer.IOrdinalizer> Ordinalizers { get; }
         public static Humanizer.ITimeOnlyHumanizeStrategy TimeOnlyHumanizeStrategy { get; set; }
         public static Humanizer.LocaliserRegistry<Humanizer.ITimeOnlyToClockNotationConverter> TimeOnlyToClockNotationConverters { get; }
+        public static Humanizer.ITimeSpanHumanizeStrategy TimeSpanHumanizeStrategy { get; set; }
         public static bool IsCultureSupported(System.Globalization.CultureInfo culture) { }
         public static void UseEnumDescriptionPropertyLocator(System.Func<System.Reflection.PropertyInfo, bool> func) { }
     }
@@ -312,6 +313,11 @@ namespace Humanizer
     {
         public DefaultTimeOnlyHumanizeStrategy() { }
         public string Humanize(System.TimeOnly input, System.TimeOnly comparisonBase, System.Globalization.CultureInfo? culture) { }
+    }
+    public class DefaultTimeSpanHumanizeStrategy : Humanizer.ITimeSpanHumanizeStrategy
+    {
+        public DefaultTimeSpanHumanizeStrategy() { }
+        public string Humanize(System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture, Humanizer.TimeUnit maxUnit, Humanizer.TimeUnit minUnit, string? collectionSeparator, bool toWords, bool toSymbols) { }
     }
     public class DynamicNumberOfCharactersAndPreserveWordsTruncator : Humanizer.ITruncator
     {
@@ -456,6 +462,10 @@ namespace Humanizer
     public interface ITimeOnlyToClockNotationConverter
     {
         string Convert(System.TimeOnly time, Humanizer.ClockNotationRounding roundToNearestFive);
+    }
+    public interface ITimeSpanHumanizeStrategy
+    {
+        string Humanize(System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture, Humanizer.TimeUnit maxUnit, Humanizer.TimeUnit minUnit, string? collectionSeparator, bool toWords, bool toSymbols);
     }
     public interface ITruncator
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -240,6 +240,7 @@ namespace Humanizer
         public static Humanizer.LocaliserRegistry<Humanizer.IOrdinalizer> Ordinalizers { get; }
         public static Humanizer.ITimeOnlyHumanizeStrategy TimeOnlyHumanizeStrategy { get; set; }
         public static Humanizer.LocaliserRegistry<Humanizer.ITimeOnlyToClockNotationConverter> TimeOnlyToClockNotationConverters { get; }
+        public static Humanizer.ITimeSpanHumanizeStrategy TimeSpanHumanizeStrategy { get; set; }
         public static bool IsCultureSupported(System.Globalization.CultureInfo culture) { }
         public static void UseEnumDescriptionPropertyLocator(System.Func<System.Reflection.PropertyInfo, bool> func) { }
     }
@@ -311,6 +312,11 @@ namespace Humanizer
     {
         public DefaultTimeOnlyHumanizeStrategy() { }
         public string Humanize(System.TimeOnly input, System.TimeOnly comparisonBase, System.Globalization.CultureInfo? culture) { }
+    }
+    public class DefaultTimeSpanHumanizeStrategy : Humanizer.ITimeSpanHumanizeStrategy
+    {
+        public DefaultTimeSpanHumanizeStrategy() { }
+        public string Humanize(System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture, Humanizer.TimeUnit maxUnit, Humanizer.TimeUnit minUnit, string? collectionSeparator, bool toWords, bool toSymbols) { }
     }
     public class DynamicNumberOfCharactersAndPreserveWordsTruncator : Humanizer.ITruncator
     {
@@ -455,6 +461,10 @@ namespace Humanizer
     public interface ITimeOnlyToClockNotationConverter
     {
         string Convert(System.TimeOnly time, Humanizer.ClockNotationRounding roundToNearestFive);
+    }
+    public interface ITimeSpanHumanizeStrategy
+    {
+        string Humanize(System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture, Humanizer.TimeUnit maxUnit, Humanizer.TimeUnit minUnit, string? collectionSeparator, bool toWords, bool toSymbols);
     }
     public interface ITruncator
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -235,6 +235,7 @@ namespace Humanizer
         public static Humanizer.LocaliserRegistry<Humanizer.IFormatter> Formatters { get; }
         public static Humanizer.LocaliserRegistry<Humanizer.INumberToWordsConverter> NumberToWordsConverters { get; }
         public static Humanizer.LocaliserRegistry<Humanizer.IOrdinalizer> Ordinalizers { get; }
+        public static Humanizer.ITimeSpanHumanizeStrategy TimeSpanHumanizeStrategy { get; set; }
         public static bool IsCultureSupported(System.Globalization.CultureInfo culture) { }
         public static void UseEnumDescriptionPropertyLocator(System.Func<System.Reflection.PropertyInfo, bool> func) { }
     }
@@ -290,6 +291,11 @@ namespace Humanizer
         public virtual string TimeSpanHumanize_Age() { }
         public virtual string TimeSpanHumanize_Zero() { }
         public virtual string TimeUnitHumanize(Humanizer.TimeUnit timeUnit) { }
+    }
+    public class DefaultTimeSpanHumanizeStrategy : Humanizer.ITimeSpanHumanizeStrategy
+    {
+        public DefaultTimeSpanHumanizeStrategy() { }
+        public string Humanize(System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture, Humanizer.TimeUnit maxUnit, Humanizer.TimeUnit minUnit, string? collectionSeparator, bool toWords, bool toSymbols) { }
     }
     public class DynamicNumberOfCharactersAndPreserveWordsTruncator : Humanizer.ITruncator
     {
@@ -409,6 +415,10 @@ namespace Humanizer
     public interface IStringTransformer
     {
         string Transform(string input);
+    }
+    public interface ITimeSpanHumanizeStrategy
+    {
+        string Humanize(System.TimeSpan timeSpan, int precision, bool countEmptyUnits, System.Globalization.CultureInfo? culture, Humanizer.TimeUnit maxUnit, Humanizer.TimeUnit minUnit, string? collectionSeparator, bool toWords, bool toSymbols);
     }
     public interface ITruncator
     {

--- a/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
+++ b/tests/Humanizer.Tests/TimeSpanHumanizeTests.cs
@@ -589,4 +589,103 @@ public class TimeSpanHumanizeTests
 
         Assert.Equal("1h", actual);
     }
+
+    [Fact]
+    public void DefaultStrategyPreservesExistingOutputs()
+    {
+        var strategy = new DefaultTimeSpanHumanizeStrategy();
+        var timeSpan = new TimeSpan(8, 1, 2, 3, 4);
+
+        Assert.Equal(
+            "1 week, 1 day, 1 hour",
+            strategy.Humanize(timeSpan, 3, false, new("en-US"), TimeUnit.Week, TimeUnit.Millisecond, ", ", false, false));
+        Assert.Equal(
+            "1week, 1d, 1h",
+            strategy.Humanize(timeSpan, 3, false, new("en-US"), TimeUnit.Week, TimeUnit.Millisecond, ", ", false, true));
+    }
+
+    [Fact]
+    public void ConfiguredStrategyReceivesEveryOptionFromEveryOverload()
+    {
+        var originalStrategy = Configurator.TimeSpanHumanizeStrategy;
+        var strategy = new RecordingTimeSpanHumanizeStrategy();
+        var culture = new CultureInfo("fr");
+        strategy.Target = TimeSpan.FromTicks(123456789012341);
+
+        try
+        {
+            Configurator.TimeSpanHumanizeStrategy = strategy;
+
+            Assert.Equal("custom", strategy.Target.Humanize(2, culture, TimeUnit.Day, TimeUnit.Second, " / ", true));
+            Assert.Equal(new(strategy.Target, 2, false, culture, TimeUnit.Day, TimeUnit.Second, " / ", true, false), strategy.LastCall);
+
+            strategy.Target = TimeSpan.FromTicks(123456789012342);
+            Assert.Equal("custom", strategy.Target.Humanize(3, true, culture, TimeUnit.Hour, TimeUnit.Minute, " + ", true));
+            Assert.Equal(new(strategy.Target, 3, true, culture, TimeUnit.Hour, TimeUnit.Minute, " + ", true, false), strategy.LastCall);
+
+            strategy.Target = TimeSpan.FromTicks(123456789012343);
+            Assert.Equal("custom", strategy.Target.HumanizeToSymbols(4, culture, TimeUnit.Month, TimeUnit.Week, " | "));
+            Assert.Equal(new(strategy.Target, 4, false, culture, TimeUnit.Month, TimeUnit.Week, " | ", false, true), strategy.LastCall);
+
+            strategy.Target = TimeSpan.FromTicks(123456789012344);
+            Assert.Equal("custom", strategy.Target.HumanizeToSymbols(5, true, culture, TimeUnit.Year, TimeUnit.Day, null));
+            Assert.Equal(new(strategy.Target, 5, true, culture, TimeUnit.Year, TimeUnit.Day, null, false, true), strategy.LastCall);
+
+            Assert.Equal(4, strategy.CallCount);
+        }
+        finally
+        {
+            Configurator.TimeSpanHumanizeStrategy = originalStrategy;
+        }
+    }
+
+    sealed class RecordingTimeSpanHumanizeStrategy : ITimeSpanHumanizeStrategy
+    {
+        readonly DefaultTimeSpanHumanizeStrategy defaultStrategy = new();
+
+        public TimeSpan Target { get; set; }
+        public int CallCount { get; private set; }
+        public TimeSpanHumanizeCall? LastCall { get; private set; }
+
+        public string Humanize(
+            TimeSpan timeSpan,
+            int precision,
+            bool countEmptyUnits,
+            CultureInfo? culture,
+            TimeUnit maxUnit,
+            TimeUnit minUnit,
+            string? collectionSeparator,
+            bool toWords,
+            bool toSymbols)
+        {
+            if (timeSpan != Target)
+            {
+                return defaultStrategy.Humanize(
+                    timeSpan,
+                    precision,
+                    countEmptyUnits,
+                    culture,
+                    maxUnit,
+                    minUnit,
+                    collectionSeparator,
+                    toWords,
+                    toSymbols);
+            }
+
+            CallCount++;
+            LastCall = new(timeSpan, precision, countEmptyUnits, culture, maxUnit, minUnit, collectionSeparator, toWords, toSymbols);
+            return "custom";
+        }
+    }
+
+    sealed record TimeSpanHumanizeCall(
+        TimeSpan TimeSpan,
+        int Precision,
+        bool CountEmptyUnits,
+        CultureInfo? Culture,
+        TimeUnit MaxUnit,
+        TimeUnit MinUnit,
+        string? CollectionSeparator,
+        bool ToWords,
+        bool ToSymbols);
 }


### PR DESCRIPTION
## Summary

`TimeSpan.Humanize` and `HumanizeToSymbols` can now use an application-defined decomposition strategy, including precision, empty-unit counting, culture, bounds, separators, and word or symbol output. The default strategy remains directly callable and preserves existing output, while formatters continue to localize only the units selected by the strategy.

Thanks to @Chris55 for reporting the missing extensibility point.

Fixes #1038.

## Validation

- [x] `TimeSpanHumanizeTests` passed: 325/325 on net8
- [x] Public API approval passed on net8
- [x] `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
- [x] Full `Humanizer.Tests` matrix: 57,865/57,865 on each of net8, net10, and net11
- [x] Release pack succeeded for netstandard2.0, net48, net8, net10, and net11

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or OSS
- [x] There are very few or no comments
- [x] XML documentation is added for the public API
- [x] The branch is rebased on the latest `main`
- [x] The issue is linked with `Fixes #1038`
- [x] Extensibility documentation is updated
- [x] The supported test and package matrix passes
