### PR TITLE
chore: start v4.0 preview line

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.5.0-preview.{height}",
+  "version": "4.0.0-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of main
     "^refs/heads/rel/v\\d+\\.\\d+" // we also release branches starting with rel/vN.N


### PR DESCRIPTION
## Summary

Starts packages built from `main` on the `4.0.0-preview` line while preserving Nerdbank.GitVersioning's existing commit-height and SemVer2 conventions. This does not publish or promote a stable release; the documentation checkout remains `main/preview`.

## Validation

- `nbgv get-version` produced `4.0.0-preview.1.g132b88dade`, assembly version `4.0.0.0`, and file version `4.0.0`
- Release pack produced `Humanizer.4.0.0-preview.1.g132b88dade.nupkg` for all supported library targets; its nuspec contains the same version
- `tests/verify-packages.ps1` passed package contents and analyzer smoke verification
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` formatted 0 of 2,713 files
- `pwsh tools/docs/build.ps1 -ValidateOnly` passed language coverage, version-manifest, and generated-output validation

## Checklist

- [x] Implementation is clean and follows the existing coding standards
- [x] Pack completed without code-analysis warnings
- [x] Unit-test changes are not applicable because this changes only declarative package-version metadata
- [x] No copied code is included
- [x] XML documentation changes are not applicable
- [x] Based on current `main`
- [x] No issue is closed by this release-coordination change
- [x] README changes are not applicable
- [x] Applicable validation from `AGENTS.md` passed
