### PR TITLE
feat: add Chinese financial numeral conversion

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -666,6 +666,10 @@ Convert numbers to their word representation:
 // Culture-specific large-number behavior
 123456789.ToWords(new CultureInfo("en-GB")) => "one hundred and twenty-three million four hundred and fifty-six thousand seven hundred and eighty-nine"
 123456789.ToWords(new CultureInfo("en-IN")) => "twelve crore thirty-four lakh fifty-six thousand seven hundred and eighty-nine"
+
+// Chinese financial characters (culture selects simplified or traditional)
+123.ToChineseFinancialCharacters(new CultureInfo("zh-CN")) => "壹佰贰拾叁"
+123.ToChineseFinancialCharacters(new CultureInfo("zh-TW")) => "壹佰貳拾參"
 ```
 
 

--- a/src/Humanizer/ChineseFinancialNumeralExtensions.cs
+++ b/src/Humanizer/ChineseFinancialNumeralExtensions.cs
@@ -1,0 +1,90 @@
+namespace Humanizer;
+
+/// <summary>
+/// Contains extension methods for converting integers to Chinese financial characters.
+/// </summary>
+public static class ChineseFinancialNumeralExtensions
+{
+    static readonly EastAsianGroupedNumberToWordsConverter SimplifiedConverter = CreateConverter(
+        "负",
+        ["零", "壹", "贰", "叁", "肆", "伍", "陆", "柒", "捌", "玖"],
+        ["", "万", "亿", "兆", "京"]);
+
+    static readonly EastAsianGroupedNumberToWordsConverter TraditionalConverter = CreateConverter(
+        "負",
+        ["零", "壹", "貳", "參", "肆", "伍", "陸", "柒", "捌", "玖"],
+        ["", "萬", "億", "兆", "京"]);
+
+    /// <summary>
+    /// Converts the given value to Chinese financial characters.
+    /// </summary>
+    /// <param name="number">The value to convert.</param>
+    /// <param name="culture">
+    /// A culture in the <c>zh-Hans</c> or <c>zh-Hant</c> hierarchy, which selects simplified or
+    /// traditional financial characters.
+    /// </param>
+    /// <returns>The value written with Chinese financial digits and units.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="culture"/> is <c>null</c>.</exception>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <paramref name="culture"/> does not resolve to simplified or traditional Chinese.
+    /// </exception>
+    public static string ToChineseFinancialCharacters(this int number, CultureInfo culture) =>
+        ((long)number).ToChineseFinancialCharacters(culture);
+
+    /// <summary>
+    /// Converts the given value to Chinese financial characters.
+    /// </summary>
+    /// <param name="number">The value to convert.</param>
+    /// <param name="culture">
+    /// A culture in the <c>zh-Hans</c> or <c>zh-Hant</c> hierarchy, which selects simplified or
+    /// traditional financial characters.
+    /// </param>
+    /// <returns>The value written with Chinese financial digits and units.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="culture"/> is <c>null</c>.</exception>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <paramref name="culture"/> does not resolve to simplified or traditional Chinese.
+    /// </exception>
+    /// <remarks>
+    /// Supports the full <see cref="long"/> range. This method does not add currency names or units
+    /// such as yuan, jiao, or fen.
+    /// </remarks>
+    public static string ToChineseFinancialCharacters(this long number, CultureInfo culture)
+    {
+        ArgumentNullException.ThrowIfNull(culture);
+
+        for (var current = culture; !string.IsNullOrEmpty(current.Name); current = current.Parent)
+        {
+            if (current.Name == "zh-Hans")
+            {
+                return SimplifiedConverter.Convert(number);
+            }
+
+            if (current.Name == "zh-Hant")
+            {
+                return TraditionalConverter.Convert(number);
+            }
+        }
+
+        throw new NotSupportedException(
+            $"Culture '{culture.Name}' does not resolve to simplified or traditional Chinese.");
+    }
+
+    static EastAsianGroupedNumberToWordsConverter CreateConverter(
+        string negativePrefix,
+        string[] digitWords,
+        string[] largeUnits) =>
+        new(new(
+            "零",
+            negativePrefix,
+            "",
+            "",
+            digitWords,
+            ["", "拾", "佰", "仟"],
+            largeUnits,
+            false,
+            false,
+            false,
+            false,
+            true,
+            true));
+}

--- a/src/Humanizer/Localisation/NumberToWords/EastAsianGroupedNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/EastAsianGroupedNumberToWordsConverter.cs
@@ -17,8 +17,8 @@ class EastAsianGroupedNumberToWordsConverter(EastAsianGroupedNumberToWordsProfil
     /// <returns>The localized cardinal words for <paramref name="number"/>.</returns>
     public override string Convert(long number) =>
         number < 0
-            ? profile.NegativePrefix + ConvertPositive(-number)
-            : ConvertPositive(number);
+            ? profile.NegativePrefix + ConvertPositive((ulong)(-(number + 1)) + 1)
+            : ConvertPositive((ulong)number);
 
     /// <summary>
     /// Converts the given value to the locale's ordinal form.
@@ -32,13 +32,14 @@ class EastAsianGroupedNumberToWordsConverter(EastAsianGroupedNumberToWordsProfil
             return ordinal;
         }
 
-        return profile.OrdinalPrefix + ConvertPositive(number) + profile.OrdinalSuffix;
+        var cardinal = number < 0 ? string.Empty : ConvertPositive((ulong)number);
+        return profile.OrdinalPrefix + cardinal + profile.OrdinalSuffix;
     }
 
     /// <summary>
     /// Converts a four-digit East Asian group into text.
     /// </summary>
-    string ConvertPositive(long number)
+    string ConvertPositive(ulong number)
     {
         if (number == 0)
         {

--- a/src/Humanizer/Localisation/NumberToWords/EastAsianGroupedNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/EastAsianGroupedNumberToWordsConverter.cs
@@ -32,7 +32,13 @@ class EastAsianGroupedNumberToWordsConverter(EastAsianGroupedNumberToWordsProfil
             return ordinal;
         }
 
-        var cardinal = number < 0 ? string.Empty : ConvertPositive((ulong)number);
+        if (number < 0)
+        {
+            var magnitude = (ulong)(-(long)number);
+            return profile.NegativePrefix + profile.OrdinalPrefix + ConvertPositive(magnitude) + profile.OrdinalSuffix;
+        }
+
+        var cardinal = ConvertPositive((ulong)number);
         return profile.OrdinalPrefix + cardinal + profile.OrdinalSuffix;
     }
 

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -214,6 +214,11 @@ namespace Humanizer
     {
         public static string ApplyCase(this string input, Humanizer.LetterCasing casing) { }
     }
+    public static class ChineseFinancialNumeralExtensions
+    {
+        public static string ToChineseFinancialCharacters(this int number, System.Globalization.CultureInfo culture) { }
+        public static string ToChineseFinancialCharacters(this long number, System.Globalization.CultureInfo culture) { }
+    }
     public enum ClockNotationRounding
     {
         None = 0,

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -214,6 +214,11 @@ namespace Humanizer
     {
         public static string ApplyCase(this string input, Humanizer.LetterCasing casing) { }
     }
+    public static class ChineseFinancialNumeralExtensions
+    {
+        public static string ToChineseFinancialCharacters(this int number, System.Globalization.CultureInfo culture) { }
+        public static string ToChineseFinancialCharacters(this long number, System.Globalization.CultureInfo culture) { }
+    }
     public enum ClockNotationRounding
     {
         None = 0,

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -213,6 +213,11 @@ namespace Humanizer
     {
         public static string ApplyCase(this string input, Humanizer.LetterCasing casing) { }
     }
+    public static class ChineseFinancialNumeralExtensions
+    {
+        public static string ToChineseFinancialCharacters(this int number, System.Globalization.CultureInfo culture) { }
+        public static string ToChineseFinancialCharacters(this long number, System.Globalization.CultureInfo culture) { }
+    }
     public enum ClockNotationRounding
     {
         None = 0,

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -212,6 +212,11 @@ namespace Humanizer
     {
         public static string ApplyCase(this string input, Humanizer.LetterCasing casing) { }
     }
+    public static class ChineseFinancialNumeralExtensions
+    {
+        public static string ToChineseFinancialCharacters(this int number, System.Globalization.CultureInfo culture) { }
+        public static string ToChineseFinancialCharacters(this long number, System.Globalization.CultureInfo culture) { }
+    }
     public enum ClockNotationRounding
     {
         None = 0,

--- a/tests/Humanizer.Tests/Localisation/zh-Hans/SimplifiedChineseFinancialNumeralTests.cs
+++ b/tests/Humanizer.Tests/Localisation/zh-Hans/SimplifiedChineseFinancialNumeralTests.cs
@@ -1,0 +1,31 @@
+namespace Humanizer.Tests.Localisation.zh_Hans;
+
+[UseCulture("zh-Hans")]
+public class SimplifiedChineseFinancialNumeralTests
+{
+    static readonly CultureInfo ZhHans = CultureInfo.GetCultureInfo("zh-Hans");
+
+    [Theory]
+    [InlineData(0, "零")]
+    [InlineData(-5, "负伍")]
+    [InlineData(10, "壹拾")]
+    [InlineData(1001000001, "壹拾亿零壹佰万零壹")]
+    public void ConvertsFinancialCharacters(long number, string expected) =>
+        Assert.Equal(expected, number.ToChineseFinancialCharacters(ZhHans));
+
+    [Fact]
+    public void ConvertsFullLongRange() =>
+        Assert.Equal(
+            "负玖佰贰拾贰京叁仟叁佰柒拾贰兆零叁佰陆拾捌亿伍仟肆佰柒拾柒万伍仟捌佰零捌",
+            long.MinValue.ToChineseFinancialCharacters(ZhHans));
+
+    [Theory]
+    [InlineData("zh-CN")]
+    [InlineData("zh-SG")]
+    public void ResolvesSimplifiedCultureFallback(string cultureName) =>
+        Assert.Equal("贰", 2.ToChineseFinancialCharacters(CultureInfo.GetCultureInfo(cultureName)));
+
+    [Fact]
+    public void DoesNotReplaceStandardChineseWords() =>
+        Assert.Equal("十", 10.ToWords(ZhHans));
+}

--- a/tests/Humanizer.Tests/Localisation/zh-Hans/SimplifiedChineseFinancialNumeralTests.cs
+++ b/tests/Humanizer.Tests/Localisation/zh-Hans/SimplifiedChineseFinancialNumeralTests.cs
@@ -25,6 +25,12 @@ public class SimplifiedChineseFinancialNumeralTests
     public void ResolvesSimplifiedCultureFallback(string cultureName) =>
         Assert.Equal("贰", 2.ToChineseFinancialCharacters(CultureInfo.GetCultureInfo(cultureName)));
 
+    [Theory]
+    [InlineData(-23, "负 第 二十三")]
+    [InlineData(int.MinValue, "负 第 二十一亿四千七百四十八万三千六百四十八")]
+    public void ConvertsNegativeStandardOrdinals(int number, string expected) =>
+        Assert.Equal(expected, number.ToOrdinalWords(ZhHans));
+
     [Fact]
     public void DoesNotReplaceStandardChineseWords() =>
         Assert.Equal("十", 10.ToWords(ZhHans));

--- a/tests/Humanizer.Tests/Localisation/zh-Hant/TraditionalChineseFinancialNumeralTests.cs
+++ b/tests/Humanizer.Tests/Localisation/zh-Hant/TraditionalChineseFinancialNumeralTests.cs
@@ -1,0 +1,42 @@
+namespace Humanizer.Tests.Localisation.zh_Hant;
+
+[UseCulture("zh-Hant")]
+public class TraditionalChineseFinancialNumeralTests
+{
+    static readonly CultureInfo ZhHant = CultureInfo.GetCultureInfo("zh-Hant");
+
+    [Theory]
+    [InlineData(0, "零")]
+    [InlineData(-5, "負伍")]
+    [InlineData(10, "壹拾")]
+    [InlineData(1001000001, "壹拾億零壹佰萬零壹")]
+    public void ConvertsFinancialCharacters(long number, string expected) =>
+        Assert.Equal(expected, number.ToChineseFinancialCharacters(ZhHant));
+
+    [Fact]
+    public void ConvertsFullLongRange() =>
+        Assert.Equal(
+            "負玖佰貳拾貳京參仟參佰柒拾貳兆零參佰陸拾捌億伍仟肆佰柒拾柒萬伍仟捌佰零捌",
+            long.MinValue.ToChineseFinancialCharacters(ZhHant));
+
+    [Theory]
+    [InlineData("zh-TW")]
+    [InlineData("zh-HK")]
+    public void ResolvesTraditionalCultureFallback(string cultureName) =>
+        Assert.Equal("貳", 2.ToChineseFinancialCharacters(CultureInfo.GetCultureInfo(cultureName)));
+
+    [Theory]
+    [InlineData("zh")]
+    [InlineData("en-US")]
+    public void RejectsUnsupportedCultures(string cultureName) =>
+        Assert.Throws<NotSupportedException>(
+            () => 1.ToChineseFinancialCharacters(CultureInfo.GetCultureInfo(cultureName)));
+
+    [Fact]
+    public void RejectsNullCulture() =>
+        Assert.Throws<ArgumentNullException>(() => 1.ToChineseFinancialCharacters(null!));
+
+    [Fact]
+    public void DoesNotReplaceStandardChineseWords() =>
+        Assert.Equal("十", 10.ToWords(ZhHant));
+}


### PR DESCRIPTION
## Summary

- Add explicit `ToChineseFinancialCharacters(CultureInfo)` overloads for `int` and `long`, with the culture hierarchy selecting simplified or traditional characters without changing ordinary `ToWords`.
- Reuse the East Asian grouped-number engine and make signed-magnitude conversion safe for the full `long` range, including `long.MinValue`.
- Correct shared East Asian negative ordinal rendering with an `int.MinValue`-safe magnitude.
- Add XML documentation, README examples, all public API approvals, and focused zh-Hans/zh-Hant coverage.

Thank you @xiaobudian for reporting this request and @reznor244 for the Roman-style explicit API and culture-selection design direction.

## Validation

Full review-fix matrix on `8925bde2`:

- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 57,925 passed
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 57,925 passed
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 57,925 passed

Final-base gate after rebasing onto `8c21a527` (current head `e73410c5`):

- zh-Hans targeted tests — 18 passed
- zh-Hant targeted tests — 19 passed
- `PublicApiApprovalTest` on .NET 8 — 1 passed
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — 0/2,702 files changed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o /tmp/humanizer-1868-final-8c21a527.PK5QnQ` — succeeded for all library TFMs

Fixes #710
