### PR TITLE
feat: add composite ByteSize formatting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -872,6 +872,28 @@ If you want a string representation you can call `ToString` or `Humanize` interc
 (1024).Gigabytes().ToString(); // 1 TB
 ```
 
+Use `HumanizeComposite` to emit up to the requested number of non-zero parts:
+
+```csharp
+10242.Bytes().HumanizeComposite();                    // 10 KB 2 B
+10242.Bytes().HumanizeComposite(1);                   // 10 KB
+10242.Bytes().HumanizeComposite(
+    separator: ", ", toWords: true);                  // 10 kilobytes, 2 bytes
+1024.Bytes().HumanizeComposite();                     // 1 KB
+(-10242).Bytes().HumanizeComposite();                 // -10 KB 2 B
+0.Bytes().HumanizeComposite();                        // 0 b
+10242.Bytes().HumanizeComposite(formatProvider:
+    new CultureInfo("fr"));                           // 10 Ko 2 o
+```
+
+Composite formatting decomposes the stored bit count from `EB` through `b`,
+uses a space between parts by default, and never rounds a residual into a
+different unit. Each unit keeps its existing factor: `PB` and `EB` remain SI,
+while `KB` through `TB` and their default labels retain their historical binary
+behavior. The lower IEC factories therefore decompose to the same values while
+the existing explicit `Humanize` and `ToString` format tokens remain the way to
+request `KiB` through `TiB` labels.
+
 You can also optionally provide a format for the expected string representation.
 The formatter can contain the symbol of the value to display: `b`, `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `EB`, `PiB`.
 The formatter uses the built in [`double.ToString` method](https://docs.microsoft.com/dotnet/api/system.double.tostring) with `#.##` as the default format which rounds the number to two decimal places:

--- a/src/Humanizer/Bytes/ByteSizeExtensions.cs
+++ b/src/Humanizer/Bytes/ByteSizeExtensions.cs
@@ -455,6 +455,85 @@ public static class ByteSizeExtensions
         string.IsNullOrWhiteSpace(format) ? input.ToString(formatProvider) : input.ToString(format, formatProvider);
 
     /// <summary>
+    /// Turns a byte quantity into a composite human-readable form using descending units, e.g. 10 KB 2 B.
+    /// </summary>
+    /// <param name="input">The byte quantity to humanize.</param>
+    /// <param name="precision">The maximum number of non-zero parts to return.</param>
+    /// <param name="formatProvider">The format provider to use. If null, the current culture is used.</param>
+    /// <param name="separator">The separator to use between parts.</param>
+    /// <param name="toWords">Uses unit words instead of symbols if true.</param>
+    /// <returns>The composite byte quantity.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="precision"/> is less than one.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="separator"/> is null.</exception>
+    public static string HumanizeComposite(
+        this ByteSize input,
+        int precision = 2,
+        IFormatProvider? formatProvider = null,
+        string separator = " ",
+        bool toWords = false)
+    {
+        if (precision < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(precision), precision, "Precision must be greater than zero.");
+        }
+
+        ArgumentNullException.ThrowIfNull(separator);
+
+        formatProvider ??= CultureInfo.CurrentCulture;
+        var culture = formatProvider as CultureInfo;
+        if (culture is not null)
+        {
+            formatProvider = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(culture);
+        }
+
+        var formatter = Configurator.GetFormatter(culture);
+        var isNegative = input.Bits < 0;
+        var remainingBits = isNegative
+            ? (ulong)(-(input.Bits + 1)) + 1
+            : (ulong)input.Bits;
+
+        if (remainingBits == 0)
+        {
+            return string.Concat("0 ", formatter.DataUnitHumanize(DataUnit.Bit, 0, toSymbol: !toWords));
+        }
+
+        var parts = new List<string>(Math.Min(precision, 8));
+
+        void addPart(ulong bitsPerUnit, DataUnit unit)
+        {
+            if (parts.Count >= precision)
+            {
+                return;
+            }
+
+            var count = remainingBits / bitsPerUnit;
+            if (count == 0)
+            {
+                return;
+            }
+
+            parts.Add(string.Concat(
+                count.ToString(formatProvider),
+                " ",
+                formatter.DataUnitHumanize(unit, count, toSymbol: !toWords)));
+            remainingBits %= bitsPerUnit;
+        }
+
+        addPart((ulong)ByteSize.BytesInExabyte * ByteSize.BitsInByte, DataUnit.Exabyte);
+        addPart((ulong)ByteSize.BytesInPetabyte * ByteSize.BitsInByte, DataUnit.Petabyte);
+        addPart((ulong)ByteSize.BytesInTerabyte * ByteSize.BitsInByte, DataUnit.Terabyte);
+        addPart((ulong)ByteSize.BytesInGigabyte * ByteSize.BitsInByte, DataUnit.Gigabyte);
+        addPart((ulong)ByteSize.BytesInMegabyte * ByteSize.BitsInByte, DataUnit.Megabyte);
+        addPart((ulong)ByteSize.BytesInKilobyte * ByteSize.BitsInByte, DataUnit.Kilobyte);
+        addPart(ByteSize.BitsInByte, DataUnit.Byte);
+        addPart(1, DataUnit.Bit);
+
+        return string.Concat(
+            isNegative ? NumberFormatInfo.GetInstance(formatProvider).NegativeSign : null,
+            string.Join(separator, parts));
+    }
+
+    /// <summary>
     /// Turns a quantity of bytes in a given interval into a rate that can be manipulated
     /// </summary>
     /// <param name="size">Quantity of bytes</param>

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -167,6 +167,7 @@ namespace Humanizer
         public static string Humanize(this Humanizer.ByteSize input, System.IFormatProvider formatProvider) { }
         public static string Humanize(this Humanizer.ByteSize input, string? format = null) { }
         public static string Humanize(this Humanizer.ByteSize input, string? format, System.IFormatProvider? formatProvider) { }
