### PR TITLE
feat(metric): preserve trailing zeros

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -797,6 +797,7 @@ Convert between numbers and metric notation:
 1230d.ToMetric() => "1.23k"
 0.1d.ToMetric() => "100m"
 456789.ToMetric(decimals: 2) => "456.79k"
+1000.ToMetric(MetricNumeralFormats.KeepTrailingZeros, decimals: 2) => "1.00k"
 
 // Locale-aware scale words
 CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("de-DE");

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -34,6 +34,14 @@ public static class MetricNumeralExtensions
     static readonly double BigLimit = Math.Pow(10, Limit);
     static readonly double SmallLimit = Math.Pow(10, -Limit);
 
+    static bool ShouldKeepTrailingZeros(MetricNumeralFormats? formats, int? decimals) =>
+        decimals.HasValue && formats.HasValue && formats.Value.HasFlag(MetricNumeralFormats.KeepTrailingZeros);
+
+    static string FormatLongWithTrailingZeros(long input, int decimals, NumberFormatInfo nfi) =>
+        decimals > 0
+            ? input.ToString(nfi) + nfi.NumberDecimalSeparator + new string('0', decimals)
+            : input.ToString(nfi);
+
     /// <summary>
     /// Symbols is a list of every symbols for the Metric system.
     /// </summary>
@@ -137,7 +145,7 @@ public static class MetricNumeralExtensions
     /// </remarks>
     /// <param name="input">Number to convert to a Metric representation.</param>
     /// <param name="formats">A bitwise combination of <see cref="MetricNumeralFormats"/> enumeration values that format the metric representation.</param>
-    /// <param name="decimals">If not null it is the numbers of decimals to round the number to</param>
+    /// <param name="decimals">The maximum number of fractional digits to include. When <see cref="MetricNumeralFormats.KeepTrailingZeros"/> is used, exactly this many fractional digits are included. If null, all available precision is preserved and the flag has no effect.</param>
     /// <example>
     /// <code>
     /// 1000.ToMetric() => "1k"
@@ -193,7 +201,7 @@ public static class MetricNumeralExtensions
     /// </remarks>
     /// <param name="input">Number to convert to a Metric representation.</param>
     /// <param name="formats">A bitwise combination of <see cref="MetricNumeralFormats"/> enumeration values that format the metric representation.</param>
-    /// <param name="decimals">The maximum number of fractional digits to include. If null, all available precision is preserved. Trailing zeros are omitted.</param>
+    /// <param name="decimals">The maximum number of fractional digits to include. When <see cref="MetricNumeralFormats.KeepTrailingZeros"/> is used, exactly this many fractional digits are included. If null, all available precision is preserved and the flag has no effect.</param>
     /// <example>
     /// <code>
     /// 1000.ToMetric() => "1k"
@@ -206,6 +214,12 @@ public static class MetricNumeralExtensions
     {
         if (input.Equals(0))
         {
+            if (ShouldKeepTrailingZeros(formats, decimals))
+            {
+                var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
+                return FormatLongWithTrailingZeros(input, decimals.GetValueOrDefault(), nfi);
+            }
+
             return input.ToString();
         }
 
@@ -221,7 +235,7 @@ public static class MetricNumeralExtensions
     /// </remarks>
     /// <param name="input">Number to convert to a Metric representation.</param>
     /// <param name="formats">A bitwise combination of <see cref="MetricNumeralFormats"/> enumeration values that format the metric representation.</param>
-    /// <param name="decimals">If not null it is the numbers of decimals to round the number to</param>
+    /// <param name="decimals">The maximum number of fractional digits to include. When <see cref="MetricNumeralFormats.KeepTrailingZeros"/> is used, exactly this many fractional digits are included. If null, all available precision is preserved and the flag has no effect.</param>
     /// <example>
     /// <code>
     /// 1000d.ToMetric() => "1k"
@@ -234,6 +248,12 @@ public static class MetricNumeralExtensions
     {
         if (input.Equals(0))
         {
+            if (ShouldKeepTrailingZeros(formats, decimals))
+            {
+                var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
+                return input.ToString($"F{decimals.GetValueOrDefault()}", nfi);
+            }
+
             return input.ToString();
         }
 
@@ -333,8 +353,11 @@ public static class MetricNumeralExtensions
         }
 
         var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
+        var representation = ShouldKeepTrailingZeros(formats, decimals)
+            ? FormatLongWithTrailingZeros(input, decimals.GetValueOrDefault(), nfi)
+            : input.ToString(nfi);
         var space = (formats & MetricNumeralFormats.WithSpace) == MetricNumeralFormats.WithSpace ? " " : string.Empty;
-        return input.ToString(nfi) + space;
+        return representation + space;
     }
 
     /// <summary>
