### PR TITLE
fix: support long ordinal values

### DIFF
--- a/src/Humanizer/Localisation/Ordinalizers/DefaultOrdinalizer.cs
+++ b/src/Humanizer/Localisation/Ordinalizers/DefaultOrdinalizer.cs
@@ -3,29 +3,70 @@ namespace Humanizer;
 /// <summary>
 /// Base ordinalizer that leaves the input unchanged unless a derived type overrides it.
 /// </summary>
-class DefaultOrdinalizer : IOrdinalizer
+class DefaultOrdinalizer : ILongOrdinalizer
 {
     /// <summary>
     /// Ordinalizes the number using the default grammatical form.
     /// </summary>
     public virtual string Convert(int number, string numberString, GrammaticalGender gender) =>
+        Convert((long)number, numberString, gender);
+
+    /// <summary>
+    /// Ordinalizes the number using the default grammatical form.
+    /// </summary>
+    public virtual string Convert(long number, string numberString, GrammaticalGender gender) =>
         Convert(number, numberString);
 
     /// <summary>
     /// Returns the original numeric text unchanged.
     /// </summary>
     public virtual string Convert(int number, string numberString) =>
+        Convert((long)number, numberString);
+
+    /// <summary>
+    /// Returns the original numeric text unchanged.
+    /// </summary>
+    public virtual string Convert(long number, string numberString) =>
         numberString;
 
     /// <summary>
     /// Ordinalizes the number using a locale-specific word form.
     /// </summary>
     public virtual string Convert(int number, string numberString, WordForm wordForm) =>
+        Convert((long)number, numberString, wordForm);
+
+    /// <summary>
+    /// Ordinalizes the number using a locale-specific word form.
+    /// </summary>
+    public virtual string Convert(long number, string numberString, WordForm wordForm) =>
         Convert(number, numberString, default, wordForm);
 
     /// <summary>
     /// Ordinalizes the number using the default implementation for the provided gender and word form.
     /// </summary>
     public virtual string Convert(int number, string numberString, GrammaticalGender gender, WordForm wordForm) =>
+        Convert((long)number, numberString, gender, wordForm);
+
+    /// <summary>
+    /// Ordinalizes the number using the default implementation for the provided gender and word form.
+    /// </summary>
+    public virtual string Convert(long number, string numberString, GrammaticalGender gender, WordForm wordForm) =>
         Convert(number, numberString, gender);
+
+    protected static ulong GetAbsoluteValue(long number) =>
+        number < 0
+            ? (ulong)(-(number + 1)) + 1
+            : (ulong)number;
+
+    protected static bool TryGetInt32Value(long number, out int value)
+    {
+        if (number is >= int.MinValue and <= int.MaxValue)
+        {
+            value = (int)number;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
 }

--- a/src/Humanizer/Localisation/Ordinalizers/IOrdinalizer.cs
+++ b/src/Humanizer/Localisation/Ordinalizers/IOrdinalizer.cs
@@ -41,3 +41,50 @@ public interface IOrdinalizer
     /// <returns>The ordinalized text.</returns>
     string Convert(int number, string numberString, GrammaticalGender gender, WordForm wordForm);
 }
+
+/// <summary>
+/// Localizes the ordinal form of a 64-bit integer.
+/// </summary>
+/// <remarks>
+/// Implement this interface when registering a custom ordinalizer that supports values outside the
+/// <see cref="int"/> range. Existing <see cref="IOrdinalizer"/> implementations remain supported for
+/// 32-bit values.
+/// </remarks>
+public interface ILongOrdinalizer : IOrdinalizer
+{
+    /// <summary>
+    /// Ordinalizes the number using the default grammatical form.
+    /// </summary>
+    /// <param name="number">The numeric value being ordinalized.</param>
+    /// <param name="numberString">The cardinal representation of the number.</param>
+    /// <returns>The ordinalized text.</returns>
+    string Convert(long number, string numberString);
+
+    /// <summary>
+    /// Ordinalizes the number using a locale-specific word form.
+    /// </summary>
+    /// <param name="number">The numeric value being ordinalized.</param>
+    /// <param name="numberString">The cardinal representation of the number.</param>
+    /// <param name="wordForm">The word form to use when the locale distinguishes abbreviations from full words.</param>
+    /// <returns>The ordinalized text.</returns>
+    string Convert(long number, string numberString, WordForm wordForm);
+
+    /// <summary>
+    /// Ordinalizes the number using the provided grammatical gender.
+    /// </summary>
+    /// <param name="number">The numeric value being ordinalized.</param>
+    /// <param name="numberString">The cardinal representation of the number.</param>
+    /// <param name="gender">The grammatical gender to use when the locale requires one.</param>
+    /// <returns>The ordinalized text.</returns>
+    string Convert(long number, string numberString, GrammaticalGender gender);
+
+    /// <summary>
+    /// Ordinalizes the number using the provided grammatical gender and word form.
+    /// </summary>
+    /// <param name="number">The numeric value being ordinalized.</param>
+    /// <param name="numberString">The cardinal representation of the number.</param>
+    /// <param name="gender">The grammatical gender to use when the locale requires one.</param>
+    /// <param name="wordForm">The word form to use when the locale distinguishes abbreviations from full words.</param>
+    /// <returns>The ordinalized text.</returns>
+    string Convert(long number, string numberString, GrammaticalGender gender, WordForm wordForm);
+}

--- a/src/Humanizer/Localisation/Ordinalizers/ModuloSuffixOrdinalizer.cs
+++ b/src/Humanizer/Localisation/Ordinalizers/ModuloSuffixOrdinalizer.cs
@@ -10,20 +10,18 @@ class ModuloSuffixOrdinalizer(ModuloSuffixOrdinalizer.Options options) : Default
     /// <summary>
     /// Appends the configured suffix for <paramref name="number"/> to <paramref name="numberString"/>.
     /// </summary>
-    public override string Convert(int number, string numberString) =>
+    public override string Convert(long number, string numberString) =>
         numberString + GetSuffix(number);
 
-    string GetSuffix(int number)
+    string GetSuffix(long number)
     {
-        var comparisonValue = options.UseAbsoluteValue
-            ? Math.Abs((long)number)
-            : number;
+        var absoluteValue = GetAbsoluteValue(number);
 
         // The precedence matters: range rules, exact numbers, and threshold rules can all override
         // the general last-digit fallback for the same locale.
         if (options.LastTwoDigitsRange is { } lastTwoDigitsRange)
         {
-            var lastTwoDigits = Math.Abs(comparisonValue % 100);
+            var lastTwoDigits = (int)(absoluteValue % 100);
             if (lastTwoDigits >= lastTwoDigitsRange.Start &&
                 lastTwoDigits <= lastTwoDigitsRange.End)
             {
@@ -31,29 +29,46 @@ class ModuloSuffixOrdinalizer(ModuloSuffixOrdinalizer.Options options) : Default
             }
         }
 
-        if (comparisonValue <= int.MaxValue &&
-            options.ExactSuffixes.TryGetValue((int)comparisonValue, out var exactSuffix))
+        var hasExactValue = options.UseAbsoluteValue
+            ? TryGetInt32Value(absoluteValue, out var exactValue)
+            : TryGetInt32Value(number, out exactValue);
+        if (hasExactValue &&
+            options.ExactSuffixes.TryGetValue(exactValue, out var exactSuffix))
         {
             return exactSuffix;
         }
 
         if (options.AbsoluteAtLeast is { } absoluteAtLeast &&
-            comparisonValue >= absoluteAtLeast &&
+            (options.UseAbsoluteValue
+                ? absoluteAtLeast <= 0 || absoluteValue >= (ulong)absoluteAtLeast
+                : number >= absoluteAtLeast) &&
             options.AbsoluteAtLeastSuffix is not null)
         {
             return options.AbsoluteAtLeastSuffix;
         }
 
-        var moduloLastTwoDigits = (int)Math.Abs(comparisonValue % 100);
+        var moduloLastTwoDigits = (int)(absoluteValue % 100);
         if (options.LastTwoDigitSuffixes.TryGetValue(moduloLastTwoDigits, out var lastTwoDigitSuffix))
         {
             return lastTwoDigitSuffix;
         }
 
-        var lastDigit = (int)Math.Abs(comparisonValue % 10);
+        var lastDigit = (int)(absoluteValue % 10);
         return options.LastDigitSuffixes.TryGetValue(lastDigit, out var lastDigitSuffix)
             ? lastDigitSuffix
             : options.DefaultSuffix;
+    }
+
+    static bool TryGetInt32Value(ulong number, out int value)
+    {
+        if (number <= int.MaxValue)
+        {
+            value = (int)number;
+            return true;
+        }
+
+        value = default;
+        return false;
     }
 
     /// <summary>

--- a/src/Humanizer/Localisation/Ordinalizers/NumberWordSuffixOrdinalizer.cs
+++ b/src/Humanizer/Localisation/Ordinalizers/NumberWordSuffixOrdinalizer.cs
@@ -19,23 +19,23 @@ class NumberWordSuffixOrdinalizer(CultureInfo culture, NumberWordSuffixOrdinaliz
     /// <summary>
     /// Ordinalizes using the default masculine gender.
     /// </summary>
-    public override string Convert(int number, string numberString) =>
+    public override string Convert(long number, string numberString) =>
         Convert(number, numberString, GrammaticalGender.Masculine);
 
     /// <summary>
     /// Ordinalizes using the requested gender.
     /// </summary>
-    public override string Convert(int number, string numberString, GrammaticalGender gender) =>
+    public override string Convert(long number, string numberString, GrammaticalGender gender) =>
         ConvertCore(number, gender);
 
     /// <summary>
     /// Ordinalizes using the requested gender and word form. Word form is ignored because
     /// this engine does not distinguish abbreviation from normal.
     /// </summary>
-    public override string Convert(int number, string numberString, GrammaticalGender gender, WordForm wordForm) =>
+    public override string Convert(long number, string numberString, GrammaticalGender gender, WordForm wordForm) =>
         ConvertCore(number, gender);
 
-    string ConvertCore(int number, GrammaticalGender gender)
+    string ConvertCore(long number, GrammaticalGender gender)
     {
         var effectiveGender = ResolveEffectiveGender(gender);
         var block = ResolveGenderBlock(effectiveGender);
@@ -46,12 +46,12 @@ class NumberWordSuffixOrdinalizer(CultureInfo culture, NumberWordSuffixOrdinaliz
         // This ensures negative and positive irregulars both come from ExactReplacements.
         if (number < 0)
         {
-            var magnitude = number == int.MinValue ? (long)int.MaxValue + 1 : Math.Abs(number);
+            var magnitude = GetAbsoluteValue(number);
             if (magnitude <= int.MaxValue
                 && block.ExactReplacements.TryGetValue((int)magnitude, out var negExact))
             {
                 var converter = Configurator.GetNumberToWordsConverter(culture);
-                var magnitudeCardinal = converter.Convert((int)magnitude, effectiveGender);
+                var magnitudeCardinal = converter.Convert((long)magnitude, effectiveGender);
                 var negativeCardinal = converter.Convert(number, effectiveGender);
 
                 if (!negativeCardinal.EndsWith(magnitudeCardinal, StringComparison.Ordinal))
@@ -67,7 +67,8 @@ class NumberWordSuffixOrdinalizer(CultureInfo culture, NumberWordSuffixOrdinaliz
             return cardinal + block.DefaultSuffix;
         }
 
-        if (block.ExactReplacements.TryGetValue(number, out var exact))
+        if (TryGetInt32Value(number, out var exactValue) &&
+            block.ExactReplacements.TryGetValue(exactValue, out var exact))
         {
             return exact;
         }

--- a/src/Humanizer/Localisation/Ordinalizers/SuffixOrdinalizer.cs
+++ b/src/Humanizer/Localisation/Ordinalizers/SuffixOrdinalizer.cs
@@ -19,13 +19,13 @@ class SuffixOrdinalizer(string masculineSuffix, string feminineSuffix, string ne
     /// <summary>
     /// Ordinalizes the number using the masculine suffix by default.
     /// </summary>
-    public override string Convert(int number, string numberString) =>
+    public override string Convert(long number, string numberString) =>
         Convert(number, numberString, GrammaticalGender.Masculine);
 
     /// <summary>
     /// Ordinalizes the number using the suffix for the requested grammatical gender.
     /// </summary>
-    public override string Convert(int number, string numberString, GrammaticalGender gender)
+    public override string Convert(long number, string numberString, GrammaticalGender gender)
     {
         if (zeroAsPlainNumber && number == 0)
         {

--- a/src/Humanizer/Localisation/Ordinalizers/TemplateOrdinalizer.cs
+++ b/src/Humanizer/Localisation/Ordinalizers/TemplateOrdinalizer.cs
@@ -10,54 +10,68 @@ class TemplateOrdinalizer(TemplateOrdinalizer.Options options) : DefaultOrdinali
     /// <summary>
     /// Ordinalizes the number using the default masculine form.
     /// </summary>
-    public override string Convert(int number, string numberString) =>
+    public override string Convert(long number, string numberString) =>
         Convert(number, numberString, GrammaticalGender.Masculine, WordForm.Normal);
 
     /// <summary>
     /// Ordinalizes the number using the default word form for the requested gender.
     /// </summary>
-    public override string Convert(int number, string numberString, GrammaticalGender gender) =>
+    public override string Convert(long number, string numberString, GrammaticalGender gender) =>
         Convert(number, numberString, gender, WordForm.Normal);
 
     /// <summary>
     /// Ordinalizes the number using the template data for the requested gender and word form.
     /// </summary>
-    public override string Convert(int number, string numberString, GrammaticalGender gender, WordForm wordForm)
+    public override string Convert(long number, string numberString, GrammaticalGender gender, WordForm wordForm)
     {
         if (options.ZeroAsPlainNumber && number == 0)
         {
             return "0";
         }
 
-        if (options.MinValueAsPlainNumber && number == int.MinValue)
+        if (options.MinValueAsPlainNumber && number is int.MinValue or long.MinValue)
         {
             return "0";
         }
 
         if (number < 0 && options.NegativeMode == NegativeNumberMode.AbsoluteInvariant)
         {
-            var positiveNumber = -number;
-            return Convert(positiveNumber, positiveNumber.ToString(CultureInfo.InvariantCulture), gender, wordForm);
+            var positiveNumber = GetAbsoluteValue(number);
+            return positiveNumber <= long.MaxValue
+                ? Convert((long)positiveNumber, positiveNumber.ToString(CultureInfo.InvariantCulture), gender, wordForm)
+                : Format(positiveNumber, positiveNumber.ToString(CultureInfo.InvariantCulture), gender);
         }
 
         var pattern = GetPattern(gender);
-        if (pattern.ExactReplacements.TryGetValue(number, out var exactReplacement))
+        if (TryGetInt32Value(number, out var exactValue) &&
+            pattern.ExactReplacements.TryGetValue(exactValue, out var exactReplacement))
         {
             return exactReplacement;
         }
 
-        if (pattern.ExactSuffixes.TryGetValue(number, out var exactSuffix))
+        if (TryGetInt32Value(number, out exactValue) &&
+            pattern.ExactSuffixes.TryGetValue(exactValue, out var exactSuffix))
         {
             return pattern.Prefix + numberString + exactSuffix;
         }
 
-        var lastDigit = Math.Abs(number % 10);
+        var lastDigit = (int)(GetAbsoluteValue(number) % 10);
         if (pattern.LastDigitSuffixes.TryGetValue(lastDigit, out var lastDigitSuffix))
         {
             return pattern.Prefix + numberString + lastDigitSuffix;
         }
 
         return pattern.Prefix + numberString + pattern.DefaultSuffix;
+    }
+
+    string Format(ulong number, string numberString, GrammaticalGender gender)
+    {
+        var pattern = GetPattern(gender);
+        var lastDigit = (int)(number % 10);
+        return pattern.Prefix + numberString +
+               (pattern.LastDigitSuffixes.TryGetValue(lastDigit, out var suffix)
+                   ? suffix
+                   : pattern.DefaultSuffix);
     }
 
     Pattern GetPattern(GrammaticalGender gender) =>

--- a/src/Humanizer/Localisation/Ordinalizers/TemplateOrdinalizer.cs
+++ b/src/Humanizer/Localisation/Ordinalizers/TemplateOrdinalizer.cs
@@ -111,7 +111,7 @@ class TemplateOrdinalizer(TemplateOrdinalizer.Options options) : DefaultOrdinali
     /// <param name="Feminine">The feminine pattern.</param>
     /// <param name="Neuter">The neuter pattern.</param>
     /// <param name="ZeroAsPlainNumber">Whether zero should be returned as plain <c>0</c>.</param>
-    /// <param name="MinValueAsPlainNumber">Whether <see cref="int.MinValue"/> should be returned as plain <c>0</c>.</param>
+    /// <param name="MinValueAsPlainNumber">Whether <see cref="int.MinValue"/> and <see cref="long.MinValue"/> should be returned as plain <c>0</c>.</param>
     /// <param name="NegativeMode">How negative numbers should be normalized before formatting.</param>
     public readonly record struct Options(
         Pattern Masculine,

--- a/src/Humanizer/Localisation/Ordinalizers/TemplateOrdinalizer.cs
+++ b/src/Humanizer/Localisation/Ordinalizers/TemplateOrdinalizer.cs
@@ -29,7 +29,7 @@ class TemplateOrdinalizer(TemplateOrdinalizer.Options options) : DefaultOrdinali
             return "0";
         }
 
-        if (options.MinValueAsPlainNumber && number is int.MinValue or long.MinValue)
+        if (options.MinValueAsPlainNumber && number == int.MinValue)
         {
             return "0";
         }
@@ -111,7 +111,7 @@ class TemplateOrdinalizer(TemplateOrdinalizer.Options options) : DefaultOrdinali
     /// <param name="Feminine">The feminine pattern.</param>
     /// <param name="Neuter">The neuter pattern.</param>
     /// <param name="ZeroAsPlainNumber">Whether zero should be returned as plain <c>0</c>.</param>
-    /// <param name="MinValueAsPlainNumber">Whether <see cref="int.MinValue"/> and <see cref="long.MinValue"/> should be returned as plain <c>0</c>.</param>
+    /// <param name="MinValueAsPlainNumber">Whether <see cref="int.MinValue"/> should be returned as plain <c>0</c>.</param>
     /// <param name="NegativeMode">How negative numbers should be normalized before formatting.</param>
     public readonly record struct Options(
         Pattern Masculine,

--- a/src/Humanizer/Localisation/Ordinalizers/WordFormTemplateOrdinalizer.cs
+++ b/src/Humanizer/Localisation/Ordinalizers/WordFormTemplateOrdinalizer.cs
@@ -143,7 +143,7 @@ class WordFormTemplateOrdinalizer(CultureInfo culture, WordFormTemplateOrdinaliz
     /// <param name="Feminine">The feminine pattern set.</param>
     /// <param name="Neuter">The neuter pattern set.</param>
     /// <param name="ZeroAsPlainNumber">Whether zero should be returned as plain <c>0</c>.</param>
-    /// <param name="MinValueAsPlainNumber">Whether <see cref="int.MinValue"/> should be returned as plain <c>0</c>.</param>
+    /// <param name="MinValueAsPlainNumber">Whether <see cref="int.MinValue"/> and <see cref="long.MinValue"/> should be returned as plain <c>0</c>.</param>
     /// <param name="NegativeMode">How negative numbers should be normalized before formatting.</param>
     public readonly record struct Options(
         PatternSet Masculine,

--- a/src/Humanizer/Localisation/Ordinalizers/WordFormTemplateOrdinalizer.cs
+++ b/src/Humanizer/Localisation/Ordinalizers/WordFormTemplateOrdinalizer.cs
@@ -30,7 +30,7 @@ class WordFormTemplateOrdinalizer(CultureInfo culture, WordFormTemplateOrdinaliz
             return "0";
         }
 
-        if (options.MinValueAsPlainNumber && number is int.MinValue or long.MinValue)
+        if (options.MinValueAsPlainNumber && number == int.MinValue)
         {
             return "0";
         }
@@ -143,7 +143,7 @@ class WordFormTemplateOrdinalizer(CultureInfo culture, WordFormTemplateOrdinaliz
     /// <param name="Feminine">The feminine pattern set.</param>
     /// <param name="Neuter">The neuter pattern set.</param>
     /// <param name="ZeroAsPlainNumber">Whether zero should be returned as plain <c>0</c>.</param>
-    /// <param name="MinValueAsPlainNumber">Whether <see cref="int.MinValue"/> and <see cref="long.MinValue"/> should be returned as plain <c>0</c>.</param>
+    /// <param name="MinValueAsPlainNumber">Whether <see cref="int.MinValue"/> should be returned as plain <c>0</c>.</param>
     /// <param name="NegativeMode">How negative numbers should be normalized before formatting.</param>
     public readonly record struct Options(
         PatternSet Masculine,

--- a/src/Humanizer/Localisation/Ordinalizers/WordFormTemplateOrdinalizer.cs
+++ b/src/Humanizer/Localisation/Ordinalizers/WordFormTemplateOrdinalizer.cs
@@ -11,37 +11,38 @@ class WordFormTemplateOrdinalizer(CultureInfo culture, WordFormTemplateOrdinaliz
     /// <summary>
     /// Ordinalizes the number using the default masculine form.
     /// </summary>
-    public override string Convert(int number, string numberString) =>
+    public override string Convert(long number, string numberString) =>
         Convert(number, numberString, GrammaticalGender.Masculine, WordForm.Normal);
 
     /// <summary>
     /// Ordinalizes the number using the default word form for the requested gender.
     /// </summary>
-    public override string Convert(int number, string numberString, GrammaticalGender gender) =>
+    public override string Convert(long number, string numberString, GrammaticalGender gender) =>
         Convert(number, numberString, gender, WordForm.Normal);
 
     /// <summary>
     /// Ordinalizes the number using the template data for the requested gender and word form.
     /// </summary>
-    public override string Convert(int number, string numberString, GrammaticalGender gender, WordForm wordForm)
+    public override string Convert(long number, string numberString, GrammaticalGender gender, WordForm wordForm)
     {
         if (options.ZeroAsPlainNumber && number == 0)
         {
             return "0";
         }
 
-        if (options.MinValueAsPlainNumber && number == int.MinValue)
+        if (options.MinValueAsPlainNumber && number is int.MinValue or long.MinValue)
         {
             return "0";
         }
 
         if (number < 0)
         {
+            var positiveNumber = GetAbsoluteValue(number);
             return options.NegativeMode switch
             {
                 NegativeNumberMode.None => Format(number, numberString, gender, wordForm),
-                NegativeNumberMode.AbsoluteInvariant => Convert(-number, (-number).ToString(CultureInfo.InvariantCulture), gender, wordForm),
-                NegativeNumberMode.AbsoluteCulture => Convert(-number, (-number).ToString(culture), gender, wordForm),
+                NegativeNumberMode.AbsoluteInvariant => ConvertAbsolute(positiveNumber, positiveNumber.ToString(CultureInfo.InvariantCulture), gender, wordForm),
+                NegativeNumberMode.AbsoluteCulture => ConvertAbsolute(positiveNumber, positiveNumber.ToString(culture), gender, wordForm),
                 _ => throw new InvalidOperationException("Unknown negative number mode.")
             };
         }
@@ -49,26 +50,43 @@ class WordFormTemplateOrdinalizer(CultureInfo culture, WordFormTemplateOrdinaliz
         return Format(number, numberString, gender, wordForm);
     }
 
-    string Format(int number, string numberString, GrammaticalGender gender, WordForm wordForm)
+    string ConvertAbsolute(ulong number, string numberString, GrammaticalGender gender, WordForm wordForm) =>
+        number <= long.MaxValue
+            ? Convert((long)number, numberString, gender, wordForm)
+            : Format(number, numberString, gender, wordForm);
+
+    string Format(long number, string numberString, GrammaticalGender gender, WordForm wordForm)
     {
         var pattern = GetPattern(gender, wordForm);
-        if (pattern.ExactReplacements.TryGetValue(number, out var exactReplacement))
+        if (TryGetInt32Value(number, out var exactValue) &&
+            pattern.ExactReplacements.TryGetValue(exactValue, out var exactReplacement))
         {
             return exactReplacement;
         }
 
-        if (pattern.ExactSuffixes.TryGetValue(number, out var exactSuffix))
+        if (TryGetInt32Value(number, out exactValue) &&
+            pattern.ExactSuffixes.TryGetValue(exactValue, out var exactSuffix))
         {
             return pattern.Prefix + numberString + exactSuffix;
         }
 
-        var lastDigit = Math.Abs(number % 10);
+        var lastDigit = (int)(GetAbsoluteValue(number) % 10);
         if (pattern.LastDigitSuffixes.TryGetValue(lastDigit, out var lastDigitSuffix))
         {
             return pattern.Prefix + numberString + lastDigitSuffix;
         }
 
         return pattern.Prefix + numberString + pattern.DefaultSuffix;
+    }
+
+    string Format(ulong number, string numberString, GrammaticalGender gender, WordForm wordForm)
+    {
+        var pattern = GetPattern(gender, wordForm);
+        var lastDigit = (int)(number % 10);
+        return pattern.Prefix + numberString +
+               (pattern.LastDigitSuffixes.TryGetValue(lastDigit, out var suffix)
+                   ? suffix
+                   : pattern.DefaultSuffix);
     }
 
     Pattern GetPattern(GrammaticalGender gender, WordForm wordForm)

--- a/src/Humanizer/OrdinalizeExtensions.cs
+++ b/src/Humanizer/OrdinalizeExtensions.cs
@@ -3,6 +3,10 @@ namespace Humanizer;
 /// <summary>
 /// Ordinalize extensions
 /// </summary>
+/// <remarks>
+/// Ordinalization accepts integral values only. Callers with fractional values must choose and apply
+/// an explicit rounding and conversion policy before ordinalizing.
+/// </remarks>
 public static class OrdinalizeExtensions
 {
     static readonly ConcurrentDictionary<string, OrdinalNumberFormatting> OrdinalNumberFormattingCache = new(StringComparer.OrdinalIgnoreCase);
@@ -251,7 +255,145 @@ public static class OrdinalizeExtensions
         return Configurator.Ordinalizers.ResolveForCulture(culture).Convert(number, NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)), gender, wordForm);
     }
 
-    static string FormatOrdinalNumberString(int number, CultureInfo culture)
+    /// <summary>
+    /// Turns a number into an ordinal number used to denote the position in an ordered sequence such as 1st, 2nd, 3rd, 4th.
+    /// </summary>
+    /// <param name="number">The number to be ordinalized</param>
+    public static string Ordinalize(this long number) =>
+        number.Ordinalize(CultureInfo.CurrentCulture);
+
+    /// <summary>
+    /// Turns a number into an ordinal number used to denote the position in an ordered sequence supporting specific locale's variations.
+    /// </summary>
+    /// <param name="number">The number to be ordinalized</param>
+    /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
+    /// <returns>The number ordinalized</returns>
+    public static string Ordinalize(this long number, WordForm wordForm) =>
+        number.Ordinalize(CultureInfo.CurrentCulture, wordForm);
+
+    /// <summary>
+    /// Turns a number into an ordinal number used to denote the position in an ordered sequence such as 1st, 2nd, 3rd, 4th.
+    /// </summary>
+    /// <param name="number">The number to be ordinalized</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
+    public static string Ordinalize(this long number, CultureInfo? culture)
+    {
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
+        return ConvertOrdinalizer(
+            Configurator.Ordinalizers.ResolveForCulture(culture),
+            number,
+            NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)));
+    }
+
+    /// <summary>
+    /// Turns a number into an ordinal number used to denote the position in an ordered sequence supporting specific locale's variations.
+    /// </summary>
+    /// <param name="number">The number to be ordinalized</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
+    /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
+    /// <returns>The number ordinalized</returns>
+    public static string Ordinalize(this long number, CultureInfo? culture, WordForm wordForm)
+    {
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
+        return ConvertOrdinalizer(
+            Configurator.Ordinalizers.ResolveForCulture(culture),
+            number,
+            NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)),
+            wordForm);
+    }
+
+    /// <summary>
+    /// Turns a number into an ordinal number used to denote the position in an ordered sequence using the provided grammatical gender.
+    /// </summary>
+    /// <param name="number">The number to be ordinalized</param>
+    /// <param name="gender">The grammatical gender to use for output words</param>
+    public static string Ordinalize(this long number, GrammaticalGender gender) =>
+        number.Ordinalize(gender, CultureInfo.CurrentCulture);
+
+    /// <summary>
+    /// Turns a number into an ordinal number used to denote the position in an ordered sequence supporting specific
+    /// locale's variations using the grammatical gender provided.
+    /// </summary>
+    /// <param name="number">The number to be ordinalized</param>
+    /// <param name="gender">The grammatical gender to use for output words</param>
+    /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
+    /// <returns>The number ordinalized</returns>
+    public static string Ordinalize(this long number, GrammaticalGender gender, WordForm wordForm) =>
+        number.Ordinalize(gender, CultureInfo.CurrentCulture, wordForm);
+
+    /// <summary>
+    /// Turns a number into an ordinal number used to denote the position in an ordered sequence using the provided grammatical gender.
+    /// </summary>
+    /// <param name="number">The number to be ordinalized</param>
+    /// <param name="gender">The grammatical gender to use for output words</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
+    public static string Ordinalize(this long number, GrammaticalGender gender, CultureInfo? culture)
+    {
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
+        return ConvertOrdinalizer(
+            Configurator.Ordinalizers.ResolveForCulture(culture),
+            number,
+            NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)),
+            gender);
+    }
+
+    /// <summary>
+    /// Turns a number into an ordinal number used to denote the position in an ordered sequence supporting specific
+    /// locale's variations using the grammatical gender provided.
+    /// </summary>
+    /// <param name="number">The number to be ordinalized</param>
+    /// <param name="gender">The grammatical gender to use for output words</param>
+    /// <param name="culture">Culture to use. If null, current thread's culture is used.</param>
+    /// <param name="wordForm">Form of the word, i.e. abbreviation</param>
+    /// <returns>The number ordinalized</returns>
+    public static string Ordinalize(this long number, GrammaticalGender gender, CultureInfo? culture, WordForm wordForm)
+    {
+        var resolvedCulture = culture ?? CultureInfo.CurrentCulture;
+        return ConvertOrdinalizer(
+            Configurator.Ordinalizers.ResolveForCulture(culture),
+            number,
+            NormalizeOrdinalNumberString(FormatOrdinalNumberString(number, resolvedCulture)),
+            gender,
+            wordForm);
+    }
+
+    static string ConvertOrdinalizer(IOrdinalizer ordinalizer, long number, string numberString) =>
+        ordinalizer is ILongOrdinalizer longOrdinalizer
+            ? longOrdinalizer.Convert(number, numberString)
+            : ordinalizer.Convert(ConvertToInt32(number, ordinalizer), numberString);
+
+    static string ConvertOrdinalizer(IOrdinalizer ordinalizer, long number, string numberString, WordForm wordForm) =>
+        ordinalizer is ILongOrdinalizer longOrdinalizer
+            ? longOrdinalizer.Convert(number, numberString, wordForm)
+            : ordinalizer.Convert(ConvertToInt32(number, ordinalizer), numberString, wordForm);
+
+    static string ConvertOrdinalizer(IOrdinalizer ordinalizer, long number, string numberString, GrammaticalGender gender) =>
+        ordinalizer is ILongOrdinalizer longOrdinalizer
+            ? longOrdinalizer.Convert(number, numberString, gender)
+            : ordinalizer.Convert(ConvertToInt32(number, ordinalizer), numberString, gender);
+
+    static string ConvertOrdinalizer(
+        IOrdinalizer ordinalizer,
+        long number,
+        string numberString,
+        GrammaticalGender gender,
+        WordForm wordForm) =>
+        ordinalizer is ILongOrdinalizer longOrdinalizer
+            ? longOrdinalizer.Convert(number, numberString, gender, wordForm)
+            : ordinalizer.Convert(ConvertToInt32(number, ordinalizer), numberString, gender, wordForm);
+
+    static int ConvertToInt32(long number, IOrdinalizer ordinalizer)
+    {
+        if (number is >= int.MinValue and <= int.MaxValue)
+        {
+            return (int)number;
+        }
+
+        throw new NotSupportedException(
+            $"The registered ordinalizer '{ordinalizer.GetType().FullName}' does not support 64-bit values.");
+    }
+
+    static string FormatOrdinalNumberString(long number, CultureInfo culture)
     {
         if (number >= 0)
         {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -430,6 +430,13 @@ namespace Humanizer
         string TimeSpanHumanize_Zero();
         string TimeUnitHumanize(Humanizer.TimeUnit timeUnit);
     }
+    public interface ILongOrdinalizer : Humanizer.IOrdinalizer
+    {
+        string Convert(long number, string numberString);
+        string Convert(long number, string numberString, Humanizer.GrammaticalGender gender);
+        string Convert(long number, string numberString, Humanizer.WordForm wordForm);
+        string Convert(long number, string numberString, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm);
+    }
     public interface INumberToWordsConverter
     {
         string Convert(long number);
@@ -1890,20 +1897,28 @@ namespace Humanizer
     public static class OrdinalizeExtensions
     {
         public static string Ordinalize(this int number) { }
+        public static string Ordinalize(this long number) { }
         public static string Ordinalize(this string numberString) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this int number, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender) { }
+        public static string Ordinalize(this long number, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this string numberString, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this long number, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
     }
     public enum Plurality

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -430,6 +430,13 @@ namespace Humanizer
         string TimeSpanHumanize_Zero();
         string TimeUnitHumanize(Humanizer.TimeUnit timeUnit);
     }
+    public interface ILongOrdinalizer : Humanizer.IOrdinalizer
+    {
+        string Convert(long number, string numberString);
+        string Convert(long number, string numberString, Humanizer.GrammaticalGender gender);
+        string Convert(long number, string numberString, Humanizer.WordForm wordForm);
+        string Convert(long number, string numberString, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm);
+    }
     public interface INumberToWordsConverter
     {
         string Convert(long number);
@@ -1890,20 +1897,28 @@ namespace Humanizer
     public static class OrdinalizeExtensions
     {
         public static string Ordinalize(this int number) { }
+        public static string Ordinalize(this long number) { }
         public static string Ordinalize(this string numberString) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this int number, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender) { }
+        public static string Ordinalize(this long number, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this string numberString, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this long number, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
     }
     public enum Plurality

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -429,6 +429,13 @@ namespace Humanizer
         string TimeSpanHumanize_Zero();
         string TimeUnitHumanize(Humanizer.TimeUnit timeUnit);
     }
+    public interface ILongOrdinalizer : Humanizer.IOrdinalizer
+    {
+        string Convert(long number, string numberString);
+        string Convert(long number, string numberString, Humanizer.GrammaticalGender gender);
+        string Convert(long number, string numberString, Humanizer.WordForm wordForm);
+        string Convert(long number, string numberString, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm);
+    }
     public interface INumberToWordsConverter
     {
         string Convert(long number);
@@ -1889,20 +1896,28 @@ namespace Humanizer
     public static class OrdinalizeExtensions
     {
         public static string Ordinalize(this int number) { }
+        public static string Ordinalize(this long number) { }
         public static string Ordinalize(this string numberString) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this int number, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender) { }
+        public static string Ordinalize(this long number, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this string numberString, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this long number, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
     }
     public enum Plurality

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -391,6 +391,13 @@ namespace Humanizer
         string TimeSpanHumanize_Zero();
         string TimeUnitHumanize(Humanizer.TimeUnit timeUnit);
     }
+    public interface ILongOrdinalizer : Humanizer.IOrdinalizer
+    {
+        string Convert(long number, string numberString);
+        string Convert(long number, string numberString, Humanizer.GrammaticalGender gender);
+        string Convert(long number, string numberString, Humanizer.WordForm wordForm);
+        string Convert(long number, string numberString, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm);
+    }
     public interface INumberToWordsConverter
     {
         string Convert(long number);
@@ -1234,20 +1241,28 @@ namespace Humanizer
     public static class OrdinalizeExtensions
     {
         public static string Ordinalize(this int number) { }
+        public static string Ordinalize(this long number) { }
         public static string Ordinalize(this string numberString) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this int number, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender) { }
+        public static string Ordinalize(this long number, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender) { }
         public static string Ordinalize(this string numberString, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this int number, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
+        public static string Ordinalize(this long number, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture) { }
         public static string Ordinalize(this string numberString, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this int number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
+        public static string Ordinalize(this long number, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
         public static string Ordinalize(this string numberString, Humanizer.GrammaticalGender gender, System.Globalization.CultureInfo? culture, Humanizer.WordForm wordForm) { }
     }
     public enum Plurality

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -754,6 +754,31 @@ public class CoverageGapTests
     }
 
     [Fact]
+    public void TemplateOrdinalizersFormatLongMinValueWithoutOverflow()
+    {
+        var pattern = CreateTemplateOrdinalizerPattern("t-", "-ordinal");
+        var templateOrdinalizer = new TemplateOrdinalizer(
+            new(
+                pattern,
+                pattern,
+                pattern,
+                MinValueAsPlainNumber: false,
+                NegativeMode: TemplateOrdinalizer.NegativeNumberMode.AbsoluteInvariant));
+        Assert.Equal(
+            "t-9223372036854775808-ordinal",
+            templateOrdinalizer.Convert(long.MinValue, long.MinValue.ToString(CultureInfo.InvariantCulture)));
+
+        var wordFormOrdinalizer = new WordFormTemplateOrdinalizer(
+            CultureInfo.InvariantCulture,
+            CreateWordFormTemplateOrdinalizerOptions(
+                WordFormTemplateOrdinalizer.NegativeNumberMode.AbsoluteInvariant,
+                minValueAsPlainNumber: false));
+        Assert.Equal(
+            "m-9223372036854775808-m",
+            wordFormOrdinalizer.Convert(long.MinValue, long.MinValue.ToString(CultureInfo.InvariantCulture)));
+    }
+
+    [Fact]
     public void TokenMapWordsToNumberNormalizerCoversFastAndBuilderEdges()
     {
         Assert.Equal(string.Empty, TokenMapWordsToNumberNormalizer.Normalize("   ", TokenMapNormalizationProfile.CollapseWhitespace));
@@ -3040,6 +3065,9 @@ public class CoverageGapTests
             (exactReplacements ?? []).ToFrozenDictionary(),
             (exactSuffixes ?? []).ToFrozenDictionary(),
             (lastDigitSuffixes ?? []).ToFrozenDictionary());
+
+    static TemplateOrdinalizer.Pattern CreateTemplateOrdinalizerPattern(string prefix, string defaultSuffix) =>
+        new(prefix, defaultSuffix, FrozenDictionary<int, string>.Empty, FrozenDictionary<int, string>.Empty, FrozenDictionary<int, string>.Empty);
 
     static PluralizedScaleNumberToWordsProfile CreatePluralizedScaleProfile(
         PluralizedScaleFormDetector formDetector,

--- a/tests/Humanizer.Tests/OrdinalizeTests.cs
+++ b/tests/Humanizer.Tests/OrdinalizeTests.cs
@@ -87,6 +87,17 @@ public class OrdinalizeTests
     }
 
     [Fact]
+    public void OrdinalizeLongMinValueUsesCultureSpecificRules()
+    {
+        Assert.Equal(
+            "9223372036854775808.º",
+            long.MinValue.Ordinalize(new CultureInfo("es-ES"), WordForm.Normal));
+        Assert.Equal(
+            "9223372036854775808è",
+            long.MinValue.Ordinalize(new CultureInfo("ca-ES")));
+    }
+
+    [Fact]
     public void OrdinalizeLongNumberUsesNumberWordSuffixFallback()
     {
         const long number = 2_147_483_648;

--- a/tests/Humanizer.Tests/OrdinalizeTests.cs
+++ b/tests/Humanizer.Tests/OrdinalizeTests.cs
@@ -70,7 +70,7 @@ public class OrdinalizeTests
     [InlineData(-2_147_483_651L, "-2147483651st")]
     [InlineData(long.MinValue, "-9223372036854775808th")]
     public void OrdinalizeLongNumber(long number, string ordinalized) =>
-        Assert.Equal(ordinalized, number.Ordinalize());
+        Assert.Equal(number.Ordinalize(), ordinalized);
 
     [Fact]
     public void OrdinalizeLongNumberUsesCultureSpecificRules()

--- a/tests/Humanizer.Tests/OrdinalizeTests.cs
+++ b/tests/Humanizer.Tests/OrdinalizeTests.cs
@@ -66,6 +66,58 @@ public class OrdinalizeTests
         Assert.Equal(number.Ordinalize(), ordinalized);
 
     [Theory]
+    [InlineData(2_147_483_651L, "2147483651st")]
+    [InlineData(-2_147_483_651L, "-2147483651st")]
+    [InlineData(long.MinValue, "-9223372036854775808th")]
+    public void OrdinalizeLongNumber(long number, string ordinalized) =>
+        Assert.Equal(ordinalized, number.Ordinalize());
+
+    [Fact]
+    public void OrdinalizeLongNumberUsesCultureSpecificRules()
+    {
+        const long number = 4_294_967_297;
+
+        Assert.Equal("4294967297ème", number.Ordinalize(new CultureInfo("fr-FR")));
+        Assert.Equal(
+            "2147483651.er",
+            2_147_483_651L.Ordinalize(
+                GrammaticalGender.Masculine,
+                new CultureInfo("es-ES"),
+                WordForm.Abbreviation));
+    }
+
+    [Fact]
+    public void OrdinalizeLongNumberUsesNumberWordSuffixFallback()
+    {
+        const long number = 2_147_483_648;
+        var culture = new CultureInfo("hi-IN");
+
+        Assert.Equal(
+            number.ToWords(GrammaticalGender.Masculine, culture) + "वाँ",
+            number.Ordinalize(GrammaticalGender.Masculine, culture));
+    }
+
+    [Fact]
+    public void OrdinalizeLongOverloads()
+    {
+        const long number = 2_147_483_651;
+        var culture = new CultureInfo("en-US");
+
+        Assert.Equal("2147483651st", number.Ordinalize());
+        Assert.Equal("2147483651st", number.Ordinalize(WordForm.Normal));
+        Assert.Equal("2147483651st", number.Ordinalize(culture));
+        Assert.Equal("2147483651st", number.Ordinalize(culture, WordForm.Normal));
+        Assert.Equal("2147483651st", number.Ordinalize(GrammaticalGender.Masculine));
+        Assert.Equal("2147483651st", number.Ordinalize(GrammaticalGender.Masculine, WordForm.Normal));
+        Assert.Equal("2147483651st", number.Ordinalize(GrammaticalGender.Masculine, culture));
+        Assert.Equal("2147483651st", number.Ordinalize(GrammaticalGender.Masculine, culture, WordForm.Normal));
+    }
+
+    [Fact]
+    public void OrdinalizeStringRemainsIntBounded() =>
+        Assert.Throws<OverflowException>(() => "2147483648".Ordinalize());
+
+    [Theory]
     [InlineData(0)]
     [InlineData(1)]
     [InlineData(8)]


### PR DESCRIPTION
## Summary

`long` values can now use the complete ordinalization API without truncation, including localized suffix and word-form rules, negative values, and `long.MinValue`. Existing `int` and string behavior remains unchanged, and custom `IOrdinalizer` implementations remain source-compatible through the opt-in `ILongOrdinalizer` contract.

Fractional overloads and implicit rounding are deliberately out of scope: callers with `float`, `double`, or `decimal` values must choose and apply an explicit rounding and conversion policy before ordinalizing.

Reported by @StefH. @hazzik’s question identified the unspecified fractional-rounding semantics preserved by this boundary.

Fixes #1077

## Validation

- Focused ordinal tests: 93 passed
- Public API approval: 1 passed
- Format verification: 0 of 2,683 files changed
- Full `net8.0`, `net10.0`, and `net11.0` matrices: 57,911 passed per target
- Release pack: succeeded without warnings or errors