+        public static string HumanizeComposite(this Humanizer.ByteSize input, int precision = 2, System.IFormatProvider? formatProvider = null, string separator = " ", bool toWords = false) { }
         public static Humanizer.ByteSize Kilobytes(this byte input) { }
         public static Humanizer.ByteSize Kilobytes(this double input) { }
         public static Humanizer.ByteSize Kilobytes(this int input) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -167,6 +167,7 @@ namespace Humanizer
         public static string Humanize(this Humanizer.ByteSize input, System.IFormatProvider formatProvider) { }
         public static string Humanize(this Humanizer.ByteSize input, string? format = null) { }
         public static string Humanize(this Humanizer.ByteSize input, string? format, System.IFormatProvider? formatProvider) { }
+        public static string HumanizeComposite(this Humanizer.ByteSize input, int precision = 2, System.IFormatProvider? formatProvider = null, string separator = " ", bool toWords = false) { }
         public static Humanizer.ByteSize Kilobytes(this byte input) { }
         public static Humanizer.ByteSize Kilobytes(this double input) { }
         public static Humanizer.ByteSize Kilobytes(this int input) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -166,6 +166,7 @@ namespace Humanizer
         public static string Humanize(this Humanizer.ByteSize input, System.IFormatProvider formatProvider) { }
         public static string Humanize(this Humanizer.ByteSize input, string? format = null) { }
         public static string Humanize(this Humanizer.ByteSize input, string? format, System.IFormatProvider? formatProvider) { }
+        public static string HumanizeComposite(this Humanizer.ByteSize input, int precision = 2, System.IFormatProvider? formatProvider = null, string separator = " ", bool toWords = false) { }
         public static Humanizer.ByteSize Kilobytes(this byte input) { }
         public static Humanizer.ByteSize Kilobytes(this double input) { }
         public static Humanizer.ByteSize Kilobytes(this int input) { }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -165,6 +165,7 @@ namespace Humanizer
         public static string Humanize(this Humanizer.ByteSize input, System.IFormatProvider formatProvider) { }
         public static string Humanize(this Humanizer.ByteSize input, string? format = null) { }
         public static string Humanize(this Humanizer.ByteSize input, string? format, System.IFormatProvider? formatProvider) { }
+        public static string HumanizeComposite(this Humanizer.ByteSize input, int precision = 2, System.IFormatProvider? formatProvider = null, string separator = " ", bool toWords = false) { }
         public static Humanizer.ByteSize Kilobytes(this byte input) { }
         public static Humanizer.ByteSize Kilobytes(this double input) { }
         public static Humanizer.ByteSize Kilobytes(this int input) { }

--- a/tests/Humanizer.Tests/Bytes/ByteSizeExtensionsTests.cs
+++ b/tests/Humanizer.Tests/Bytes/ByteSizeExtensionsTests.cs
@@ -429,4 +429,88 @@ public class ByteSizeExtensionsTests
             .Bits()
             .Humanize(format, cultureInfo));
     }
