### PR TITLE
fix(docs): target Pages archive repository

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,6 +38,7 @@ concurrency:
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
+  GH_REPO: ${{ github.repository }}
 
 jobs:
   build:

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -66,3 +66,7 @@ test('subsequent deployments retain the latest successful documentation run', ()
 test('missing deployment history fails closed', () => {
   assert.equal(selectPrior([]), '');
 });
+
+test('release operations have repository context without a checkout', () => {
+  assert.match(workflow, /^env:\n(?:  .+\n)*  GH_REPO: \$\{\{ github\.repository \}\}$/m);
+});

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -68,5 +68,6 @@ test('missing deployment history fails closed', () => {
 });
 
 test('release operations have repository context without a checkout', () => {
-  assert.match(workflow, /^env:\n(?:  .+\n)*  GH_REPO: \$\{\{ github\.repository \}\}$/m);
+  const workflowEnv = workflow.replaceAll('\r\n', '\n').match(/^env:\n([\s\S]*?)^\S/m)?.[1];
+  assert.match(workflowEnv, /^  GH_REPO: \$\{\{ github\.repository \}\}$/m);
 });


### PR DESCRIPTION
## Summary

- set `GH_REPO` from `github.repository` for every GitHub CLI release operation, including no-checkout jobs
- add a contract assertion that release operations retain explicit repository context
- preserve all existing artifact, checksum, SHA, archive, and deployment-pointer validations

## Failure evidence

Main Documentation run [30413601589](https://github.com/Humanizr/Humanizer/actions/runs/30413601589) successfully found and verified legacy artifact `30386738318`, then failed creating `docs-pages-archive` because the retention job has no checkout and GitHub CLI could not infer a repository.

## Validation

- `node --test website/tests/pages-run-selection.test.mjs`
- `pnpm --dir website test:unit` (20 passed)
- `pnpm --dir website check:content`
- `pnpm --dir website typecheck`
- `actionlint .github/workflows/docs.yml`
- `git diff --check`

## Post-merge verification

A fresh main Documentation run must complete artifact retention, Pages deploy, production smoke, and deployment recording before this task is closed.

## Checklist

- [x] Implementation is clean
- [x] Code follows existing standards
- [x] Relevant unit/contract coverage is included
- [x] Branch is based on current `main`
- [x] Applicable documentation validation passed
- [x] No copied external code