### PR TITLE
fix: pluralize Albanian million scale

### DIFF
--- a/src/Humanizer/Locales/sq.yml
+++ b/src/Humanizer/Locales/sq.yml
@@ -286,6 +286,7 @@ surfaces:
         -
           value: 1000000
           name: 'milion'
+          pluralName: 'milionë'
         -
           value: 1000
           name: 'mijë'

--- a/tests/Humanizer.Tests/Localisation/LocaleNumberMagnitudeTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleNumberMagnitudeTheoryData.cs
@@ -13,7 +13,7 @@ public static class LocaleNumberMagnitudeTheoryData
             { "et", 1000001L, "miljon üks" },
             { "et", 1234567L, "miljon kakssada kolmkümmend neli tuhat viissada kuuskümmend seitse" },
         { "sq", 1000000L, "një milion" },
-        { "sq", 12345678L, "dymbëdhjetë milion e treqind e dyzet e pesë mijë e gjashtëqind e shtatëdhjetë e tetë" },
+        { "sq", 12345678L, "dymbëdhjetë milionë e treqind e dyzet e pesë mijë e gjashtëqind e shtatëdhjetë e tetë" },
         { "sq", 1000000000L, "një miliar" },
         { "mk", 1001L, "илјада и еден" },
         { "mk", 1000001L, "еден милион и еден" },
@@ -228,7 +228,7 @@ public static class LocaleNumberMagnitudeTheoryData
 
             { "et", 1001000001L, "miljard miljon üks" },
         { "sq", 1000000000000L, "një bilion" },
-        { "sq", 1234567890123L, "një bilion e dyqind e tridhjetë e katër miliarë e pesëqind e gjashtëdhjetë e shtatë milion e tetëqind e nëntëdhjetë mijë e njëqind e njëzet e tre" },
+        { "sq", 1234567890123L, "një bilion e dyqind e tridhjetë e katër miliarë e pesëqind e gjashtëdhjetë e shtatë milionë e tetëqind e nëntëdhjetë mijë e njëqind e njëzet e tre" },
         { "mk", 1001000001L, "една милијарда еден милион и еден" },
         { "mk", 4325010007018L, "четири билиони триста дваесет и пет милијарди десет милиони седум илјади и осумнаесет" },
 

--- a/tests/Humanizer.Tests/Localisation/LocaleNumberOverloadTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleNumberOverloadTheoryData.cs
@@ -8,7 +8,7 @@ public static class LocaleNumberOverloadTheoryData
         { "tk", 1001001L, "bir million müň bir" },
 
             { "et", 1001001L, "miljon tuhat üks" },
-        { "sq", 1234567890123L, "një bilion e dyqind e tridhjetë e katër miliarë e pesëqind e gjashtëdhjetë e shtatë milion e tetëqind e nëntëdhjetë mijë e njëqind e njëzet e tre" },
+        { "sq", 1234567890123L, "një bilion e dyqind e tridhjetë e katër miliarë e pesëqind e gjashtëdhjetë e shtatë milionë e tetëqind e nëntëdhjetë mijë e njëqind e njëzet e tre" },
         { "mk", 1001001L, "еден милион илјада и еден" },
         { "mk", 1001000001L, "една милијарда еден милион и еден" },
         { "mk", 4325010007018L, "четири билиони триста дваесет и пет милијарди десет милиони седум илјади и осумнаесет" },
@@ -271,7 +271,7 @@ public static class LocaleNumberOverloadTheoryData
         { "tk", 1001001L, "bir million müň bir" },
 
             { "et", 1001001L, "miljon tuhat üks" },
-        { "sq", 1234567890123L, "një bilion e dyqind e tridhjetë e katër miliarë e pesëqind e gjashtëdhjetë e shtatë milion e tetëqind e nëntëdhjetë mijë e njëqind e njëzet e tre" },
+        { "sq", 1234567890123L, "një bilion e dyqind e tridhjetë e katër miliarë e pesëqind e gjashtëdhjetë e shtatë milionë e tetëqind e nëntëdhjetë mijë e njëqind e njëzet e tre" },
         { "mk", 1001001L, "еден милион илјада и еден" },
         { "mk", 1001000001L, "една милијарда еден милион и еден" },
         { "mk", 4325010007018L, "четири билиони триста дваесет и пет милијарди десет милиони седум илјади и осумнаесет" },