+
+    [Fact]
+    public void HumanizesCompositeBytesWithoutChangingDefaultHumanize()
+    {
+        var input = 10242.Bytes();
+
+        Assert.Equal("10 KB", input.Humanize());
+        Assert.Equal("10 KB 2 B", input.HumanizeComposite());
+        Assert.Equal("10 kilobytes, 2 bytes", input.HumanizeComposite(separator: ", ", toWords: true));
+    }
+
+    [Theory]
+    [InlineData(1, "1 MB")]
+    [InlineData(2, "1 MB 1 KB")]
+    [InlineData(3, "1 MB 1 KB 1 B")]
+    public void LimitsCompositeOutputToNonZeroParts(int precision, string expected)
+    {
+        var input = ByteSize.FromBytes(ByteSize.BytesInMegabyte + ByteSize.BytesInKilobyte + 1);
+
+        Assert.Equal(expected, input.HumanizeComposite(precision));
+    }
+
+    [Theory]
+    [InlineData(1023, "1023 B")]
+    [InlineData(1024, "1 KB")]
+    [InlineData(0, "0 b")]
+    public void HumanizesCompositeBoundaries(long bytes, string expected) =>
+        Assert.Equal(expected, bytes.Bytes().HumanizeComposite());
+
+    [Fact]
+    public void HumanizesCompositeBitResidualsExactly() =>
+        Assert.Equal("10 KB 2 B 1 b", ByteSize.FromBits(81937).HumanizeComposite(3));
+
+    [Fact]
+    public void UsesExistingLargeUnitFactorsInDescendingOrder()
+    {
+        var input = ByteSize.FromBytes(ByteSize.BytesInPetabyte + ByteSize.BytesInTerabyte + ByteSize.BytesInGigabyte);
+
+        Assert.Equal("1 PB 1 TB 1 GB", input.HumanizeComposite(3));
+        Assert.Equal("1 EB", ByteSize.FromExabytes(1).HumanizeComposite());
+    }
+
+    [Fact]
+    public void HumanizesNegativeCompositeValuesWithOneLeadingSign()
+    {
+        var numberFormat = (NumberFormatInfo)CultureInfo.InvariantCulture.NumberFormat.Clone();
+        numberFormat.NegativeSign = "~";
+
+        Assert.Equal("-10 KB 2 B", (-10242).Bytes().HumanizeComposite());
+        Assert.Equal("~10 KB 2 B", (-10242).Bytes().HumanizeComposite(formatProvider: numberFormat));
+        Assert.Equal("-1 EB", ByteSize.FromBits(long.MinValue).HumanizeComposite(1));
+    }
+
+    [Fact]
+    public void HumanizesCompositeWithSeparatorAndCulture()
+    {
+        var input = ByteSize.FromBytes(ByteSize.BytesInMegabyte + ByteSize.BytesInKilobyte + 1);
+
+        Assert.Equal("1 MB, 1 KB, 1 B", input.HumanizeComposite(3, separator: ", "));
+        Assert.Equal("1 Mo 1 Ko 1 o", input.HumanizeComposite(3, new CultureInfo("fr")));
+        Assert.Equal("1 megabyte, 1 kilobyte, 1 byte", input.HumanizeComposite(3, separator: ", ", toWords: true));
+    }
+
+    [Fact]
+    public void PreservesLegacyLabelsForLowerIecCompositeValues()
+    {
+        var input = ByteSize.FromBytes(ByteSize.BytesInMebibyte + ByteSize.BytesInKibibyte);
+
+        Assert.Equal("1 MB 1 KB", input.HumanizeComposite());
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void RejectsInvalidCompositePrecision(int precision)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => 1.Bytes().HumanizeComposite(precision));
+
+        Assert.Equal(nameof(precision), exception.ParamName);
+    }
+
+    [Fact]
+    public void RejectsNullCompositeSeparator() =>
+        Assert.Throws<ArgumentNullException>(() => 1.Bytes().HumanizeComposite(separator: null!));
 }


### PR DESCRIPTION
## Summary

Byte sizes can now be rendered as an additive composite such as `10 KB 2 B` without changing the existing one-unit `Humanize` or `ToString` output.

`HumanizeComposite` treats precision as the maximum number of non-zero parts, decomposes the exact stored bit count in descending existing ByteSize magnitudes, and truncates only by omitting lower residual parts. It keeps the established SI `PB`/`EB` factors and legacy binary `KB`-`TB` factors and labels, including lower IEC factory compatibility; culture-aware symbols or existing word forms, a deterministic separator, zero, and one leading negative sign are supported.

Thanks to @fhaag for reporting the use case and providing the motivating example.

Fixes #1101

## Validation

- Focused ByteSize tests: 143 passed
- Public API approval: 1 passed
- Full Humanizer.Tests matrix: 57,898 passed on each of .NET 8, .NET 10, and .NET 11
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
- Release pack across supported targets; the first attempt hit a host MSBuild worker SIGABRT, and the cleared exclusive retry passed

Here is a checklist you should tick through before submitting a pull request:

 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [x] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [x] Run either `build.cmd` or `build.ps1` and ensure there are no test failures