@@ -369,6 +392,9 @@ public static class MetricNumeralExtensions
             number = input / divisor;
             fractionalPart = Math.Abs(input % divisor);
         }
+
+        var requestedDecimals = decimals;
+        var keepTrailingZeros = ShouldKeepTrailingZeros(formats, decimals);
 
         if (!decimals.HasValue)
             decimals = exponent;
@@ -454,7 +480,10 @@ public static class MetricNumeralExtensions
             }
 
             var space = formats.HasValue && formats.Value.HasFlag(MetricNumeralFormats.WithSpace) ? " " : string.Empty;
-            return number.ToString(nfi) + space + unitText;
+            var representation = keepTrailingZeros
+                ? FormatLongWithTrailingZeros(number, requestedDecimals.GetValueOrDefault(), nfi)
+                : number.ToString(nfi);
+            return representation + space + unitText;
         }
         else
         {
@@ -463,6 +492,7 @@ public static class MetricNumeralExtensions
             return number.ToString(nfi)
                  + nfi.NumberDecimalSeparator
                  + new string(fractionalPartCharacters, 0, decimals.Value)
+                 + (keepTrailingZeros && requestedDecimals > decimals ? new string('0', requestedDecimals.Value - decimals.Value) : string.Empty)
                  + space
                  + unitText;
         }
@@ -493,7 +523,9 @@ public static class MetricNumeralExtensions
         }
 
         var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
-        var representation = input.ToString(nfi);
+        var representation = ShouldKeepTrailingZeros(formats, decimals)
+            ? input.ToString($"F{decimals.GetValueOrDefault()}", nfi)
+            : input.ToString(nfi);
         var space = (formats & MetricNumeralFormats.WithSpace) == MetricNumeralFormats.WithSpace ? " " : string.Empty;
         return representation + space;
     }
@@ -520,12 +552,19 @@ public static class MetricNumeralExtensions
             exponent += 1;
         }
 
-        var symbol = Math.Sign(exponent) == 1
-            ? Symbols[0][exponent - 1]
-            : Symbols[1][-exponent - 1];
+        var unitText =
+            Math.Sign(exponent) switch
+            {
+                +1 => GetUnitText(Symbols[0][exponent - 1], formats),
+                -1 => GetUnitText(Symbols[1][-exponent - 1], formats),
+                _ => string.Empty
+            };
         var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
+        var representation = ShouldKeepTrailingZeros(formats, decimals)
+            ? number.ToString($"F{decimals.GetValueOrDefault()}", nfi)
+            : number.ToString("G15", nfi);
         var space = formats.HasValue && formats.Value.HasFlag(MetricNumeralFormats.WithSpace) ? " " : string.Empty;
-        return number.ToString("G15", nfi) + space + GetUnitText(symbol, formats);
+        return representation + space + unitText;
     }
 
     /// <summary>

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -217,7 +217,8 @@ public static class MetricNumeralExtensions
             if (ShouldKeepTrailingZeros(formats, decimals))
             {
                 var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
-                return FormatLongWithTrailingZeros(input, decimals.GetValueOrDefault(), nfi);
+                var space = formats.HasValue && formats.Value.HasFlag(MetricNumeralFormats.WithSpace) ? " " : string.Empty;
+                return FormatLongWithTrailingZeros(input, decimals.GetValueOrDefault(), nfi) + space;
             }
 
             return input.ToString();
