### PR TITLE
feat: select enum humanization source

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -170,6 +170,21 @@ UserType.MemberWithoutDescriptionAttribute.Humanize().Transform(To.TitleCase)
     => "Member Without Description Attribute"
 ```
 
+Callers can select the enum member name or a specific `DisplayAttribute` value without changing the default metadata precedence:
+
+```csharp
+public enum UserType
+{
+    [Display(Name = "Administrator", Description = "Manages users", ShortName = "Admin")]
+    AdministratorUser
+}
+
+UserType.AdministratorUser.Humanize(LetterCasing.Sentence, EnumHumanizeSource.EnumName) => "Administrator user"
+UserType.AdministratorUser.Humanize(LetterCasing.Sentence, EnumHumanizeSource.DisplayName) => "Administrator"
+UserType.AdministratorUser.Humanize(LetterCasing.Sentence, EnumHumanizeSource.DisplayDescription) => "Manages users"
+UserType.AdministratorUser.Humanize(LetterCasing.Sentence, EnumHumanizeSource.DisplayShortName) => "Admin"
+```
+
 Humanizer works with any attribute containing a `Description` property and supports localized `DisplayAttribute` for multi-language scenarios. This helps you avoid littering enums with unnecessary attributes while still providing customization when needed.
 
 

--- a/src/Humanizer/EnumCache.cs
+++ b/src/Humanizer/EnumCache.cs
@@ -7,13 +7,25 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
 {
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
     static readonly Type TypeOfT = typeof(T);
-    static readonly (
-        T Zero,
-        FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized,
-        FrozenDictionary<T, (string EnumName, DisplayAttribute? Display)> Sources,
-        FrozenDictionary<string, T> Dehumanized,
-        FrozenSet<T> Values,
-        bool IsBitFieldEnum) Info = CreateInfo();
+    static class DefaultInfo
+    {
+        public static readonly (
+            T Zero,
+            FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized,
+            FrozenDictionary<T, (string EnumName, DisplayAttribute? Display)> Sources,
+            FrozenDictionary<string, T> Dehumanized,
+            FrozenSet<T> Values,
+            bool IsBitFieldEnum) Value = CreateInfo();
+    }
+
+    static class ExplicitInfo
+    {
+        public static readonly (
+            T Zero,
+            FrozenDictionary<T, (string EnumName, DisplayAttribute? Display)> Sources,
+            FrozenSet<T> Values,
+            bool IsBitFieldEnum) Value = CreateExplicitInfo();
+    }
 
     private static (
         T Zero,
@@ -53,6 +65,24 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
             isBitFieldEnum);
     }
 
+    static (
+        T Zero,
+        FrozenDictionary<T, (string EnumName, DisplayAttribute? Display)> Sources,
+        FrozenSet<T> Values,
+        bool IsBitFieldEnum) CreateExplicitInfo()
+    {
+        var valuesArray = Enum.GetValues<T>();
+        var zero = (T)Convert.ChangeType(Enum.ToObject(TypeOfT, 0), TypeOfT);
+        var sources = new Dictionary<T, (string EnumName, DisplayAttribute? Display)>(valuesArray.Length);
+        foreach (var value in valuesArray)
+        {
+            sources[value] = GetSources(value);
+        }
+
+        var isBitFieldEnum = TypeOfT.GetCustomAttribute<FlagsAttribute>() != null;
+        return (zero, sources.ToFrozenDictionary(), valuesArray.ToFrozenSet(), isBitFieldEnum);
+    }
+
     static void AddAliases(Dictionary<string, T> dehumanized, string caseName, T value)
     {
         var member = TypeOfT.GetField(caseName)!;
@@ -76,17 +106,19 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
         }
     }
 
-    public static (T Zero, FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized, FrozenSet<T> Values) GetInfo() =>
-        (Info.Zero, Info.Humanized, Info.Values);
+    public static (T Zero, FrozenSet<T> Values) GetInfo(EnumHumanizeSource source) =>
+        source == EnumHumanizeSource.Default
+            ? (DefaultInfo.Value.Zero, DefaultInfo.Value.Values)
+            : (ExplicitInfo.Value.Zero, ExplicitInfo.Value.Values);
 
     public static (string Text, bool IsMetadata) GetHumanized(T input, EnumHumanizeSource source)
     {
         if (source == EnumHumanizeSource.Default)
         {
-            return Info.Humanized[input];
+            return DefaultInfo.Value.Humanized[input];
         }
 
-        var (enumName, display) = Info.Sources[input];
+        var (enumName, display) = ExplicitInfo.Value.Sources[input];
         var metadata = source switch
         {
             EnumHumanizeSource.EnumName => null,
@@ -100,11 +132,14 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
     }
 
     public static FrozenDictionary<string, T> GetDehumanized() =>
-        Info.Dehumanized;
+        DefaultInfo.Value.Dehumanized;
 
-    public static bool TreatAsFlags(T input)
+    public static bool TreatAsFlags(T input, EnumHumanizeSource source)
     {
-        if (!Info.IsBitFieldEnum)
+        var isBitFieldEnum = source == EnumHumanizeSource.Default
+            ? DefaultInfo.Value.IsBitFieldEnum
+            : ExplicitInfo.Value.IsBitFieldEnum;
+        if (!isBitFieldEnum)
         {
             return false;
         }

--- a/src/Humanizer/EnumCache.cs
+++ b/src/Humanizer/EnumCache.cs
@@ -7,15 +7,28 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
 {
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
     static readonly Type TypeOfT = typeof(T);
-    static readonly (T Zero, FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized, FrozenDictionary<string, T> Dehumanized, FrozenSet<T> Values, bool IsBitFieldEnum) Info = CreateInfo();
+    static readonly (
+        T Zero,
+        FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized,
+        FrozenDictionary<T, (string EnumName, DisplayAttribute? Display)> Sources,
+        FrozenDictionary<string, T> Dehumanized,
+        FrozenSet<T> Values,
+        bool IsBitFieldEnum) Info = CreateInfo();
 
-    private static (T Zero, FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized, FrozenDictionary<string, T> Dehumanized, FrozenSet<T> Values, bool IsBitFieldEnum) CreateInfo()
+    private static (
+        T Zero,
+        FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized,
+        FrozenDictionary<T, (string EnumName, DisplayAttribute? Display)> Sources,
+        FrozenDictionary<string, T> Dehumanized,
+        FrozenSet<T> Values,
+        bool IsBitFieldEnum) CreateInfo()
     {
         var valuesArray = Enum.GetValues<T>();
         var namesArray = Enum.GetNames(TypeOfT);
         var zero = (T)Convert.ChangeType(Enum.ToObject(TypeOfT, 0), TypeOfT);
         var count = valuesArray.Length;
         var humanized = new Dictionary<T, (string Text, bool IsMetadata)>(count);
+        var sources = new Dictionary<T, (string EnumName, DisplayAttribute? Display)>(count);
         var dehumanized = new Dictionary<string, T>(count * 6, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < namesArray.Length; i++)
         {
@@ -26,6 +39,7 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
         {
             var description = GetDescription(value);
             humanized[value] = description;
+            sources[value] = GetSources(value);
             dehumanized[description.Text] = value;
         }
 
@@ -33,6 +47,7 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
         return (
             zero,
             humanized.ToFrozenDictionary(),
+            sources.ToFrozenDictionary(),
             dehumanized.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase),
             valuesArray.ToFrozenSet(),
             isBitFieldEnum);
@@ -64,6 +79,26 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
     public static (T Zero, FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized, FrozenSet<T> Values) GetInfo() =>
         (Info.Zero, Info.Humanized, Info.Values);
 
+    public static (string Text, bool IsMetadata) GetHumanized(T input, EnumHumanizeSource source)
+    {
+        if (source == EnumHumanizeSource.Default)
+        {
+            return Info.Humanized[input];
+        }
+
+        var (enumName, display) = Info.Sources[input];
+        var metadata = source switch
+        {
+            EnumHumanizeSource.EnumName => null,
+            EnumHumanizeSource.DisplayName => display?.GetName(),
+            EnumHumanizeSource.DisplayDescription => display?.GetDescription(),
+            EnumHumanizeSource.DisplayShortName => display?.GetShortName(),
+            _ => throw new ArgumentOutOfRangeException(nameof(source))
+        };
+
+        return metadata is null ? (enumName, false) : (metadata, true);
+    }
+
     public static FrozenDictionary<string, T> GetDehumanized() =>
         Info.Dehumanized;
 
@@ -92,6 +127,17 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
         }
 
         return (caseName.Humanize(), false);
+    }
+
+    static (string EnumName, DisplayAttribute? Display) GetSources(T input)
+    {
+#if NET5_0_OR_GREATER
+        var caseName = Enum.GetName(input)!;
+#else
+        var caseName = Enum.GetName(TypeOfT, input)!;
+#endif
+        var member = TypeOfT.GetField(caseName)!;
+        return (caseName.Humanize(), member.GetCustomAttribute<DisplayAttribute>());
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Reflection over attribute properties is intentional and documented.")]

--- a/src/Humanizer/EnumCache.cs
+++ b/src/Humanizer/EnumCache.cs
@@ -12,7 +12,6 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
         public static readonly (
             T Zero,
             FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized,
-            FrozenDictionary<T, (string EnumName, DisplayAttribute? Display)> Sources,
             FrozenDictionary<string, T> Dehumanized,
             FrozenSet<T> Values,
             bool IsBitFieldEnum) Value = CreateInfo();
@@ -30,7 +29,6 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
     private static (
         T Zero,
         FrozenDictionary<T, (string Text, bool IsMetadata)> Humanized,
-        FrozenDictionary<T, (string EnumName, DisplayAttribute? Display)> Sources,
         FrozenDictionary<string, T> Dehumanized,
         FrozenSet<T> Values,
         bool IsBitFieldEnum) CreateInfo()
@@ -40,7 +38,6 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
         var zero = (T)Convert.ChangeType(Enum.ToObject(TypeOfT, 0), TypeOfT);
         var count = valuesArray.Length;
         var humanized = new Dictionary<T, (string Text, bool IsMetadata)>(count);
-        var sources = new Dictionary<T, (string EnumName, DisplayAttribute? Display)>(count);
         var dehumanized = new Dictionary<string, T>(count * 6, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < namesArray.Length; i++)
         {
@@ -51,7 +48,6 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
         {
             var description = GetDescription(value);
             humanized[value] = description;
-            sources[value] = GetSources(value);
             dehumanized[description.Text] = value;
         }
 
@@ -59,7 +55,6 @@ static class EnumCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
         return (
             zero,
             humanized.ToFrozenDictionary(),
-            sources.ToFrozenDictionary(),
             dehumanized.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase),
             valuesArray.ToFrozenSet(),
             isBitFieldEnum);

--- a/src/Humanizer/EnumHumanizeExtensions.cs
+++ b/src/Humanizer/EnumHumanizeExtensions.cs
@@ -10,17 +10,21 @@ public static class EnumHumanizeExtensions
     [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "The method is only used by Humanize which already has RequiresUnreferencedCode")]
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "The method is only used by Humanize which already has RequiresDynamicCode")]
 #endif
-    static MethodInfo GetGenericHumanizeMethodInfo(int parameterCount) =>
+    static MethodInfo GetGenericHumanizeMethodInfo(params Type[] parameterTypes) =>
         typeof(EnumHumanizeExtensions)
             .GetMethods()
             .Single(method =>
                 method.Name == nameof(Humanize) &&
                 method.IsGenericMethodDefinition &&
-                method.GetParameters().Length == parameterCount &&
-                method.GetGenericArguments().Length == 1);
+                method.GetGenericArguments().Length == 1 &&
+                method.GetParameters()
+                    .Skip(1)
+                    .Select(parameter => parameter.ParameterType)
+                    .SequenceEqual(parameterTypes));
 
-    static readonly Lazy<MethodInfo> GenericHumanizeMethod = new(() => GetGenericHumanizeMethodInfo(1));
-    static readonly Lazy<MethodInfo> GenericHumanizeWithCasingMethod = new(() => GetGenericHumanizeMethodInfo(2));
+    static readonly Lazy<MethodInfo> GenericHumanizeMethod = new(() => GetGenericHumanizeMethodInfo());
+    static readonly Lazy<MethodInfo> GenericHumanizeWithCasingMethod = new(() => GetGenericHumanizeMethodInfo(typeof(LetterCasing)));
+    static readonly Lazy<MethodInfo> GenericHumanizeWithCasingAndSourceMethod = new(() => GetGenericHumanizeMethodInfo(typeof(LetterCasing), typeof(EnumHumanizeSource)));
 
 #if NET6_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2060", Justification = "The method is only used by Humanize which preserves the generic methods with DynamicDependency")]
@@ -71,6 +75,21 @@ public static class EnumHumanizeExtensions
         InvokeGenericHumanize(input, GenericHumanizeWithCasingMethod, input, casing);
 
     /// <summary>
+    /// Converts an enum value to a human-readable string using the specified casing and source when the concrete enum type is only known at runtime.
+    /// </summary>
+    /// <param name="input">The enum value to be humanized.</param>
+    /// <param name="casing">The desired letter casing to apply when humanizing the enum member name.</param>
+    /// <param name="source">The source used to humanize the enum value.</param>
+    /// <returns>A human-readable string representation of the enum value.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(EnumHumanizeExtensions))]
+#endif
+    public static string Humanize(this Enum input, LetterCasing casing, EnumHumanizeSource source) =>
+        InvokeGenericHumanize(input, GenericHumanizeWithCasingAndSourceMethod, input, casing, source);
+
+    /// <summary>
     /// Converts an enum value to a human-readable string by intelligently formatting the enum member name
     /// and respecting any <see cref="System.ComponentModel.DescriptionAttribute"/> applied to the member.
     /// </summary>
@@ -106,11 +125,19 @@ public static class EnumHumanizeExtensions
     /// </example>
     public static string Humanize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(this T input)
         where T : struct, Enum =>
-        Humanize(input, null);
+        Humanize(input, null, EnumHumanizeSource.Default);
 
-    static string Humanize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(T input, LetterCasing? casing)
+    static string Humanize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(
+        T input,
+        LetterCasing? casing,
+        EnumHumanizeSource source)
         where T : struct, Enum
     {
+        if (!Enum.IsDefined(source))
+        {
+            throw new ArgumentOutOfRangeException(nameof(source));
+        }
+
         var (zero, humanized, values) = EnumCache<T>.GetInfo();
         if (EnumCache<T>.TreatAsFlags(input))
         {
@@ -126,7 +153,9 @@ public static class EnumHumanizeExtensions
                 if (value.CompareTo(zero) != 0 && input.HasFlag(value))
                 {
                     flagValues ??= new List<string>();
-                    var flag = humanized[value];
+                    var flag = source == EnumHumanizeSource.Default
+                        ? humanized[value]
+                        : EnumCache<T>.GetHumanized(value, source);
                     flagValues.Add(casing is { } flagCasing && !flag.IsMetadata ? flag.Text.ApplyCase(flagCasing) : flag.Text);
                 }
             }
@@ -134,7 +163,9 @@ public static class EnumHumanizeExtensions
             return flagValues?.Humanize() ?? string.Empty;
         }
 
-        var humanizedEnum = humanized[input];
+        var humanizedEnum = source == EnumHumanizeSource.Default
+            ? humanized[input]
+            : EnumCache<T>.GetHumanized(input, source);
         if (casing is not { } enumCasing)
         {
             return humanizedEnum.Text;
@@ -173,5 +204,20 @@ public static class EnumHumanizeExtensions
     /// </example>
     public static string Humanize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(this T input, LetterCasing casing)
         where T : struct, Enum
-        => Humanize(input, (LetterCasing?)casing);
+        => Humanize(input, casing, EnumHumanizeSource.Default);
+
+    /// <summary>
+    /// Converts an enum value to a human-readable string using the specified casing and source.
+    /// </summary>
+    /// <typeparam name="T">The enum type. Must be a struct and implement <see cref="Enum"/>.</typeparam>
+    /// <param name="input">The enum value to be humanized.</param>
+    /// <param name="casing">The desired letter casing to apply when humanizing the enum member name.</param>
+    /// <param name="source">The source used to humanize the enum value.</param>
+    /// <returns>A human-readable string representation of the enum value.</returns>
+    public static string Humanize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(
+        this T input,
+        LetterCasing casing,
+        EnumHumanizeSource source)
+        where T : struct, Enum =>
+        Humanize(input, (LetterCasing?)casing, source);
 }

--- a/src/Humanizer/EnumHumanizeExtensions.cs
+++ b/src/Humanizer/EnumHumanizeExtensions.cs
@@ -138,8 +138,8 @@ public static class EnumHumanizeExtensions
             throw new ArgumentOutOfRangeException(nameof(source));
         }
 
-        var (zero, humanized, values) = EnumCache<T>.GetInfo();
-        if (EnumCache<T>.TreatAsFlags(input))
+        var (zero, values) = EnumCache<T>.GetInfo(source);
+        if (EnumCache<T>.TreatAsFlags(input, source))
         {
             if (casing is { } flagsCasing && !Enum.IsDefined(flagsCasing))
             {
@@ -153,9 +153,7 @@ public static class EnumHumanizeExtensions
                 if (value.CompareTo(zero) != 0 && input.HasFlag(value))
                 {
                     flagValues ??= new List<string>();
-                    var flag = source == EnumHumanizeSource.Default
-                        ? humanized[value]
-                        : EnumCache<T>.GetHumanized(value, source);
+                    var flag = EnumCache<T>.GetHumanized(value, source);
                     flagValues.Add(casing is { } flagCasing && !flag.IsMetadata ? flag.Text.ApplyCase(flagCasing) : flag.Text);
                 }
             }
@@ -163,9 +161,7 @@ public static class EnumHumanizeExtensions
             return flagValues?.Humanize() ?? string.Empty;
         }
 
-        var humanizedEnum = source == EnumHumanizeSource.Default
-            ? humanized[input]
-            : EnumCache<T>.GetHumanized(input, source);
+        var humanizedEnum = EnumCache<T>.GetHumanized(input, source);
         if (casing is not { } enumCasing)
         {
             return humanizedEnum.Text;

--- a/src/Humanizer/EnumHumanizeSource.cs
+++ b/src/Humanizer/EnumHumanizeSource.cs
@@ -1,0 +1,36 @@
+namespace Humanizer;
+
+/// <summary>
+/// Specifies the source used to humanize an enum value.
+/// </summary>
+public enum EnumHumanizeSource
+{
+    /// <summary>
+    /// Uses the default metadata precedence, falling back to the enum member name.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// Uses the enum member name.
+    /// </summary>
+    EnumName,
+
+    /// <summary>
+    /// Uses <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.Name"/>,
+    /// falling back to the enum member name.
+    /// </summary>
+    DisplayName,
+
+    /// <summary>
+    /// Uses <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.Description"/>,
+    /// falling back to the enum member name.
+    /// </summary>
+    DisplayDescription,
+
+    /// <summary>
+    /// Uses <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.ShortName"/>,
+    /// then <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.Name"/>,
+    /// falling back to the enum member name when neither is available.
+    /// </summary>
+    DisplayShortName
+}

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet10_0.verified.txt
@@ -356,10 +356,24 @@ namespace Humanizer
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
         public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing) { }
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods, typeof(Humanizer.EnumHumanizeExtensions))]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing, Humanizer.EnumHumanizeSource source) { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input)
             where T :  struct, System.Enum { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing)
             where T :  struct, System.Enum { }
+        public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing, Humanizer.EnumHumanizeSource source)
+            where T :  struct, System.Enum { }
+    }
+    public enum EnumHumanizeSource
+    {
+        Default = 0,
+        EnumName = 1,
+        DisplayName = 2,
+        DisplayDescription = 3,
+        DisplayShortName = 4,
     }
     public static class FractionalizeExtensions
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet11_0.verified.txt
@@ -356,10 +356,24 @@ namespace Humanizer
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
         public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing) { }
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods, typeof(Humanizer.EnumHumanizeExtensions))]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing, Humanizer.EnumHumanizeSource source) { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input)
             where T :  struct, System.Enum { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing)
             where T :  struct, System.Enum { }
+        public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing, Humanizer.EnumHumanizeSource source)
+            where T :  struct, System.Enum { }
+    }
+    public enum EnumHumanizeSource
+    {
+        Default = 0,
+        EnumName = 1,
+        DisplayName = 2,
+        DisplayDescription = 3,
+        DisplayShortName = 4,
     }
     public static class FractionalizeExtensions
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.DotNet8_0.verified.txt
@@ -355,10 +355,24 @@ namespace Humanizer
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
         public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing) { }
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods, typeof(Humanizer.EnumHumanizeExtensions))]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+        public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing, Humanizer.EnumHumanizeSource source) { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input)
             where T :  struct, System.Enum { }
         public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing)
             where T :  struct, System.Enum { }
+        public static string Humanize<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  T>(this T input, Humanizer.LetterCasing casing, Humanizer.EnumHumanizeSource source)
+            where T :  struct, System.Enum { }
+    }
+    public enum EnumHumanizeSource
+    {
+        Default = 0,
+        EnumName = 1,
+        DisplayName = 2,
+        DisplayDescription = 3,
+        DisplayShortName = 4,
     }
     public static class FractionalizeExtensions
     {

--- a/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
+++ b/tests/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.Approve_Public_Api.Net4_8.verified.txt
@@ -326,10 +326,21 @@ namespace Humanizer
     {
         public static string Humanize(this System.Enum input) { }
         public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing) { }
+        public static string Humanize(this System.Enum input, Humanizer.LetterCasing casing, Humanizer.EnumHumanizeSource source) { }
         public static string Humanize<T>(this T input)
             where T :  struct, System.Enum { }
         public static string Humanize<T>(this T input, Humanizer.LetterCasing casing)
             where T :  struct, System.Enum { }
+        public static string Humanize<T>(this T input, Humanizer.LetterCasing casing, Humanizer.EnumHumanizeSource source)
+            where T :  struct, System.Enum { }
+    }
+    public enum EnumHumanizeSource
+    {
+        Default = 0,
+        EnumName = 1,
+        DisplayName = 2,
+        DisplayDescription = 3,
+        DisplayShortName = 4,
     }
     public static class FractionalizeExtensions
     {

--- a/tests/Humanizer.Tests/BitFieldEnumHumanizeTests.cs
+++ b/tests/Humanizer.Tests/BitFieldEnumHumanizeTests.cs
@@ -25,6 +25,19 @@ public class BitFieldEnumHumanizeTests
     }
 
     [Fact]
+    public void HumanizeSourceAppliesToEachCompositeBitFieldValue()
+    {
+        var composite = MixedMetadataBitFieldEnumUnderTest.AuthoredMetadata | MixedMetadataBitFieldEnumUnderTest.NameDerived;
+
+        Assert.Equal(
+            "Authored Metadata and Name Derived",
+            composite.Humanize(LetterCasing.Title, EnumHumanizeSource.EnumName));
+        Assert.Equal(
+            "SpaceX and Name Derived",
+            composite.Humanize(LetterCasing.Title, EnumHumanizeSource.DisplayDescription));
+    }
+
+    [Fact]
     public void CanHumanizeShortSingleWordDescriptionAttribute() =>
         Assert.Equal(BitFlagEnumTestsResources.MemberWithSingleWordDisplayAttribute, ShortBitFieldEnumUnderTest.RED.Humanize());
 

--- a/tests/Humanizer.Tests/EnumHumanizeTests.cs
+++ b/tests/Humanizer.Tests/EnumHumanizeTests.cs
@@ -106,6 +106,80 @@ public class EnumHumanizeTests
     public void HonorsLocalizedDisplayAttribute() =>
         Assert.Equal(EnumTestsResources.MemberWithLocalizedDisplayAttribute, EnumUnderTest.MemberWithLocalizedDisplayAttribute.Humanize());
 
+    [Theory]
+    [InlineData(EnumHumanizeSource.Default, "Localized display description")]
+    [InlineData(EnumHumanizeSource.EnumName, "Raw enum name")]
+    [InlineData(EnumHumanizeSource.DisplayName, "Localized display name")]
+    [InlineData(EnumHumanizeSource.DisplayDescription, "Localized display description")]
+    [InlineData(EnumHumanizeSource.DisplayShortName, "Localized short name")]
+    public void CanSelectHumanizeSource(EnumHumanizeSource source, string expected) =>
+        Assert.Equal(expected, EnumHumanizeSourcesUnderTest.RawEnumName.Humanize(LetterCasing.Sentence, source));
+
+    [Fact]
+    public void SelectedMetadataPreservesCasingWhileEnumNameHonorsIt()
+    {
+        var value = EnumHumanizeSourcesUnderTest.RawEnumName;
+
+        Assert.Equal("Localized display name", value.Humanize(LetterCasing.AllCaps, EnumHumanizeSource.DisplayName));
+        Assert.Equal("RAW ENUM NAME", value.Humanize(LetterCasing.AllCaps, EnumHumanizeSource.EnumName));
+    }
+
+    [Theory]
+    [InlineData(EnumHumanizeSource.DisplayName)]
+    [InlineData(EnumHumanizeSource.DisplayDescription)]
+    [InlineData(EnumHumanizeSource.DisplayShortName)]
+    public void MissingSelectedMetadataFallsBackToEnumName(EnumHumanizeSource source) =>
+        Assert.Equal(
+            "No display metadata",
+            EnumHumanizeSourcesUnderTest.NoDisplayMetadata.Humanize(LetterCasing.Sentence, source));
+
+    [Fact]
+    public void DisplayShortNameUsesDisplayNameFallback() =>
+        Assert.Equal(
+            "Display name only",
+            EnumHumanizeSourcesUnderTest.DisplayNameOnly.Humanize(
+                LetterCasing.Sentence,
+                EnumHumanizeSource.DisplayShortName));
+
+    [Fact]
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+    public void RuntimeEnumCanSelectHumanizeSource()
+    {
+        Enum value = EnumHumanizeSourcesUnderTest.RawEnumName;
+
+        Assert.Equal(
+            "Localized short name",
+            value.Humanize(LetterCasing.Sentence, EnumHumanizeSource.DisplayShortName));
+        Assert.Equal("RAW ENUM NAME", value.Humanize(LetterCasing.AllCaps, EnumHumanizeSource.EnumName));
+    }
+
+    [Fact]
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+    public void LegacyZeroCasingCallsRemainUnambiguous()
+    {
+        var value = EnumUnderTest.MemberWithoutDescriptionAttribute;
+        Enum runtimeValue = value;
+
+        Assert.Equal(EnumTestsResources.MemberWithoutDescriptionAttributeTitle, value.Humanize(default));
+        Assert.Equal(EnumTestsResources.MemberWithoutDescriptionAttributeTitle, value.Humanize(0));
+        Assert.Equal(EnumTestsResources.MemberWithoutDescriptionAttributeTitle, runtimeValue.Humanize(default));
+        Assert.Equal(EnumTestsResources.MemberWithoutDescriptionAttributeTitle, runtimeValue.Humanize(0));
+    }
+
+    [Fact]
+    [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
+    [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
+    public void InvalidHumanizeSourceThrows()
+    {
+        var source = (EnumHumanizeSource)42;
+        Enum runtimeValue = EnumHumanizeSourcesUnderTest.RawEnumName;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => EnumHumanizeSourcesUnderTest.RawEnumName.Humanize(LetterCasing.Title, source));
+        Assert.Throws<ArgumentOutOfRangeException>(() => runtimeValue.Humanize(LetterCasing.Title, source));
+    }
+
     [Fact]
     public void HumanizeCustomPropertyAttributeWithLocator()
     {
@@ -114,6 +188,11 @@ public class EnumHumanizeTests
         try
         {
             Assert.Equal(EnumTestsResources.MemberWithCustomPropertyAttribute, EnumForCustomLocator.MemberWithCustomPropertyAttribute.Humanize());
+            Assert.Equal(
+                "Member with custom property attribute",
+                EnumForCustomLocator.MemberWithCustomPropertyAttribute.Humanize(
+                    LetterCasing.Sentence,
+                    EnumHumanizeSource.DisplayDescription));
         }
         finally
         {
@@ -317,6 +396,26 @@ public class EnumHumanizeTests
             Description = "Display description",
             ShortName = "Display short name")]
         RawEnumName
+    }
+
+    enum EnumHumanizeSourcesUnderTest
+    {
+        [System.ComponentModel.DataAnnotations.Display(
+            Name = nameof(EnumHumanizeSourceResources.Name),
+            Description = nameof(EnumHumanizeSourceResources.Description),
+            ShortName = nameof(EnumHumanizeSourceResources.ShortName),
+            ResourceType = typeof(EnumHumanizeSourceResources))]
+        RawEnumName,
+        NoDisplayMetadata,
+        [System.ComponentModel.DataAnnotations.Display(Name = "Display name only")]
+        DisplayNameOnly
+    }
+
+    public static class EnumHumanizeSourceResources
+    {
+        public static string Name => "Localized display name";
+        public static string Description => "Localized display description";
+        public static string ShortName => "Localized short name";
     }
 
     enum EnumShortNameAliasUnderTest

--- a/tests/Humanizer.Tests/EnumHumanizeTests.cs
+++ b/tests/Humanizer.Tests/EnumHumanizeTests.cs
@@ -142,6 +142,15 @@ public class EnumHumanizeTests
                 EnumHumanizeSource.DisplayShortName));
 
     [Fact]
+    public void SelectedSourceDoesNotEvaluateUnrelatedDisplayMetadata()
+    {
+        var value = EnumHumanizeSourcesWithInvalidMetadataUnderTest.RawEnumName;
+
+        Assert.Equal("Raw enum name", value.Humanize(LetterCasing.Sentence, EnumHumanizeSource.EnumName));
+        Assert.Equal("Localized display name", value.Humanize(LetterCasing.Sentence, EnumHumanizeSource.DisplayName));
+    }
+
+    [Fact]
     [RequiresDynamicCode("The native code for the target enumeration might not be available at runtime.")]
     [RequiresUnreferencedCode("The native code for the target enumeration might not be available at runtime.")]
     public void RuntimeEnumCanSelectHumanizeSource()
@@ -416,6 +425,15 @@ public class EnumHumanizeTests
         public static string Name => "Localized display name";
         public static string Description => "Localized display description";
         public static string ShortName => "Localized short name";
+    }
+
+    enum EnumHumanizeSourcesWithInvalidMetadataUnderTest
+    {
+        [System.ComponentModel.DataAnnotations.Display(
+            Name = nameof(EnumHumanizeSourceResources.Name),
+            Description = "MissingDescription",
+            ResourceType = typeof(EnumHumanizeSourceResources))]
+        RawEnumName
     }
 
     enum EnumShortNameAliasUnderTest


### PR DESCRIPTION
## Summary

Callers can now explicitly humanize enum values from the raw member name, `DisplayAttribute.Name`, `DisplayAttribute.Description`, or `DisplayAttribute.ShortName`. Source selection is available only through the new `(LetterCasing casing, EnumHumanizeSource source)` overloads, preserving source and binary compatibility for existing no-argument and casing-only calls, including `Humanize(default)` and `Humanize(0)`.

The default path keeps the existing display precedence and casing behavior, while explicit sources apply to each constituent of flags values. Dehumanization alias parsing and collision behavior remain unchanged.

Thanks to @maxkatz6 for reporting the source-selection gap and @KillyMXI for the `ShortName` contribution context.

Fixes #926

Related: #1490

## Validation

- `EnumHumanizeTests` on .NET 8: 69 passed
- `BitFieldEnumHumanizeTests` on .NET 8: 10 passed
- `PublicApiApprovalTest` on .NET 8: 1 passed
- Full test suite on .NET 8, .NET 10, and .NET 11: 57,997 passed per target
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`: 0 of 2,707 files changed
- Fresh Release pack succeeded for `netstandard2.0`, `net8.0`, `net10.0`, `net11.0`, and `net48`

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No code was copied from StackOverflow, a blog, or OSS
- [x] XML documentation is added for the new public API
- [x] The PR is rebased on the latest `main`
- [x] The fixed issue is linked with `Fixes #926`
- [x] The readme is updated
- [x] Focused, API approval, full matrix, format, and Release pack validation passed