@@ -533,7 +533,7 @@ public static class LocaleNumberOverloadTheoryData
         { "tk", 1001001L, "bir million müň bir" },
 
             { "et", 1001001L, "miljon tuhat üks" },
-        { "sq", 1234567890123L, "një bilion e dyqind e tridhjetë e katër miliarë e pesëqind e gjashtëdhjetë e shtatë milion e tetëqind e nëntëdhjetë mijë e njëqind e njëzet e tre" },
+        { "sq", 1234567890123L, "një bilion e dyqind e tridhjetë e katër miliarë e pesëqind e gjashtëdhjetë e shtatë milionë e tetëqind e nëntëdhjetë mijë e njëqind e njëzet e tre" },
         { "mk", 1001001L, "еден милион илјада и една" },
         { "mk", 1001000001L, "една милијарда еден милион и една" },
         { "mk", 4325010007018L, "четири билиони триста дваесет и пет милијарди десет милиони седум илјади и осумнаесет" },
@@ -795,7 +795,7 @@ public static class LocaleNumberOverloadTheoryData
         { "tk", 1001001L, "bir million müň bir" },
 
             { "et", 1001001L, "miljon tuhat üks" },
-        { "sq", 1234567890123L, "një bilion e dyqind e tridhjetë e katër miliarë e pesëqind e gjashtëdhjetë e shtatë milion e tetëqind e nëntëdhjetë mijë e njëqind e njëzet e tre" },
+        { "sq", 1234567890123L, "një bilion e dyqind e tridhjetë e katër miliarë e pesëqind e gjashtëdhjetë e shtatë milionë e tetëqind e nëntëdhjetë mijë e njëqind e njëzet e tre" },
         { "mk", 1001001L, "еден милион илјада и една" },
         { "mk", 1001000001L, "една милијарда еден милион и една" },
         { "mk", 4325010007018L, "четири билиони триста дваесет и пет милијарди десет милиони седум илјади и осумнаесет" },

--- a/tests/Humanizer.Tests/Localisation/sq/AlbanianLocaleParityTests.cs
+++ b/tests/Humanizer.Tests/Localisation/sq/AlbanianLocaleParityTests.cs
@@ -15,6 +15,7 @@ public class AlbanianLocaleParityTests
     [InlineData(101, "njëqind e një")]
     [InlineData(1234, "një mijë e dyqind e tridhjetë e katër")]
     [InlineData(1000000, "një milion")]
+    [InlineData(2_000_000, "dy milionë")]
     [InlineData(1_000_000_000, "një miliar")]
     [InlineData(2_000_000_000, "dy miliarë")]
     [InlineData(1_000_000_000_000, "një bilion")]


### PR DESCRIPTION
## Summary

Albanian number-to-words output now uses the plural scale word `milionë` whenever the million count is greater than one, while preserving singular `një milion`. Previously, compound values such as 12,345,678 rendered the plural count with singular `milion`.

The locale data follows the official [CLDR Albanian spellout rules](https://github.com/unicode-org/cldr/blob/release-48-2/common/rbnf/sq.xml#L41-L42), and dedicated `sq` coverage protects both singular and plural output.

Related: #1863 — this independent follow-up preserves credit for the Albanian finding reported by @chatgpt-codex-connector during review.

## Validation

- Albanian locale parity tests — 48 passed
- Number-word magnitude tests — 617 passed
- Number-word overload tests — 1,012 passed
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — succeeded
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 57,920 passed
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — succeeded
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 57,920 passed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release` — succeeded for all supported package targets

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or OSS
- [x] XML documentation was reviewed; no public API changed
- [x] The branch is rebased on the latest `main`
- [x] Related work and finding credit are preserved without closing the prior PR
- [x] Readme impact was reviewed; no documentation change is required
- [x] The full supported test matrix and Release pack succeed
