### PR TITLE
feat: add decimal common fraction formatting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -807,6 +807,17 @@ CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("de-DE");
 "100m".FromMetric() => 0.1
 ```
 
+### Common fractions
+
+Convert a decimal to the closest common fraction within a caller-supplied tolerance:
+
+```csharp
+1.25m.Fractionalize(maxDenominator: 5, tolerance: 0m) => "1 1/4"
+0.34m.Fractionalize(maxDenominator: 5, tolerance: 0.01m) => "1/3"
+0.75m.Fractionalize(maxDenominator: 4, tolerance: 0m, useUnicode: true) => "¾"
+0.11m.Fractionalize(maxDenominator: 10, tolerance: 0m) => "0.11"
+```
+
 
 ### ByteSize
 

--- a/src/Humanizer/FractionalizeExtensions.cs
+++ b/src/Humanizer/FractionalizeExtensions.cs
@@ -48,9 +48,8 @@ public static class FractionalizeExtensions
             throw new ArgumentOutOfRangeException(nameof(tolerance));
 #endif
 
-        var numberFormat = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
         if (decimal.Truncate(input) == input)
-            return input.ToString("0", numberFormat);
+            return input.ToString("0", CultureInfo.InvariantCulture);
 
         var value = ToFraction(input);
         var approximation = LimitDenominator(BigInteger.Abs(value.Numerator), value.Denominator, maxDenominator);
@@ -58,7 +57,7 @@ public static class FractionalizeExtensions
             approximation.Numerator = -approximation.Numerator;
 
         if (!IsWithinTolerance(value, approximation, ToFraction(tolerance)))
-            return input.ToString(numberFormat);
+            return input.ToString(LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture));
 
         return Format(approximation, useUnicode);
     }

--- a/src/Humanizer/FractionalizeExtensions.cs
+++ b/src/Humanizer/FractionalizeExtensions.cs
@@ -1,0 +1,192 @@
+using System.Numerics;
+
+namespace Humanizer;
+
+/// <summary>
+/// Contains extension methods for converting decimals to common fractions.
+/// </summary>
+public static class FractionalizeExtensions
+{
+    /// <summary>
+    /// Converts a decimal to the closest reduced fraction whose denominator does not exceed the specified maximum.
+    /// </summary>
+    /// <param name="input">The decimal to convert.</param>
+    /// <param name="maxDenominator">The largest denominator that may be used.</param>
+    /// <param name="tolerance">The maximum absolute difference allowed between the input and the fraction.</param>
+    /// <param name="useUnicode">Whether to use a Unicode vulgar-fraction character when an exact character exists.</param>
+    /// <returns>
+    /// A whole number, proper fraction, or mixed fraction when the closest fraction is within
+    /// <paramref name="tolerance"/>; otherwise, the culture-formatted input.
+    /// </returns>
+    /// <remarks>
+    /// The tolerance boundary is inclusive. Equidistant fractions prefer the smaller denominator,
+    /// then the value farther from zero. Fraction components use invariant digits and slash notation.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="maxDenominator"/> is less than one or <paramref name="tolerance"/> is negative.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// 1.25m.Fractionalize(5, 0m) => "1 1/4"
+    /// 0.34m.Fractionalize(5, 0.01m) => "1/3"
+    /// 0.75m.Fractionalize(4, 0m, useUnicode: true) => "¾"
+    /// </code>
+    /// </example>
+    public static string Fractionalize(
+        this decimal input,
+        int maxDenominator,
+        decimal tolerance,
+        bool useUnicode = false)
+    {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxDenominator, 1);
+        ArgumentOutOfRangeException.ThrowIfNegative(tolerance);
+#else
+        if (maxDenominator < 1)
+            throw new ArgumentOutOfRangeException(nameof(maxDenominator));
+        if (tolerance < 0)
+            throw new ArgumentOutOfRangeException(nameof(tolerance));
+#endif
+
+        var numberFormat = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
+        if (decimal.Truncate(input) == input)
+            return input.ToString("0", numberFormat);
+
+        var value = ToFraction(input);
+        var approximation = LimitDenominator(BigInteger.Abs(value.Numerator), value.Denominator, maxDenominator);
+        if (value.Numerator.Sign < 0)
+            approximation.Numerator = -approximation.Numerator;
+
+        if (!IsWithinTolerance(value, approximation, ToFraction(tolerance)))
+            return input.ToString(numberFormat);
+
+        return Format(approximation, useUnicode);
+    }
+
+    static (BigInteger Numerator, BigInteger Denominator) ToFraction(decimal value)
+    {
+        var bits = decimal.GetBits(value);
+        var numerator =
+            (BigInteger)(uint)bits[0] |
+            (BigInteger)(uint)bits[1] << 32 |
+            (BigInteger)(uint)bits[2] << 64;
+        var denominator = BigInteger.Pow(10, (bits[3] >> 16) & 0x7F);
+        var divisor = BigInteger.GreatestCommonDivisor(numerator, denominator);
+
+        if (bits[3] < 0)
+            numerator = -numerator;
+
+        return (numerator / divisor, denominator / divisor);
+    }
+
+    static (BigInteger Numerator, BigInteger Denominator) LimitDenominator(
+        BigInteger numerator,
+        BigInteger denominator,
+        int maxDenominator)
+    {
+        var originalNumerator = numerator;
+        var originalDenominator = denominator;
+        BigInteger previousNumerator = 0;
+        BigInteger previousDenominator = 1;
+        BigInteger currentNumerator = 1;
+        BigInteger currentDenominator = 0;
+
+        while (!denominator.IsZero)
+        {
+            var quotient = numerator / denominator;
+            var nextDenominator = previousDenominator + quotient * currentDenominator;
+            if (nextDenominator > maxDenominator)
+                break;
+
+            (previousNumerator, currentNumerator) =
+                (currentNumerator, previousNumerator + quotient * currentNumerator);
+            (previousDenominator, currentDenominator) = (currentDenominator, nextDenominator);
+            (numerator, denominator) = (denominator, numerator - quotient * denominator);
+        }
+
+        if (denominator.IsZero)
+            return (currentNumerator, currentDenominator);
+
+        var multiplier = (maxDenominator - previousDenominator) / currentDenominator;
+        var first = (
+            previousNumerator + multiplier * currentNumerator,
+            previousDenominator + multiplier * currentDenominator);
+        var second = (currentNumerator, currentDenominator);
+
+        var firstError = BigInteger.Abs(
+            first.Item1 * originalDenominator - originalNumerator * first.Item2);
+        var secondError = BigInteger.Abs(
+            second.Item1 * originalDenominator - originalNumerator * second.Item2);
+        var comparison = (firstError * second.Item2).CompareTo(secondError * first.Item2);
+
+        if (comparison != 0)
+            return comparison < 0 ? first : second;
+
+        if (first.Item2 != second.Item2)
+            return first.Item2 < second.Item2 ? first : second;
+
+        return first.Item1 > second.Item1 ? first : second;
+    }
+
+    static bool IsWithinTolerance(
+        (BigInteger Numerator, BigInteger Denominator) value,
+        (BigInteger Numerator, BigInteger Denominator) approximation,
+        (BigInteger Numerator, BigInteger Denominator) tolerance)
+    {
+        var difference = BigInteger.Abs(
+            approximation.Numerator * value.Denominator -
+            value.Numerator * approximation.Denominator);
+
+        return difference * tolerance.Denominator <=
+               tolerance.Numerator * value.Denominator * approximation.Denominator;
+    }
+
+    static string Format((BigInteger Numerator, BigInteger Denominator) fraction, bool useUnicode)
+    {
+        var sign = fraction.Numerator.Sign < 0 ? "-" : "";
+        var numerator = BigInteger.Abs(fraction.Numerator);
+        var whole = BigInteger.DivRem(numerator, fraction.Denominator, out var remainder);
+        var wholeText = whole.ToString(CultureInfo.InvariantCulture);
+
+        if (remainder.IsZero)
+            return sign + wholeText;
+
+        if (useUnicode && TryGetVulgarFraction(remainder, fraction.Denominator, out var vulgarFraction))
+            return sign + (whole.IsZero ? "" : wholeText) + vulgarFraction;
+
+        var fractionText =
+            remainder.ToString(CultureInfo.InvariantCulture) +
+            "/" +
+            fraction.Denominator.ToString(CultureInfo.InvariantCulture);
+
+        return sign + (whole.IsZero ? "" : wholeText + " ") + fractionText;
+    }
+
+    static bool TryGetVulgarFraction(BigInteger numerator, BigInteger denominator, out char fraction)
+    {
+        fraction = ((int)numerator, (int)denominator) switch
+        {
+            (1, 2) => '½',
+            (1, 3) => '⅓',
+            (2, 3) => '⅔',
+            (1, 4) => '¼',
+            (3, 4) => '¾',
+            (1, 5) => '⅕',
+            (2, 5) => '⅖',
+            (3, 5) => '⅗',
+            (4, 5) => '⅘',
+            (1, 6) => '⅙',
+            (5, 6) => '⅚',
+            (1, 7) => '⅐',
+            (1, 8) => '⅛',
+            (3, 8) => '⅜',
+            (5, 8) => '⅝',
+            (7, 8) => '⅞',
+            (1, 9) => '⅑',
+            (1, 10) => '⅒',
+            _ => default,
+        };
+
+        return fraction != default;
+    }
+}

--- a/src/Humanizer/FractionalizeExtensions.cs
+++ b/src/Humanizer/FractionalizeExtensions.cs
@@ -20,7 +20,8 @@ public static class FractionalizeExtensions
     /// </returns>
     /// <remarks>
     /// The tolerance boundary is inclusive. Equidistant fractions prefer the smaller denominator,
-    /// then the value farther from zero. Fraction components use invariant digits and slash notation.
+    /// then the value farther from zero. Fraction components use invariant digits; slash notation is used
+    /// unless <paramref name="useUnicode"/> requests an available exact glyph.
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="maxDenominator"/> is less than one or <paramref name="tolerance"/> is negative.

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -355,6 +355,10 @@ namespace Humanizer
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing)
             where T :  struct, System.Enum { }
     }
+    public static class FractionalizeExtensions
+    {
+        public static string Fractionalize(this decimal input, int maxDenominator, decimal tolerance, bool useUnicode = false) { }
+    }
     public enum GrammaticalCase
     {
         Nominative = 0,

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -355,6 +355,10 @@ namespace Humanizer
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing)
             where T :  struct, System.Enum { }
     }
+    public static class FractionalizeExtensions
+    {
+        public static string Fractionalize(this decimal input, int maxDenominator, decimal tolerance, bool useUnicode = false) { }
+    }
     public enum GrammaticalCase
     {
         Nominative = 0,

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -354,6 +354,10 @@ namespace Humanizer
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing)
             where T :  struct, System.Enum { }
     }
+    public static class FractionalizeExtensions
+    {
+        public static string Fractionalize(this decimal input, int maxDenominator, decimal tolerance, bool useUnicode = false) { }
+    }
     public enum GrammaticalCase
     {
         Nominative = 0,

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -325,6 +325,10 @@ namespace Humanizer
         public static string Humanize<T>(this T input, Humanizer.LetterCasing casing)
             where T :  struct, System.Enum { }
     }
+    public static class FractionalizeExtensions
+    {
+        public static string Fractionalize(this decimal input, int maxDenominator, decimal tolerance, bool useUnicode = false) { }
+    }
     public enum GrammaticalCase
     {
         Nominative = 0,

--- a/tests/Humanizer.Tests/FractionalizeTests.cs
+++ b/tests/Humanizer.Tests/FractionalizeTests.cs
@@ -1,0 +1,141 @@
+[UseCulture("en-US")]
+public class FractionalizeTests
+{
+    [Theory]
+    [InlineData("1", "1")]
+    [InlineData("1.25", "1 1/4")]
+    [InlineData("2.5", "2 1/2")]
+    [InlineData("4.33", "4 1/3")]
+    [InlineData("1.8", "1 4/5")]
+    [InlineData("0.75", "3/4")]
+    public void FractionalizesIssueExamples(string input, string expected) =>
+        Assert.Equal(expected, decimal.Parse(input, CultureInfo.InvariantCulture).Fractionalize(5, 0.01m));
+
+    [Theory]
+    [InlineData("0.34", "0.1", 5, "1/3")]
+    [InlineData("0.34", "0.0", 5, "0.34")]
+    [InlineData("0.34", "0.0", 55, "17/50")]
+    [InlineData("0.3", "0.4", 3, "1/3")]
+    [InlineData("0.199", "0.1", 5, "1/5")]
+    [InlineData("0.199", "0.1", 3, "0.199")]
+    [InlineData("0.1", "0.0", 10, "1/10")]
+    [InlineData("0.11", "0.0", 10, "0.11")]
+    public void HonorsIssueConfigurationTable(
+        string input,
+        string tolerance,
+        int maxDenominator,
+        string expected) =>
+        Assert.Equal(
+            expected,
+            decimal.Parse(input, CultureInfo.InvariantCulture).Fractionalize(
+                maxDenominator,
+                decimal.Parse(tolerance, CultureInfo.InvariantCulture)));
+
+    public static TheoryData<decimal, int, string> LinkedGistExamples =>
+        new()
+        {
+            { 0.5m, 2, "1/2" },
+            { 1m / 3m, 3, "1/3" },
+            { 2m / 55m, 55, "2/55" },
+            { 7m / 555m, 555, "7/555" },
+            { 7m / 5555m, 5555, "7/5555" },
+            { 7m / 55555m, 55555, "7/55555" },
+            { 17m / 555555m, 555555, "17/555555" },
+            { 17m / 5555555m, 5555555, "17/5555555" },
+            { 17m / 55555555m, 55555555, "17/55555555" },
+            { 1m, 1, "1" },
+            { 0.67m, 3, "2/3" },
+        };
+
+    [Theory]
+    [MemberData(nameof(LinkedGistExamples))]
+    public void CoversLinkedGistExamples(decimal input, int maxDenominator, string expected) =>
+        Assert.Equal(expected, input.Fractionalize(maxDenominator, 0.01m));
+
+    [Theory]
+    [InlineData("0.5", "½")]
+    [InlineData("0.3333333333333333333333333333", "⅓")]
+    [InlineData("0.6666666666666666666666666667", "⅔")]
+    [InlineData("0.25", "¼")]
+    [InlineData("0.75", "¾")]
+    [InlineData("0.2", "⅕")]
+    [InlineData("0.4", "⅖")]
+    [InlineData("0.6", "⅗")]
+    [InlineData("0.8", "⅘")]
+    [InlineData("0.1666666666666666666666666667", "⅙")]
+    [InlineData("0.8333333333333333333333333333", "⅚")]
+    [InlineData("0.1428571428571428571428571429", "⅐")]
+    [InlineData("0.125", "⅛")]
+    [InlineData("0.375", "⅜")]
+    [InlineData("0.625", "⅝")]
+    [InlineData("0.875", "⅞")]
+    [InlineData("0.1111111111111111111111111111", "⅑")]
+    [InlineData("0.1", "⅒")]
+    public void UsesUnicodeVulgarFractionWhenAvailable(string input, string expected) =>
+        Assert.Equal(
+            expected,
+            decimal.Parse(input, CultureInfo.InvariantCulture).Fractionalize(10, 0.0000000000000000000000000001m, true));
+
+    [Fact]
+    public void UsesSlashNotationWhenUnicodeVulgarFractionIsUnavailable() =>
+        Assert.Equal("2/7", (2m / 7m).Fractionalize(7, 0.0000000000000000000000000001m, true));
+
+    [Theory]
+    [InlineData("1.25", "1¼")]
+    [InlineData("-1.25", "-1¼")]
+    [InlineData("-0.75", "-¾")]
+    [InlineData("4.333", "4⅓")]
+    [InlineData("1.8", "1⅘")]
+    public void FormatsSignedUnicodeMixedFractions(string input, string expected) =>
+        Assert.Equal(
+            expected,
+            decimal.Parse(input, CultureInfo.InvariantCulture).Fractionalize(5, 0.01m, true));
+
+    [Theory]
+    [InlineData("-1.25", "-1 1/4")]
+    [InlineData("-0.75", "-3/4")]
+    [InlineData("0.50", "1/2")]
+    [InlineData("0.5", "1")]
+    public void HandlesSignsReductionAndTies(string input, string expected)
+    {
+        var maxDenominator = input == "0.5" ? 1 : 4;
+        var tolerance = input == "0.5" ? 0.5m : 0m;
+
+        Assert.Equal(
+            expected,
+            decimal.Parse(input, CultureInfo.InvariantCulture).Fractionalize(maxDenominator, tolerance));
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("1.00")]
+    [InlineData("79228162514264337593543950335")]
+    [InlineData("-79228162514264337593543950335")]
+    public void FormatsWholeValuesWithoutAFraction(string input) =>
+        Assert.Equal(
+            decimal.Truncate(decimal.Parse(input, CultureInfo.InvariantCulture)).ToString(CultureInfo.InvariantCulture),
+            decimal.Parse(input, CultureInfo.InvariantCulture).Fractionalize(10, 0m));
+
+    [Theory]
+    [InlineData("7922816251426433759354395033.5", "7922816251426433759354395033 1/2")]
+    [InlineData("-7922816251426433759354395033.5", "-7922816251426433759354395033 1/2")]
+    public void HandlesDecimalExtremes(string input, string expected) =>
+        Assert.Equal(
+            expected,
+            decimal.Parse(input, CultureInfo.InvariantCulture).Fractionalize(2, 0m));
+
+    [Fact]
+    [UseCulture("fr-FR")]
+    public void UsesCurrentCultureForDecimalFallback() =>
+        Assert.Equal("0,11", 0.11m.Fractionalize(10, 0m));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void RejectsInvalidMaximumDenominator(int maxDenominator) =>
+        Assert.Throws<ArgumentOutOfRangeException>(() => 0.5m.Fractionalize(maxDenominator, 0m));
+
+    [Fact]
+    public void RejectsNegativeTolerance() =>
+        Assert.Throws<ArgumentOutOfRangeException>(() => 0.5m.Fractionalize(2, -0.01m));
+}

--- a/tests/Humanizer.Tests/FractionalizeTests.cs
+++ b/tests/Humanizer.Tests/FractionalizeTests.cs
@@ -116,6 +116,16 @@ public class FractionalizeTests
             decimal.Truncate(decimal.Parse(input, CultureInfo.InvariantCulture)).ToString(CultureInfo.InvariantCulture),
             decimal.Parse(input, CultureInfo.InvariantCulture).Fractionalize(10, 0m));
 
+    [Fact]
+    public void UsesInvariantFormattingForWholeValues()
+    {
+        var culture = (CultureInfo)CultureInfo.CurrentCulture.Clone();
+        culture.NumberFormat.NegativeSign = "~";
+        CultureInfo.CurrentCulture = culture;
+
+        Assert.Equal("-1", (-1m).Fractionalize(10, 0m));
+    }
+
     [Theory]
     [InlineData("7922816251426433759354395033.5", "7922816251426433759354395033 1/2")]
     [InlineData("-7922816251426433759354395033.5", "-7922816251426433759354395033 1/2")]


### PR DESCRIPTION
## Summary

`decimal` callers can now request the closest reduced common fraction with an explicit maximum denominator and tolerance, including optional Unicode vulgar-fraction glyphs. Inputs outside the tolerance fall back to the current culture's decimal formatting instead of silently guessing, while signs, whole values, mixed fractions, and the full decimal range remain exact.

The historical `0.199`, tolerance `0.1`, maximum-denominator `5` row is corrected to `1/5`: its error is `0.001`, while the issue's stated `2/5` result has error `0.201` and exceeds the tolerance.

Thanks to @qJake for reporting and refining the caller-controlled contract, @hazzik for the general fraction-conversion exploration, and @MehdiK for the localization and configurability guidance.

Fixes #401

## Validation

- Focused fraction tests: 63 passed on net8.
- Public API approval: passed on net8; the full matrix exercised net8, net10, and net11 snapshots.
- Full solution format verification: 0 of 2,681 files changed.
- Full serial Humanizer.Tests matrix: 57,926 passed on each of net8, net10, and net11; zero failures or skips.
- Release pack: succeeded without warnings for net48, netstandard2.0, net8, net10, and net11.

## New concepts

### Bounded continued fractions

A continued fraction represents a rational number through progressively better reduced approximations. Here, the last convergent and its denominator-bounded neighbor are compared with exact `BigInteger` cross-products, so the closest permitted fraction is selected without scanning every denominator or losing decimal precision.

```csharp
// Compare rational errors exactly instead of rounding through floating point.
var comparison = (firstError * secondDenominator)
    .CompareTo(secondError * firstDenominator);
```

This fits a library API whose maximum denominator may be large and whose decimal extremes must not overflow. It is not the right selection rule when a domain wants a preferred vocabulary of fractions rather than the mathematically closest bounded fraction.

## Checklist

- [x] Implementation is clean.
- [x] Code adheres to the existing coding standards.
- [x] No Code Analysis warnings.
- [x] Proper unit test coverage is included.
- [x] No code was copied from Stack Overflow, a blog, or OSS; this uses the standard continued-fraction technique.
- [x] Comments are limited to the XML documentation required for the public API.
- [x] XML documentation is included for the new public API.
- [x] Rebased on the latest `main`.
- [x] The fixed issue is linked with `Fixes #401`.
- [x] The README documents the new API.
- [x] The required focused, format, full-matrix, and Release-pack validation completed successfully.