@@ -251,7 +252,8 @@ public static class MetricNumeralExtensions
             if (ShouldKeepTrailingZeros(formats, decimals))
             {
                 var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
-                return input.ToString($"F{decimals.GetValueOrDefault()}", nfi);
+                var space = formats.HasValue && formats.Value.HasFlag(MetricNumeralFormats.WithSpace) ? " " : string.Empty;
+                return input.ToString($"F{decimals.GetValueOrDefault()}", nfi) + space;
             }
 
             return input.ToString();

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -217,7 +217,7 @@ public static class MetricNumeralExtensions
             if (ShouldKeepTrailingZeros(formats, decimals))
             {
                 var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
-                var space = formats.HasValue && formats.Value.HasFlag(MetricNumeralFormats.WithSpace) ? " " : string.Empty;
+                var space = formats.GetValueOrDefault().HasFlag(MetricNumeralFormats.WithSpace) ? " " : string.Empty;
                 return FormatLongWithTrailingZeros(input, decimals.GetValueOrDefault(), nfi) + space;
             }
 
@@ -252,7 +252,7 @@ public static class MetricNumeralExtensions
             if (ShouldKeepTrailingZeros(formats, decimals))
             {
                 var nfi = LocaleNumberFormattingOverrides.GetFormattingNumberFormat(CultureInfo.CurrentCulture);
-                var space = formats.HasValue && formats.Value.HasFlag(MetricNumeralFormats.WithSpace) ? " " : string.Empty;
+                var space = formats.GetValueOrDefault().HasFlag(MetricNumeralFormats.WithSpace) ? " " : string.Empty;
                 return input.ToString($"F{decimals.GetValueOrDefault()}", nfi) + space;
             }
 

--- a/src/Humanizer/MetricNumeralFormats.cs
+++ b/src/Humanizer/MetricNumeralFormats.cs
@@ -31,5 +31,11 @@ public enum MetricNumeralFormats
     /// based on <see cref="System.Globalization.CultureInfo.CurrentUICulture"/>.
     /// For example, <c>1E9</c> renders as <c>billion</c> in <c>en-US</c> and <c>milliard</c> in <c>de-DE</c>.
     /// </summary>
-    UseScaleWord = 16
+    UseScaleWord = 16,
+
+    /// <summary>
+    /// Include trailing zeros so the number of fractional digits matches the <c>decimals</c> argument.
+    /// Has no effect when <c>decimals</c> is <see langword="null"/>.
+    /// </summary>
+    KeepTrailingZeros = 32
 }

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -917,6 +917,7 @@ namespace Humanizer
         UseShortScaleWord = 4,
         WithSpace = 8,
         UseScaleWord = 16,
+        KeepTrailingZeros = 32,
     }
     public class NoMatchFoundException : System.Exception
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -917,6 +917,7 @@ namespace Humanizer
         UseShortScaleWord = 4,
         WithSpace = 8,
         UseScaleWord = 16,
+        KeepTrailingZeros = 32,
     }
     public class NoMatchFoundException : System.Exception
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -916,6 +916,7 @@ namespace Humanizer
         UseShortScaleWord = 4,
         WithSpace = 8,
         UseScaleWord = 16,
+        KeepTrailingZeros = 32,
     }
     public class NoMatchFoundException : System.Exception
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -691,6 +691,7 @@ namespace Humanizer
         UseShortScaleWord = 4,
         WithSpace = 8,
         UseScaleWord = 16,
+        KeepTrailingZeros = 32,
     }
     public class NoMatchFoundException : System.Exception
     {

--- a/tests/Humanizer.Tests/MetricNumeralTests.cs
+++ b/tests/Humanizer.Tests/MetricNumeralTests.cs
@@ -381,6 +381,15 @@ public class MetricNumeralTests
         Assert.Equal(expected, input.ToMetric(MetricNumeralFormats.KeepTrailingZeros, decimals));
 
     [Fact]
+    public void ToMetric_KeepTrailingZeros_ComposesWithSpaceForZero()
+    {
+        var formats = MetricNumeralFormats.KeepTrailingZeros | MetricNumeralFormats.WithSpace;
+
+        Assert.Equal("0.00 ", 0L.ToMetric(formats, decimals: 2));
+        Assert.Equal("0.00 ", 0d.ToMetric(formats, decimals: 2));
+    }
+
+    [Fact]
     public void ToMetric_KeepTrailingZeros_ComposesWithScaleWordAndCulture()
     {
         using var _ = new Humanizer.Tests.Localisation.DistinctCultureSwap(new("de-DE"), new("en-US"));

--- a/tests/Humanizer.Tests/MetricNumeralTests.cs
+++ b/tests/Humanizer.Tests/MetricNumeralTests.cs
@@ -352,6 +352,46 @@ public class MetricNumeralTests
     public void ToMetric(string expected, double input, MetricNumeralFormats? format, int? decimals) =>
         Assert.Equal(expected, input.ToMetric(format, decimals));
 
+    [Fact]
+    public void ToMetric_KeepTrailingZeros_IsOptIn()
+    {
+        Assert.Equal("1k", 1000.ToMetric(decimals: 2));
+        Assert.Equal("1k", 1000.ToMetric(MetricNumeralFormats.KeepTrailingZeros));
+        Assert.Equal("1.00k", 1000.ToMetric(MetricNumeralFormats.KeepTrailingZeros, decimals: 2));
+    }
+
+    [Theory]
+    [InlineData("0.00", 0d)]
+    [InlineData("123.00", 123d)]
+    [InlineData("1.20k", 1200d)]
+    [InlineData("-1.20k", -1200d)]
+    [InlineData("1.00M", 999999d)]
+    [InlineData("1.00", 0.999999d)]
+    [InlineData("-1.00", -0.999999d)]
+    public void ToMetric_KeepTrailingZeros_Double(string expected, double input) =>
+        Assert.Equal(expected, input.ToMetric(MetricNumeralFormats.KeepTrailingZeros, decimals: 2));
+
+    [Theory]
+    [InlineData("0.00000", 0L, 5)]
+    [InlineData("123.00000", 123L, 5)]
+    [InlineData("1.00000k", 1000L, 5)]
+    [InlineData("-1.20000k", -1200L, 5)]
+    [InlineData("1.00M", 999999L, 2)]
+    public void ToMetric_KeepTrailingZeros_Long(string expected, long input, int decimals) =>
+        Assert.Equal(expected, input.ToMetric(MetricNumeralFormats.KeepTrailingZeros, decimals));
+
+    [Fact]
+    public void ToMetric_KeepTrailingZeros_ComposesWithScaleWordAndCulture()
+    {
+        using var _ = new Humanizer.Tests.Localisation.DistinctCultureSwap(new("de-DE"), new("en-US"));
+
+        Assert.Equal(
+            "1,00 billion",
+            1E9.ToMetric(
+                MetricNumeralFormats.KeepTrailingZeros | MetricNumeralFormats.WithSpace | MetricNumeralFormats.UseScaleWord,
+                decimals: 2));
+    }
+
     [Theory]
     [InlineData(1E+27)]
     [InlineData(1E-27)]


### PR DESCRIPTION
## Summary

`ToMetric` can now preserve fixed decimal places when callers opt into `MetricNumeralFormats.KeepTrailingZeros`, while its existing trimming behavior remains unchanged by default. The flag composes with localized scale words and culture-specific decimal separators, and rounding across the unit/scale boundary keeps the correct unit.

Thanks @shtse8 for reporting this.

Fixes #697

## Validation

- `MetricNumeralTests`: 658 passed
- `PublicApiApprovalTest` on net8.0: 1 passed
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`: 0 files changed
- Full `Humanizer.Tests` on net8.0: 57,997 passed
- Full `Humanizer.Tests` on net10.0: 57,997 passed
- Full `Humanizer.Tests` on net11.0: 57,997 passed
- Fresh Release pack: succeeded

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or OSS
- [x] There are very few or no comments
- [x] XML documentation is updated
- [x] Rebased on the latest `main`
- [x] Linked the fixed issue
- [x] Readme is updated
- [x] Formatting, supported test targets, and Release packaging pass
