### PR TITLE
fix(docs): support immutable rollback releases and parallel validation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -188,33 +188,52 @@ jobs:
               exit 1
             fi
             current_pointer_run_id=none
-            if gh release view docs-pages-archive >/dev/null 2>&1; then
-              release_id="$(
-                gh api \
-                  "repos/${GITHUB_REPOSITORY}/releases/tags/docs-pages-archive" \
-                  --jq .id
+            pointer="$(
+              gh api \
+                --paginate \
+                --slurp \
+                "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+                jq -r '
+                  [
+                    .[][]
+                    | select(
+                        .tag_name
+                        | startswith("docs-pages-deployment-")
+                      )
+                    | select(.draft == false and .immutable == true)
+                  ]
+                  | sort_by(.published_at)
+                  | (last // empty)
+                  | [
+                      .tag_name,
+                      (.assets | length),
+                      (.assets[0].id // empty),
+                      (.assets[0].name // empty)
+                    ]
+                  | @tsv
+                '
+            )"
+            if [[ -n "$pointer" ]]; then
+              IFS=$'\t' read -r pointer_tag pointer_asset_count \
+                pointer_asset_id pointer_asset_name <<<"$pointer"
+              current_pointer_run_id="${pointer_tag#docs-pages-deployment-}"
+              if [[ ! "$current_pointer_run_id" =~ ^[0-9]+$ ||
+                    "$pointer_asset_count" != 1 ||
+                    "$pointer_asset_name" != "deployment-${current_pointer_run_id}.json" ||
+                    ! "$pointer_asset_id" =~ ^[0-9]+$ ]]; then
+                echo "Current deployment pointer release is invalid." >&2
+                exit 1
+              fi
+              gh api \
+                -H "Accept: application/octet-stream" \
+                "repos/${GITHUB_REPOSITORY}/releases/assets/${pointer_asset_id}" \
+                > current-deployment.json
+              recorded_pointer_run_id="$(
+                jq -r '.deploymentRunId // empty' current-deployment.json
               )"
-              pointer_asset_id="$(
-                gh api \
-                  --paginate \
-                  "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" \
-                  --jq '.[] | select(.name | (startswith("deployment-") and endswith(".json"))) | [.created_at, .id] | @tsv' |
-                  sort -r |
-                  head -n 1 |
-                  cut -f 2
-              )"
-              if [[ -n "$pointer_asset_id" ]]; then
-                gh api \
-                  -H "Accept: application/octet-stream" \
-                  "repos/${GITHUB_REPOSITORY}/releases/assets/${pointer_asset_id}" \
-                  > current-deployment.json
-                current_pointer_run_id="$(
-                  jq -r '.deploymentRunId // empty' current-deployment.json
-                )"
-                if [[ ! "$current_pointer_run_id" =~ ^[0-9]+$ ]]; then
-                  echo "Current deployment pointer is invalid." >&2
-                  exit 1
-                fi
+              if [[ "$recorded_pointer_run_id" != "$current_pointer_run_id" ]]; then
+                echo "Current deployment pointer is invalid." >&2
+                exit 1
               fi
             fi
             if [[ "$current_pointer_run_id" != "$EXPECTED_POINTER_RUN_ID" ]]; then
@@ -295,7 +314,7 @@ jobs:
           ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
         run: |
           mkdir -p rollback
-          gh release download docs-pages-archive \
+          gh release download "docs-pages-archive-${ROLLBACK_RUN_ID}" \
             --pattern "github-pages-${ROLLBACK_RUN_ID}.tar" \
             --pattern "github-pages-${ROLLBACK_RUN_ID}.tar.sha256" \
             --dir rollback
@@ -378,22 +397,42 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           prior=
-          if gh release view docs-pages-archive >/dev/null 2>&1; then
-            release_id="$(
-              gh api \
-                "repos/${GITHUB_REPOSITORY}/releases/tags/docs-pages-archive" \
-                --jq .id
-            )"
-            pointer_asset="$(
-              gh api \
-                --paginate \
-                "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" \
-                --jq '.[] | select(.name | (startswith("deployment-") and endswith(".json"))) | [.created_at, .id] | @tsv' |
-                sort -r |
-                head -n 1
-            )"
-            if [[ -n "$pointer_asset" ]]; then
-              IFS=$'\t' read -r _ pointer_asset_id <<<"$pointer_asset"
+          pointer="$(
+            gh api \
+              --paginate \
+              --slurp \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+              jq -r '
+                [
+                  .[][]
+                  | select(
+                      .tag_name
+                      | startswith("docs-pages-deployment-")
+                    )
+                  | select(.draft == false and .immutable == true)
+                ]
+                | sort_by(.published_at)
+                | (last // empty)
+                | [
+                    .tag_name,
+                    (.assets | length),
+                    (.assets[0].id // empty),
+                    (.assets[0].name // empty)
+                  ]
+                | @tsv
+              '
+          )"
+          if [[ -n "$pointer" ]]; then
+            IFS=$'\t' read -r pointer_tag pointer_asset_count \
+              pointer_asset_id pointer_asset_name <<<"$pointer"
+            pointer_run_id="${pointer_tag#docs-pages-deployment-}"
+            if [[ ! "$pointer_run_id" =~ ^[0-9]+$ ||
+                  "$pointer_asset_count" != 1 ||
+                  "$pointer_asset_name" != "deployment-${pointer_run_id}.json" ||
+                  ! "$pointer_asset_id" =~ ^[0-9]+$ ]]; then
+              echo "Latest deployment pointer release is invalid." >&2
+              exit 1
+            fi
               gh api \
                 -H "Accept: application/octet-stream" \
                 "repos/${GITHUB_REPOSITORY}/releases/assets/${pointer_asset_id}" \
@@ -407,7 +446,7 @@ jobs:
                 <<<"$prior"
               if [[ ! "$run_id" =~ ^[0-9]+$ ||
                     ! "$source_sha" =~ ^[0-9a-f]{40}$ ||
-                    ! "$deployment_run_id" =~ ^[0-9]+$ ]]; then
+                    "$deployment_run_id" != "$pointer_run_id" ]]; then
                 echo "Latest deployment pointer is invalid." >&2
                 exit 1
               fi
@@ -474,7 +513,6 @@ jobs:
                   exit 1
                 fi
               fi
-            fi
           fi
 
           if [[ -z "$prior" ]]; then
@@ -529,35 +567,37 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRIOR_RUN_ID: ${{ steps.prior.outputs.run_id }}
+          PRIOR_SOURCE_SHA: ${{ steps.prior.outputs.source_sha }}
         run: |
+          archive_tag="docs-pages-archive-${PRIOR_RUN_ID}"
           archive_name="github-pages-${PRIOR_RUN_ID}.tar"
           checksum_name="${archive_name}.sha256"
-          archive_count=0
-          checksum_count=0
-          if gh release view docs-pages-archive >/dev/null 2>&1; then
-            release_id="$(
-              gh api \
-                "repos/${GITHUB_REPOSITORY}/releases/tags/docs-pages-archive" \
-                --jq .id
-            )"
-            assets="$(
-              gh api \
-                --paginate \
-                --slurp \
-                "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100"
-            )"
-            archive_count="$(
-              jq --arg name "$archive_name" \
-                '[.[][] | select(.name == $name)] | length' <<<"$assets"
-            )"
-            checksum_count="$(
-              jq --arg name "$checksum_name" \
-                '[.[][] | select(.name == $name)] | length' <<<"$assets"
-            )"
-          fi
-          if [[ "$archive_count" == 1 && "$checksum_count" == 1 ]]; then
+          release="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/releases/tags/${archive_tag}" \
+              --jq '
+                [
+                  .immutable,
+                  .target_commitish,
+                  (.assets | length),
+                  ([.assets[].name] | sort | join(","))
+                ]
+                | @tsv
+              ' 2>/dev/null ||
+              true
+          )"
+          if [[ -n "$release" ]]; then
+            IFS=$'\t' read -r immutable target asset_count asset_names \
+              <<<"$release"
+            if [[ "$immutable" != true ||
+                  "$target" != "$PRIOR_SOURCE_SHA" ||
+                  "$asset_count" != 2 ||
+                  "$asset_names" != "${archive_name},${checksum_name}" ]]; then
+              echo "Prior rollback release is invalid." >&2
+              exit 1
+            fi
             mkdir -p prior-archive
-            gh release download docs-pages-archive \
+            gh release download "$archive_tag" \
               --pattern "$archive_name" \
               --pattern "$checksum_name" \
               --dir prior-archive
@@ -566,11 +606,8 @@ jobs:
               sha256sum -c "$checksum_name"
             )
             echo "download=false" >> "$GITHUB_OUTPUT"
-          elif [[ "$archive_count" == 0 && "$checksum_count" == 0 ]]; then
-            echo "download=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Prior rollback archive is incomplete or duplicated." >&2
-            exit 1
+            echo "download=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Download prior Pages artifact
@@ -587,10 +624,10 @@ jobs:
         if: steps.prior-archive.outputs.download == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PRIOR_RUN_ID: ${{ steps.prior.outputs.run_id }}
           PRIOR_SOURCE_SHA: ${{ steps.prior.outputs.source_sha }}
         run: |
           mkdir -p prior-archive
+          archive_tag="docs-pages-archive-${PRIOR_RUN_ID}"
           archive_name="github-pages-${PRIOR_RUN_ID}.tar"
           checksum_name="${archive_name}.sha256"
           mv prior-download/artifact.tar "prior-archive/${archive_name}"
@@ -599,18 +636,16 @@ jobs:
             sha256sum "$archive_name" > "$checksum_name"
             sha256sum -c "$checksum_name"
           )
-          if ! gh release view docs-pages-archive >/dev/null 2>&1; then
-            gh release create docs-pages-archive \
-              --prerelease \
-              --target "$PRIOR_SOURCE_SHA" \
-              --title "Documentation deployment archive" \
-              --notes "Automation-owned Pages artifacts for exact rollback."
-          fi
-          gh release upload docs-pages-archive \
+          gh release create "$archive_tag" \
             "prior-archive/${archive_name}" \
-            "prior-archive/${checksum_name}"
+            "prior-archive/${checksum_name}" \
+            --latest=false \
+            --prerelease \
+            --target "$PRIOR_SOURCE_SHA" \
+            --title "Documentation deployment archive ${PRIOR_RUN_ID}" \
+            --notes "Automation-owned Pages artifact for exact rollback."
           mkdir prior-verify
-          gh release download docs-pages-archive \
+          gh release download "$archive_tag" \
             --pattern "$archive_name" \
             --pattern "$checksum_name" \
             --dir prior-verify
@@ -630,6 +665,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRIOR_RUN_ID: ${{ steps.prior.outputs.run_id }}
         run: |
+          archive_tag="docs-pages-archive-${GITHUB_RUN_ID}"
           archive_name="github-pages-${GITHUB_RUN_ID}.tar"
           checksum_name="${archive_name}.sha256"
           mv current-archive/artifact.tar "current-archive/${archive_name}"
@@ -638,41 +674,41 @@ jobs:
             sha256sum "$archive_name" > "$checksum_name"
             sha256sum -c "$checksum_name"
           )
-          if ! gh release view docs-pages-archive >/dev/null 2>&1; then
-            gh release create docs-pages-archive \
+          release="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/releases/tags/${archive_tag}" \
+              --jq '
+                [
+                  .immutable,
+                  .target_commitish,
+                  (.assets | length),
+                  ([.assets[].name] | sort | join(","))
+                ]
+                | @tsv
+              ' 2>/dev/null ||
+              true
+          )"
+          if [[ -z "$release" ]]; then
+            gh release create "$archive_tag" \
+              "current-archive/${archive_name}" \
+              "current-archive/${checksum_name}" \
+              --latest=false \
               --prerelease \
               --target "$GITHUB_SHA" \
-              --title "Documentation deployment archive" \
-              --notes "Automation-owned Pages artifacts for exact rollback."
-          fi
-          release_id="$(
-            gh api \
-              "repos/${GITHUB_REPOSITORY}/releases/tags/docs-pages-archive" \
-              --jq .id
-          )"
-          existing_assets="$(
-            gh api \
-              --paginate \
-              --slurp \
-              "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100"
-          )"
-          archive_count="$(
-            jq --arg name "$archive_name" \
-              '[.[][] | select(.name == $name)] | length' \
-              <<<"$existing_assets"
-          )"
-          checksum_count="$(
-            jq --arg name "$checksum_name" \
-              '[.[][] | select(.name == $name)] | length' \
-              <<<"$existing_assets"
-          )"
-          if [[ "$archive_count" == 0 && "$checksum_count" == 0 ]]; then
-            gh release upload docs-pages-archive \
-              "current-archive/${archive_name}" \
-              "current-archive/${checksum_name}"
-          elif [[ "$archive_count" == 1 && "$checksum_count" == 1 ]]; then
+              --title "Documentation deployment archive ${GITHUB_RUN_ID}" \
+              --notes "Automation-owned Pages artifact for exact rollback."
+          else
+            IFS=$'\t' read -r immutable target asset_count asset_names \
+              <<<"$release"
+            if [[ "$immutable" != true ||
+                  "$target" != "$GITHUB_SHA" ||
+                  "$asset_count" != 2 ||
+                  "$asset_names" != "${archive_name},${checksum_name}" ]]; then
+              echo "Current rollback release is invalid." >&2
+              exit 1
+            fi
             mkdir current-existing
-            gh release download docs-pages-archive \
+            gh release download "$archive_tag" \
               --pattern "$archive_name" \
               --pattern "$checksum_name" \
               --dir current-existing
@@ -684,13 +720,10 @@ jobs:
             tar -xf "current-archive/${archive_name}" -C current-tree
             tar -xf "current-existing/${archive_name}" -C existing-tree
             diff --no-dereference --recursive current-tree existing-tree
-          else
-            echo "Current rollback archive is incomplete or duplicated." >&2
-            exit 1
           fi
 
           mkdir current-verify
-          gh release download docs-pages-archive \
+          gh release download "$archive_tag" \
             --pattern "$archive_name" \
             --pattern "$checksum_name" \
             --dir current-verify
@@ -698,34 +731,6 @@ jobs:
             cd current-verify
             sha256sum -c "$checksum_name"
           )
-
-          gh api \
-              --paginate \
-              "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" \
-              --jq '.[] | select(.name | (startswith("github-pages-") and endswith(".tar"))) | [.created_at, .name] | @tsv' |
-            sort -r |
-            tail -n +11 |
-            while IFS=$'\t' read -r _ expired_name; do
-              if [[ "$expired_name" == "github-pages-${PRIOR_RUN_ID}.tar" ]]; then
-                echo "Keeping currently deployable rollback asset ${expired_name}."
-                continue
-              fi
-              for name in "$expired_name" "${expired_name}.sha256"; do
-                asset_id="$(
-                  gh api \
-                    --paginate \
-                    "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" \
-                    --jq ".[] | select(.name == \"${name}\") | .id" |
-                    head -n 1
-                )"
-                if [[ -n "$asset_id" ]]; then
-                  echo "Removing expired rollback asset ${name}."
-                  gh api \
-                    --method DELETE \
-                    "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
-                fi
-              done
-            done
 
   deploy:
     if: >-
@@ -835,21 +840,41 @@ jobs:
             "$SOURCE_SHA" \
             "$GITHUB_RUN_ID" \
             > "$pointer_name"
-          release_id="$(
+          pointer_tag="docs-pages-deployment-${GITHUB_RUN_ID}"
+          release="$(
             gh api \
-              "repos/${GITHUB_REPOSITORY}/releases/tags/docs-pages-archive" \
-              --jq .id
+              "repos/${GITHUB_REPOSITORY}/releases/tags/${pointer_tag}" \
+              --jq '
+                [
+                  .immutable,
+                  .target_commitish,
+                  (.assets | length),
+                  (.assets[0].id // empty),
+                  (.assets[0].name // empty)
+                ]
+                | @tsv
+              ' 2>/dev/null ||
+              true
           )"
-          existing_asset_id="$(
-            gh api \
-              --paginate \
-              "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" \
-              --jq ".[] | select(.name == \"${pointer_name}\") | .id" |
-              head -n 1
-          )"
-          if [[ -z "$existing_asset_id" ]]; then
-            gh release upload docs-pages-archive "$pointer_name"
+          if [[ -z "$release" ]]; then
+            gh release create "$pointer_tag" \
+              "$pointer_name" \
+              --latest=false \
+              --prerelease \
+              --target "$SOURCE_SHA" \
+              --title "Documentation deployment ${GITHUB_RUN_ID}" \
+              --notes "Automation-owned exact deployment pointer."
           else
+            IFS=$'\t' read -r immutable target asset_count \
+              existing_asset_id existing_asset_name <<<"$release"
+            if [[ "$immutable" != true ||
+                  "$target" != "$SOURCE_SHA" ||
+                  "$asset_count" != 1 ||
+                  "$existing_asset_name" != "$pointer_name" ||
+                  ! "$existing_asset_id" =~ ^[0-9]+$ ]]; then
+              echo "Deployment pointer release is invalid." >&2
+              exit 1
+            fi
             mkdir existing-pointer
             gh api \
               -H "Accept: application/octet-stream" \
@@ -857,18 +882,6 @@ jobs:
               > "existing-pointer/${pointer_name}"
             cmp "$pointer_name" "existing-pointer/${pointer_name}"
           fi
-          gh api \
-              --paginate \
-              "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" \
-              --jq '.[] | select(.name | (startswith("deployment-") and endswith(".json"))) | [.created_at, .id, .name] | @tsv' |
-            sort -r |
-            tail -n +11 |
-            while IFS=$'\t' read -r _ asset_id asset_name; do
-              echo "Removing expired deployment pointer ${asset_name}."
-              gh api \
-                --method DELETE \
-                "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
-            done
 
   recover-after-smoke-failure:
     if: >-
@@ -905,21 +918,38 @@ jobs:
           recovery_run_id="$PRIOR_RUN_ID"
           expected_pointer_run_id="$PRIOR_DEPLOYMENT_RUN_ID"
           if [[ -n "$REQUESTED_ROLLBACK_RUN_ID" ]]; then
-            release_id="$(
-              gh api \
-                "repos/${GITHUB_REPOSITORY}/releases/tags/docs-pages-archive" \
-                --jq .id
-            )"
-            pointer_asset_id="$(
+            pointer="$(
               gh api \
                 --paginate \
-                "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" \
-                --jq '.[] | select(.name | (startswith("deployment-") and endswith(".json"))) | [.created_at, .id] | @tsv' |
-                sort -r |
-                head -n 1 |
-                cut -f 2
+                --slurp \
+                "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+                jq -r '
+                  [
+                    .[][]
+                    | select(
+                        .tag_name
+                        | startswith("docs-pages-deployment-")
+                      )
+                    | select(.draft == false and .immutable == true)
+                  ]
+                  | sort_by(.published_at)
+                  | (last // empty)
+                  | [
+                      .tag_name,
+                      (.assets | length),
+                      (.assets[0].id // empty),
+                      (.assets[0].name // empty)
+                    ]
+                  | @tsv
+                '
             )"
-            if [[ ! "$pointer_asset_id" =~ ^[0-9]+$ ]]; then
+            IFS=$'\t' read -r pointer_tag pointer_asset_count \
+              pointer_asset_id pointer_asset_name <<<"$pointer"
+            pointer_run_id="${pointer_tag#docs-pages-deployment-}"
+            if [[ ! "$pointer_run_id" =~ ^[0-9]+$ ||
+                  "$pointer_asset_count" != 1 ||
+                  "$pointer_asset_name" != "deployment-${pointer_run_id}.json" ||
+                  ! "$pointer_asset_id" =~ ^[0-9]+$ ]]; then
               echo "The last known-good deployment pointer is unavailable." >&2
               exit 1
             fi
@@ -933,6 +963,10 @@ jobs:
             expected_pointer_run_id="$(
               jq -r '.deploymentRunId // empty' prior-deployment.json
             )"
+            if [[ "$expected_pointer_run_id" != "$pointer_run_id" ]]; then
+              echo "The last known-good deployment pointer is invalid." >&2
+              exit 1
+            fi
             if [[ "$recovery_run_id" == "$REQUESTED_ROLLBACK_RUN_ID" ]]; then
               echo "The last known-good artifact also failed smoke; automatic recovery stopped." >&2
               exit 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -324,6 +324,10 @@ jobs:
             exit 1
           fi
           if [[ "$conclusion" != success ]]; then
+            if [[ "$conclusion" != failure ]]; then
+              echo "Incomplete workflow attempts are not rollback sources." >&2
+              exit 1
+            fi
             if [[ "$path" != ".github/workflows/docs.yml" ]]; then
               echo "Failed workflow attempts are not rollback sources." >&2
               exit 1
@@ -700,6 +704,10 @@ jobs:
                 exit 1
               fi
               if [[ "$pointer_conclusion" != success ]]; then
+                if [[ "$pointer_conclusion" != failure ]]; then
+                  echo "Incomplete workflow attempts are not deployment pointers." >&2
+                  exit 1
+                fi
                 if [[ "$pointer_path" != ".github/workflows/docs.yml" ]]; then
                   echo "Failed legacy workflow attempts are not deployment pointers." >&2
                   exit 1
@@ -752,6 +760,10 @@ jobs:
                 exit 1
               fi
               if [[ "$archive_conclusion" != success ]]; then
+                if [[ "$archive_conclusion" != failure ]]; then
+                  echo "Incomplete workflow attempts are not archive sources." >&2
+                  exit 1
+                fi
                 archive_jobs="$(
                   gh api \
                     --paginate \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -481,6 +481,10 @@ jobs:
             jq -r '.bootstrapSource // false' "rollback/${pointer_name}"
           )"
           if [[ "$manifest_bootstrap" == true ]]; then
+            if [[ "$ROLLBACK_RUN_ATTEMPT" != 1 ]]; then
+              echo "Rollback bootstrap releases must use attempt one." >&2
+              exit 1
+            fi
             bootstrap_publication="$(
               gh api \
                 "repos/${GITHUB_REPOSITORY}/actions/runs/${deployment_run_id}/attempts/${deployment_run_attempt}" \
@@ -775,6 +779,10 @@ jobs:
                     ! "$source_sha" =~ ^[0-9a-f]{40}$ ||
                     "$deployment_run_id" != "$pointer_run_id" ||
                     "$publication_run_attempt" != "$pointer_run_attempt" ||
+                    (
+                      "$bootstrap_source" == true &&
+                      "$run_attempt" != 1
+                    ) ||
                     (
                       "$bootstrap_source" != true &&
                       (

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -309,7 +309,7 @@ jobs:
           fi
           source_run="$(
             gh api \
-              "repos/${GITHUB_REPOSITORY}/actions/runs/${ROLLBACK_RUN_ID}" \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${ROLLBACK_RUN_ID}/attempts/${ROLLBACK_RUN_ATTEMPT}" \
               --jq '[.conclusion, .event, .head_branch, .path, .head_sha, .run_attempt] | @tsv'
           )"
           IFS=$'\t' read -r conclusion event branch path source_sha run_attempt \
@@ -617,7 +617,7 @@ jobs:
               fi
               pointer_run="$(
                 gh api \
-                  "repos/${GITHUB_REPOSITORY}/actions/runs/${deployment_run_id}" \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs/${deployment_run_id}/attempts/${deployment_run_attempt}" \
                   --jq '[.conclusion, .event, .head_branch, .path, .run_attempt] | @tsv'
               )"
               if [[ "$pointer_run" != $'success\tpush\tmain\t.github/workflows/docs.yml\t'"$deployment_run_attempt" &&
@@ -627,7 +627,7 @@ jobs:
               fi
               archive_run="$(
                 gh api \
-                  "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/attempts/${run_attempt}" \
                   --jq '[.conclusion, .event, .head_branch, .path, .head_sha, .run_attempt] | @tsv'
               )"
               IFS=$'\t' read -r archive_conclusion archive_event \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,10 @@ on:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 concurrency:
   group: >-
     ${{
@@ -745,17 +749,27 @@ jobs:
           pointer_name="deployment-${PRIOR_DEPLOYMENT_RUN_ID}-${PRIOR_DEPLOYMENT_RUN_ATTEMPT}.json"
           release="$(
             gh api \
-              "repos/${GITHUB_REPOSITORY}/releases/tags/${archive_tag}" \
-              --jq '
+              --paginate \
+              --slurp \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+              jq -r --arg tag "$archive_tag" '
                 [
-                  .immutable,
-                  .target_commitish,
-                  (.assets | length),
-                  ([.assets[].name] | sort | join(","))
+                  .[][]
+                  | select(.tag_name == $tag)
                 ]
+                | if length > 1 then
+                    error("duplicate prior rollback release")
+                  else
+                    (first // empty)
+                  end
+                | [
+                    .immutable,
+                    .target_commitish,
+                    (.assets | length),
+                    ([.assets[].name] | sort | join(","))
+                  ]
                 | @tsv
-              ' 2>/dev/null ||
-              true
+              '
           )"
           if [[ -n "$release" ]]; then
             IFS=$'\t' read -r immutable target asset_count asset_names \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -655,11 +655,58 @@ jobs:
                   "repos/${GITHUB_REPOSITORY}/actions/runs/${deployment_run_id}/attempts/${deployment_run_attempt}" \
                   --jq '[.conclusion, .event, .head_branch, .path, .run_attempt] | @tsv'
               )"
-              if [[ "$pointer_run" != $'success\tpush\tmain\t.github/workflows/docs.yml\t'"$deployment_run_attempt" &&
-                    "$pointer_run" != $'success\tworkflow_dispatch\tmain\t.github/workflows/docs.yml\t'"$deployment_run_attempt" &&
-                    "$pointer_run" != $'success\tpush\tmain\t.github/workflows/jekyll-gh-pages.yml\t'"$deployment_run_attempt" ]]; then
+              IFS=$'\t' read -r pointer_conclusion pointer_event \
+                pointer_branch pointer_path pointer_attempt <<<"$pointer_run"
+              if [[ "$pointer_branch" != main ||
+                    "$pointer_attempt" != "$deployment_run_attempt" ||
+                    (
+                      "$pointer_event" != push &&
+                      "$pointer_event" != workflow_dispatch
+                    ) ||
+                    (
+                      "$pointer_path" != ".github/workflows/docs.yml" &&
+                      "$pointer_path" != ".github/workflows/jekyll-gh-pages.yml"
+                    ) ||
+                    (
+                      "$pointer_path" == ".github/workflows/jekyll-gh-pages.yml" &&
+                      "$pointer_event" != push
+                    ) ]]; then
                 echo "Latest deployment pointer is not backed by a successful main documentation run." >&2
                 exit 1
+              fi
+              if [[ "$pointer_conclusion" != success ]]; then
+                if [[ "$pointer_path" != ".github/workflows/docs.yml" ]]; then
+                  echo "Failed legacy workflow attempts are not deployment pointers." >&2
+                  exit 1
+                fi
+                pointer_jobs="$(
+                  gh api \
+                    --paginate \
+                    --slurp \
+                    "repos/${GITHUB_REPOSITORY}/actions/runs/${deployment_run_id}/attempts/${deployment_run_attempt}/jobs?per_page=100" |
+                    jq -r '
+                      [
+                        .[][].jobs[]
+                        | select(
+                            (
+                              .name == "build"
+                              or .name == "stage-pages-release"
+                              or .name == "deploy"
+                              or .name == "production-smoke"
+                            )
+                            and .conclusion == "success"
+                          )
+                        | .name
+                      ]
+                      | unique
+                      | sort
+                      | join(",")
+                    '
+                )"
+                if [[ "$pointer_jobs" != "build,deploy,production-smoke,stage-pages-release" ]]; then
+                  echo "Failed deployment attempt lacks successful publication evidence." >&2
+                  exit 1
+                fi
               fi
               archive_run="$(
                 gh api \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,7 +76,7 @@ jobs:
                 'nuget.config',
                 '.config/dotnet-tools.json'
               )
-            }}
+            }}-${{ matrix.gate }}
 
       - name: Restore documentation tools
         run: dotnet tool restore

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,6 +105,8 @@ jobs:
 
   build:
     outputs:
+      archive_run_attempt: ${{ steps.deployment-identity.outputs.archive_run_attempt }}
+      archive_run_id: ${{ steps.deployment-identity.outputs.archive_run_id }}
       bootstrap_rollback: >-
         ${{ steps.rollback-source.outputs.bootstrap_rollback || 'false' }}
       recovery_stale: >-
@@ -494,6 +496,18 @@ jobs:
         id: deployment-identity
         if: steps.rollback-source.outputs.recovery_stale != 'true'
         env:
+          ARCHIVE_RUN_ATTEMPT: >-
+            ${{
+              inputs.rollback_run_id != '' &&
+              inputs.rollback_run_attempt ||
+              github.run_attempt
+            }}
+          ARCHIVE_RUN_ID: >-
+            ${{
+              inputs.rollback_run_id != '' &&
+              inputs.rollback_run_id ||
+              github.run_id
+            }}
           SOURCE_SHA: >-
             ${{
               inputs.rollback_run_id != '' &&
@@ -501,12 +515,19 @@ jobs:
               github.sha
             }}
         run: |
+          if [[ ! "$ARCHIVE_RUN_ID" =~ ^[0-9]+$ ||
+                ! "$ARCHIVE_RUN_ATTEMPT" =~ ^[0-9]+$ ]]; then
+            echo "Deployment archive identity is invalid." >&2
+            exit 1
+          fi
           printf \
-            '{"sourceSha":"%s","deploymentRunId":%s,"deploymentRunAttempt":%s}\n' \
+            '{"sourceSha":"%s","archiveRunId":%s,"archiveRunAttempt":%s}\n' \
             "$SOURCE_SHA" \
-            "$GITHUB_RUN_ID" \
-            "$GITHUB_RUN_ATTEMPT" \
+            "$ARCHIVE_RUN_ID" \
+            "$ARCHIVE_RUN_ATTEMPT" \
             > website/build/deployment.json
+          echo "archive_run_id=${ARCHIVE_RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "archive_run_attempt=${ARCHIVE_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
           echo "source_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Verify complete Pages artifact
@@ -693,8 +714,7 @@ jobs:
                         .[][].jobs[]
                         | select(
                             (
-                              .name == "build"
-                              or .name == "stage-pages-release"
+                              .name == "stage-pages-release"
                               or .name == "deploy"
                               or .name == "production-smoke"
                             )
@@ -707,7 +727,7 @@ jobs:
                       | join(",")
                     '
                 )"
-                if [[ "$pointer_jobs" != "build,deploy,production-smoke,stage-pages-release" ]]; then
+                if [[ "$pointer_jobs" != "deploy,production-smoke,stage-pages-release" ]]; then
                   echo "Failed deployment attempt lacks successful publication evidence." >&2
                   exit 1
                 fi
@@ -741,12 +761,7 @@ jobs:
                       [
                         .[][].jobs[]
                         | select(
-                            (
-                              .name == "build"
-                              or .name == "stage-pages-release"
-                              or .name == "deploy"
-                              or .name == "production-smoke"
-                            )
+                            .name == "build"
                             and .conclusion == "success"
                           )
                         | .name
@@ -756,7 +771,7 @@ jobs:
                       | join(",")
                     '
                 )"
-                if [[ "$archive_jobs" != "build,deploy,production-smoke,stage-pages-release" ]]; then
+                if [[ "$archive_jobs" != "build" ]]; then
                   echo "Latest deployment pointer lacks successful archive evidence." >&2
                   exit 1
                 fi
@@ -1012,18 +1027,8 @@ jobs:
 
       - name: Stage and verify mutable deployment release
         env:
-          ARCHIVE_RUN_ATTEMPT: >-
-            ${{
-              inputs.rollback_run_id != '' &&
-              inputs.rollback_run_attempt ||
-              github.run_attempt
-            }}
-          ARCHIVE_RUN_ID: >-
-            ${{
-              inputs.rollback_run_id != '' &&
-              inputs.rollback_run_id ||
-              github.run_id
-            }}
+          ARCHIVE_RUN_ATTEMPT: ${{ needs.build.outputs.archive_run_attempt }}
+          ARCHIVE_RUN_ID: ${{ needs.build.outputs.archive_run_id }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
         run: |
@@ -1371,86 +1376,18 @@ jobs:
             > current-production.json
           if ! jq -e \
             --arg sourceSha "$SOURCE_SHA" \
-            --argjson deploymentRunId "$deployment_run_id" \
-            --argjson deploymentRunAttempt "$deployment_run_attempt" \
+            --argjson archiveRunId "$archive_run_id" \
+            --argjson archiveRunAttempt "$archive_run_attempt" \
             '.sourceSha == $sourceSha
-              and .deploymentRunId == $deploymentRunId
-              and .deploymentRunAttempt == $deploymentRunAttempt' \
+              and .archiveRunId == $archiveRunId
+              and .archiveRunAttempt == $archiveRunAttempt' \
             current-production.json >/dev/null; then
             echo "Production no longer matches the deployment candidate." >&2
             exit 1
           fi
 
-          if [[ "$source_attempt" != "$GITHUB_RUN_ATTEMPT" ]]; then
-            mkdir roll-forward
-            gh api \
-              "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
-              --jq '.assets[] | [.name, .id] | @tsv' |
-              while IFS=$'\t' read -r name asset_id; do
-                if [[ "$name" == "$archive_name" ||
-                      "$name" == "$checksum_name" ]]; then
-                  gh api \
-                    -H "Accept: application/octet-stream" \
-                    "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" \
-                    > "roll-forward/${name}"
-                fi
-              done
-            (
-              cd roll-forward
-              sha256sum -c "$checksum_name"
-            )
-            pointer_name="deployment-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
-            printf \
-              '{"schemaVersion":1,"archiveRunId":%s,"archiveRunAttempt":%s,"sourceSha":"%s","deploymentRunId":%s,"deploymentRunAttempt":%s}\n' \
-              "$archive_run_id" \
-              "$archive_run_attempt" \
-              "$SOURCE_SHA" \
-              "$GITHUB_RUN_ID" \
-              "$GITHUB_RUN_ATTEMPT" \
-              > "roll-forward/${pointer_name}"
-            pointer_tag="${release_prefix}${GITHUB_RUN_ATTEMPT}"
-            gh release create "$pointer_tag" \
-              "roll-forward/${archive_name}" \
-              "roll-forward/${checksum_name}" \
-              "roll-forward/${pointer_name}" \
-              --draft \
-              --latest=false \
-              --prerelease \
-              --target "$SOURCE_SHA" \
-              --title "Documentation deployment ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" \
-              --notes "Automation-owned exact deployment candidate."
-            release="$(
-              gh api \
-                --paginate \
-                --slurp \
-                "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
-                jq -r --arg tag "$pointer_tag" '
-                  [
-                    .[][]
-                    | select(.tag_name == $tag)
-                  ]
-                  | if length != 1 then
-                      error("roll-forward release is unavailable or duplicated")
-                    else
-                      first
-                    end
-                  | [
-                      .id,
-                      .draft,
-                      .immutable,
-                      .target_commitish,
-                      (.assets | length),
-                      ([.assets[].name] | sort | join(","))
-                    ]
-                  | @tsv
-                '
-            )"
-            IFS=$'\t' read -r release_id draft immutable target \
-              asset_count asset_names <<<"$release"
-          else
-            pointer_name="$source_pointer_name"
-            pointer_tag="$source_tag"
-          fi
+          pointer_name="$source_pointer_name"
+          pointer_tag="$source_tag"
           if [[ ! "$release_id" =~ ^[0-9]+$ ||
                 "$target" != "$SOURCE_SHA" ||
                 "$asset_count" != 3 ||
@@ -1534,7 +1471,6 @@ jobs:
           RECORD_RESULT: ${{ needs.record-production-deployment.result }}
           REQUESTED_ROLLBACK_RUN_ATTEMPT: ${{ inputs.rollback_run_attempt }}
           REQUESTED_ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
-          SMOKE_RESULT: ${{ needs.production-smoke.result }}
         run: |
           recovery_run_id="$PRIOR_RUN_ID"
           recovery_run_attempt="$PRIOR_RUN_ATTEMPT"
@@ -1642,10 +1578,9 @@ jobs:
               echo "The last known-good deployment assets are invalid." >&2
               exit 1
             fi
-            if [[ "$SMOKE_RESULT" == failure &&
-                  "$recovery_run_id" == "$REQUESTED_ROLLBACK_RUN_ID" &&
+            if [[ "$recovery_run_id" == "$REQUESTED_ROLLBACK_RUN_ID" &&
                   "$recovery_run_attempt" == "$REQUESTED_ROLLBACK_RUN_ATTEMPT" ]]; then
-              echo "The last known-good artifact also failed smoke; automatic recovery stopped." >&2
+              echo "The requested recovery artifact is already the last known-good deployment; automatic recovery stopped." >&2
               exit 1
             fi
           fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1001,11 +1001,15 @@ jobs:
                 ' <<<"$runs"
               )"
             fi
+            IFS=$'\t' read -r run_id run_attempt source_sha source_path \
+              <<<"$prior"
+            deployment_run_id="$run_id"
+            deployment_run_attempt="$run_attempt"
           fi
-          IFS=$'\t' read -r run_id run_attempt source_sha source_path \
-            deployment_run_id deployment_run_attempt <<<"$prior"
           if [[ ! "$run_id" =~ ^[0-9]+$ ||
                 ! "$run_attempt" =~ ^[0-9]+$ ||
+                ! "$deployment_run_id" =~ ^[0-9]+$ ||
+                ! "$deployment_run_attempt" =~ ^[0-9]+$ ||
                 ! "$source_sha" =~ ^[0-9a-f]{40}$ ||
                 (
                   "$source_path" != ".github/workflows/docs.yml" &&
@@ -1016,8 +1020,8 @@ jobs:
           fi
           echo "Retaining prior deployment ${run_id} from ${source_path}."
           {
-            echo "deployment_run_attempt=${deployment_run_attempt:-$run_attempt}"
-            echo "deployment_run_id=${deployment_run_id:-$run_id}"
+            echo "deployment_run_attempt=${deployment_run_attempt}"
+            echo "deployment_run_id=${deployment_run_id}"
             echo "run_attempt=${run_attempt}"
             echo "run_id=${run_id}"
             echo "source_sha=${source_sha}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -501,7 +501,11 @@ jobs:
               github.sha
             }}
         run: |
-          printf '{"sourceSha":"%s"}\n' "$SOURCE_SHA" \
+          printf \
+            '{"sourceSha":"%s","deploymentRunId":%s,"deploymentRunAttempt":%s}\n' \
+            "$SOURCE_SHA" \
+            "$GITHUB_RUN_ID" \
+            "$GITHUB_RUN_ATTEMPT" \
             > website/build/deployment.json
           echo "source_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
 
@@ -1353,6 +1357,27 @@ jobs:
                 "$deployment_run_attempt" != "$source_attempt" ||
                 "$asset_names" != "${source_pointer_name},${archive_name},${checksum_name}" ]]; then
             echo "Deployment candidate manifest is invalid." >&2
+            exit 1
+          fi
+          curl \
+            --fail \
+            --header "Cache-Control: no-cache" \
+            --retry 4 \
+            --retry-all-errors \
+            --retry-delay 2 \
+            --show-error \
+            --silent \
+            "https://humanizr.net/deployment.json?run=${deployment_run_id}&attempt=${deployment_run_attempt}" \
+            > current-production.json
+          if ! jq -e \
+            --arg sourceSha "$SOURCE_SHA" \
+            --argjson deploymentRunId "$deployment_run_id" \
+            --argjson deploymentRunAttempt "$deployment_run_attempt" \
+            '.sourceSha == $sourceSha
+              and .deploymentRunId == $deploymentRunId
+              and .deploymentRunAttempt == $deploymentRunAttempt' \
+            current-production.json >/dev/null; then
+            echo "Production no longer matches the deployment candidate." >&2
             exit 1
           fi
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -371,10 +371,7 @@ jobs:
               jq -r '
                 [
                   .[].workflow_runs[]
-                  | select(
-                      .path == ".github/workflows/docs.yml"
-                      and .run_attempt == 1
-                    )
+                  | select(.path == ".github/workflows/docs.yml")
                 ]
                 | sort_by(.created_at)
                 | last
@@ -385,10 +382,7 @@ jobs:
               jq -r '
                 [
                   .[].workflow_runs[]
-                  | select(
-                      .path == ".github/workflows/jekyll-gh-pages.yml"
-                      and .run_attempt == 1
-                    )
+                  | select(.path == ".github/workflows/jekyll-gh-pages.yml")
                 ]
                 | sort_by(.created_at)
                 | last
@@ -926,10 +920,7 @@ jobs:
                   jq -r '
                     [
                       .[].workflow_runs[]
-                      | select(
-                          .path == ".github/workflows/docs.yml"
-                          and .run_attempt == 1
-                        )
+                      | select(.path == ".github/workflows/docs.yml")
                     ]
                     | sort_by(.created_at)
                     | last
@@ -940,10 +931,7 @@ jobs:
                   jq -r '
                     [
                       .[].workflow_runs[]
-                      | select(
-                          .path == ".github/workflows/jekyll-gh-pages.yml"
-                          and .run_attempt == 1
-                        )
+                      | select(.path == ".github/workflows/jekyll-gh-pages.yml")
                     ]
                     | sort_by(.created_at)
                     | last

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -314,13 +314,46 @@ jobs:
           )"
           IFS=$'\t' read -r conclusion event branch path source_sha run_attempt \
             <<<"$source_run"
-          if [[ "$conclusion" != success ||
-                "$event" != push ||
+          if [[ "$event" != push ||
                 "$branch" != main ||
                 "$run_attempt" != "$ROLLBACK_RUN_ATTEMPT" ||
                 ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Rollback source must be a successful main push." >&2
             exit 1
+          fi
+          if [[ "$conclusion" != success ]]; then
+            if [[ "$path" != ".github/workflows/docs.yml" ]]; then
+              echo "Failed workflow attempts are not rollback sources." >&2
+              exit 1
+            fi
+            recovery_jobs="$(
+              gh api \
+                --paginate \
+                --slurp \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${ROLLBACK_RUN_ID}/attempts/${ROLLBACK_RUN_ATTEMPT}/jobs?per_page=100" |
+                jq -r '
+                  [
+                    .[][].jobs[]
+                    | select(
+                        (
+                          .name == "build"
+                          or .name == "stage-pages-release"
+                          or .name == "deploy"
+                          or .name == "production-smoke"
+                        )
+                        and .conclusion == "success"
+                      )
+                    | .name
+                  ]
+                  | unique
+                  | sort
+                  | join(",")
+                '
+            )"
+            if [[ "$recovery_jobs" != "build,deploy,production-smoke,stage-pages-release" ]]; then
+              echo "Failed workflow attempt lacks successful deployment evidence." >&2
+              exit 1
+            fi
           fi
 
           bootstrap_rollback=false
@@ -383,7 +416,7 @@ jobs:
           ROLLBACK_SOURCE_SHA: ${{ steps.rollback-source.outputs.source_sha }}
         run: |
           mkdir -p rollback
-          archive_name="github-pages-${ROLLBACK_RUN_ID}.tar"
+          archive_name="github-pages-${ROLLBACK_RUN_ID}-${ROLLBACK_RUN_ATTEMPT}.tar"
           checksum_name="${archive_name}.sha256"
           release_tag="$(
             gh api \
@@ -421,13 +454,13 @@ jobs:
           deployment_run_attempt="${deployment_key##*-}"
           pointer_name="deployment-${deployment_run_id}-${deployment_run_attempt}.json"
           gh release download "$release_tag" \
-            --pattern "github-pages-${ROLLBACK_RUN_ID}.tar" \
-            --pattern "github-pages-${ROLLBACK_RUN_ID}.tar.sha256" \
+            --pattern "$archive_name" \
+            --pattern "$checksum_name" \
             --pattern "$pointer_name" \
             --dir rollback
           (
             cd rollback
-            sha256sum -c "github-pages-${ROLLBACK_RUN_ID}.tar.sha256"
+            sha256sum -c "$checksum_name"
           )
           jq -e \
             --argjson archiveRunId "$ROLLBACK_RUN_ID" \
@@ -448,11 +481,13 @@ jobs:
           inputs.rollback_run_id != '' &&
           steps.rollback-source.outputs.recovery_stale != 'true'
         env:
+          ROLLBACK_RUN_ATTEMPT: ${{ inputs.rollback_run_attempt }}
           ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
         run: |
           mkdir -p website/build
+          archive_name="github-pages-${ROLLBACK_RUN_ID}-${ROLLBACK_RUN_ATTEMPT}.tar"
           tar -xf \
-            "rollback/github-pages-${ROLLBACK_RUN_ID}.tar" \
+            "rollback/${archive_name}" \
             -C website/build
 
       - name: Write deployment identity
@@ -621,7 +656,8 @@ jobs:
                   --jq '[.conclusion, .event, .head_branch, .path, .run_attempt] | @tsv'
               )"
               if [[ "$pointer_run" != $'success\tpush\tmain\t.github/workflows/docs.yml\t'"$deployment_run_attempt" &&
-                    "$pointer_run" != $'success\tworkflow_dispatch\tmain\t.github/workflows/docs.yml\t'"$deployment_run_attempt" ]]; then
+                    "$pointer_run" != $'success\tworkflow_dispatch\tmain\t.github/workflows/docs.yml\t'"$deployment_run_attempt" &&
+                    "$pointer_run" != $'success\tpush\tmain\t.github/workflows/jekyll-gh-pages.yml\t'"$deployment_run_attempt" ]]; then
                 echo "Latest deployment pointer is not backed by a successful main documentation run." >&2
                 exit 1
               fi
@@ -633,8 +669,7 @@ jobs:
               IFS=$'\t' read -r archive_conclusion archive_event \
                 archive_branch archive_path archive_sha archive_attempt \
                 <<<"$archive_run"
-              if [[ "$archive_conclusion" != success ||
-                    "$archive_event" != push ||
+              if [[ "$archive_event" != push ||
                     "$archive_branch" != main ||
                     "$archive_sha" != "$source_sha" ||
                     "$archive_attempt" != "$run_attempt" ||
@@ -644,6 +679,36 @@ jobs:
                     ) ]]; then
                 echo "Latest deployment pointer names an invalid archive source." >&2
                 exit 1
+              fi
+              if [[ "$archive_conclusion" != success ]]; then
+                archive_jobs="$(
+                  gh api \
+                    --paginate \
+                    --slurp \
+                    "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/attempts/${run_attempt}/jobs?per_page=100" |
+                    jq -r '
+                      [
+                        .[][].jobs[]
+                        | select(
+                            (
+                              .name == "build"
+                              or .name == "stage-pages-release"
+                              or .name == "deploy"
+                              or .name == "production-smoke"
+                            )
+                            and .conclusion == "success"
+                          )
+                        | .name
+                      ]
+                      | unique
+                      | sort
+                      | join(",")
+                    '
+                )"
+                if [[ "$archive_jobs" != "build,deploy,production-smoke,stage-pages-release" ]]; then
+                  echo "Latest deployment pointer lacks successful archive evidence." >&2
+                  exit 1
+                fi
               fi
               if [[ "$archive_path" == ".github/workflows/jekyll-gh-pages.yml" ]]; then
                 bootstrap_runs="$(
@@ -744,7 +809,7 @@ jobs:
           PRIOR_SOURCE_SHA: ${{ steps.prior.outputs.source_sha }}
         run: |
           archive_tag="docs-pages-deployment-v1-${PRIOR_DEPLOYMENT_RUN_ID}-${PRIOR_DEPLOYMENT_RUN_ATTEMPT}"
-          archive_name="github-pages-${PRIOR_RUN_ID}.tar"
+          archive_name="github-pages-${PRIOR_RUN_ID}-${PRIOR_RUN_ATTEMPT}.tar"
           checksum_name="${archive_name}.sha256"
           pointer_name="deployment-${PRIOR_DEPLOYMENT_RUN_ID}-${PRIOR_DEPLOYMENT_RUN_ATTEMPT}.json"
           release="$(
@@ -831,7 +896,7 @@ jobs:
         run: |
           mkdir -p prior-archive
           archive_tag="docs-pages-deployment-v1-${PRIOR_DEPLOYMENT_RUN_ID}-${PRIOR_DEPLOYMENT_RUN_ATTEMPT}"
-          archive_name="github-pages-${PRIOR_RUN_ID}.tar"
+          archive_name="github-pages-${PRIOR_RUN_ID}-${PRIOR_RUN_ATTEMPT}.tar"
           checksum_name="${archive_name}.sha256"
           pointer_name="deployment-${PRIOR_DEPLOYMENT_RUN_ID}-${PRIOR_DEPLOYMENT_RUN_ATTEMPT}.json"
           mv prior-download/artifact.tar "prior-archive/${archive_name}"
@@ -918,7 +983,7 @@ jobs:
             exit 1
           fi
           release_tag="docs-pages-deployment-v1-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          archive_name="github-pages-${ARCHIVE_RUN_ID}.tar"
+          archive_name="github-pages-${ARCHIVE_RUN_ID}-${ARCHIVE_RUN_ATTEMPT}.tar"
           checksum_name="${archive_name}.sha256"
           pointer_name="deployment-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
           mv candidate/artifact.tar "candidate/${archive_name}"
@@ -1128,59 +1193,192 @@ jobs:
     steps:
       - name: Record exact currently deployable archive
         env:
-          ARCHIVE_RUN_ATTEMPT: >-
-            ${{
-              inputs.rollback_run_id != '' &&
-              inputs.rollback_run_attempt ||
-              github.run_attempt
-            }}
-          ARCHIVE_RUN_ID: >-
-            ${{
-              inputs.rollback_run_id != '' &&
-              inputs.rollback_run_id ||
-              github.run_id
-            }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
         run: |
-          if [[ ! "$ARCHIVE_RUN_ID" =~ ^[0-9]+$ ||
-                ! "$ARCHIVE_RUN_ATTEMPT" =~ ^[0-9]+$ ||
-                ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+          if [[ ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Deployment identity is invalid." >&2
             exit 1
           fi
-          archive_name="github-pages-${ARCHIVE_RUN_ID}.tar"
-          checksum_name="${archive_name}.sha256"
-          pointer_name="deployment-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
-          pointer_tag="docs-pages-deployment-v1-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          release_prefix="docs-pages-deployment-v1-${GITHUB_RUN_ID}-"
           release="$(
             gh api \
               --paginate \
               --slurp \
               "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
-              jq -r --arg tag "$pointer_tag" '
+              jq -r --arg prefix "$release_prefix" '
                 [
                   .[][]
-                  | select(.tag_name == $tag)
+                  | select(.tag_name | startswith($prefix))
+                  | . + {
+                      deployment_attempt: (
+                        .tag_name
+                        | ltrimstr($prefix)
+                        | select(test("^[0-9]+$"))
+                        | tonumber
+                      )
+                    }
                 ]
-                | if length != 1 then
-                    error("candidate release is unavailable or duplicated")
-                  else
-                    first
-                  end
+                | sort_by(.deployment_attempt)
+                | (last // empty)
                 | [
+                    .tag_name,
+                    .deployment_attempt,
                     .id,
                     .draft,
                     .immutable,
                     .target_commitish,
                     (.assets | length),
-                    ([.assets[].name] | sort | join(","))
+                    ([.assets[].name] | sort | join(",")),
+                    ([
+                      .assets[]
+                      | select(
+                          .name
+                          | (
+                              startswith("deployment-")
+                              and endswith(".json")
+                            )
+                        )
+                    ] | length),
+                    ([
+                      .assets[]
+                      | select(
+                          .name
+                          | (
+                              startswith("deployment-")
+                              and endswith(".json")
+                            )
+                        )
+                    ][0].id // empty)
                   ]
                 | @tsv
               '
           )"
-          IFS=$'\t' read -r release_id draft immutable target \
-            asset_count asset_names <<<"$release"
+          IFS=$'\t' read -r source_tag source_attempt release_id draft \
+            immutable target asset_count asset_names manifest_count \
+            manifest_asset_id <<<"$release"
+          if [[ "$source_tag" != "${release_prefix}${source_attempt}" ||
+                ! "$source_attempt" =~ ^[0-9]+$ ||
+                ! "$release_id" =~ ^[0-9]+$ ||
+                "$target" != "$SOURCE_SHA" ||
+                "$asset_count" != 3 ||
+                "$manifest_count" != 1 ||
+                ! "$manifest_asset_id" =~ ^[0-9]+$ ||
+                ! (
+                  (
+                    "$draft" == true &&
+                    "$immutable" == false
+                  ) ||
+                  (
+                    "$draft" == false &&
+                    "$immutable" == true
+                  )
+                ) ]]; then
+            echo "Deployment candidate release is invalid." >&2
+            exit 1
+          fi
+          gh api \
+            -H "Accept: application/octet-stream" \
+            "repos/${GITHUB_REPOSITORY}/releases/assets/${manifest_asset_id}" \
+            > source-deployment.json
+          source_manifest="$(
+            jq -r '
+              select(.schemaVersion == 1)
+              | [
+                  .archiveRunId,
+                  .archiveRunAttempt,
+                  .sourceSha,
+                  .deploymentRunId,
+                  .deploymentRunAttempt
+                ]
+              | @tsv
+            ' source-deployment.json
+          )"
+          IFS=$'\t' read -r archive_run_id archive_run_attempt source_sha \
+            deployment_run_id deployment_run_attempt <<<"$source_manifest"
+          archive_name="github-pages-${archive_run_id}-${archive_run_attempt}.tar"
+          checksum_name="${archive_name}.sha256"
+          source_pointer_name="deployment-${GITHUB_RUN_ID}-${source_attempt}.json"
+          if [[ ! "$archive_run_id" =~ ^[0-9]+$ ||
+                ! "$archive_run_attempt" =~ ^[0-9]+$ ||
+                "$source_sha" != "$SOURCE_SHA" ||
+                "$deployment_run_id" != "$GITHUB_RUN_ID" ||
+                "$deployment_run_attempt" != "$source_attempt" ||
+                "$asset_names" != "${source_pointer_name},${archive_name},${checksum_name}" ]]; then
+            echo "Deployment candidate manifest is invalid." >&2
+            exit 1
+          fi
+
+          if [[ "$source_attempt" != "$GITHUB_RUN_ATTEMPT" ]]; then
+            mkdir roll-forward
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+              --jq '.assets[] | [.name, .id] | @tsv' |
+              while IFS=$'\t' read -r name asset_id; do
+                if [[ "$name" == "$archive_name" ||
+                      "$name" == "$checksum_name" ]]; then
+                  gh api \
+                    -H "Accept: application/octet-stream" \
+                    "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" \
+                    > "roll-forward/${name}"
+                fi
+              done
+            (
+              cd roll-forward
+              sha256sum -c "$checksum_name"
+            )
+            pointer_name="deployment-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
+            printf \
+              '{"schemaVersion":1,"archiveRunId":%s,"archiveRunAttempt":%s,"sourceSha":"%s","deploymentRunId":%s,"deploymentRunAttempt":%s}\n' \
+              "$archive_run_id" \
+              "$archive_run_attempt" \
+              "$SOURCE_SHA" \
+              "$GITHUB_RUN_ID" \
+              "$GITHUB_RUN_ATTEMPT" \
+              > "roll-forward/${pointer_name}"
+            pointer_tag="${release_prefix}${GITHUB_RUN_ATTEMPT}"
+            gh release create "$pointer_tag" \
+              "roll-forward/${archive_name}" \
+              "roll-forward/${checksum_name}" \
+              "roll-forward/${pointer_name}" \
+              --draft \
+              --latest=false \
+              --prerelease \
+              --target "$SOURCE_SHA" \
+              --title "Documentation deployment ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" \
+              --notes "Automation-owned exact deployment candidate."
+            release="$(
+              gh api \
+                --paginate \
+                --slurp \
+                "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+                jq -r --arg tag "$pointer_tag" '
+                  [
+                    .[][]
+                    | select(.tag_name == $tag)
+                  ]
+                  | if length != 1 then
+                      error("roll-forward release is unavailable or duplicated")
+                    else
+                      first
+                    end
+                  | [
+                      .id,
+                      .draft,
+                      .immutable,
+                      .target_commitish,
+                      (.assets | length),
+                      ([.assets[].name] | sort | join(","))
+                    ]
+                  | @tsv
+                '
+            )"
+            IFS=$'\t' read -r release_id draft immutable target \
+              asset_count asset_names <<<"$release"
+          else
+            pointer_name="$source_pointer_name"
+            pointer_tag="$source_tag"
+          fi
           if [[ ! "$release_id" =~ ^[0-9]+$ ||
                 "$target" != "$SOURCE_SHA" ||
                 "$asset_count" != 3 ||
@@ -1195,7 +1393,7 @@ jobs:
                     "$immutable" == true
                   )
                 ) ]]; then
-            echo "Deployment candidate release is invalid." >&2
+            echo "Deployment publication candidate is invalid." >&2
             exit 1
           fi
           if [[ "$draft" == true ]]; then
@@ -1261,14 +1459,17 @@ jobs:
           PRIOR_RUN_ATTEMPT: >-
             ${{ needs.retain-pages-artifacts.outputs.prior_run_attempt }}
           PRIOR_RUN_ID: ${{ needs.retain-pages-artifacts.outputs.prior_run_id }}
+          RECORD_RESULT: ${{ needs.record-production-deployment.result }}
           REQUESTED_ROLLBACK_RUN_ATTEMPT: ${{ inputs.rollback_run_attempt }}
           REQUESTED_ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
+          SMOKE_RESULT: ${{ needs.production-smoke.result }}
         run: |
           recovery_run_id="$PRIOR_RUN_ID"
           recovery_run_attempt="$PRIOR_RUN_ATTEMPT"
           expected_pointer_run_id="$PRIOR_DEPLOYMENT_RUN_ID"
           expected_pointer_run_attempt="$PRIOR_DEPLOYMENT_RUN_ATTEMPT"
-          if [[ -n "$REQUESTED_ROLLBACK_RUN_ID" ]]; then
+          if [[ -n "$REQUESTED_ROLLBACK_RUN_ID" ||
+                "$RECORD_RESULT" == failure ]]; then
             pointer="$(
               gh api \
                 --paginate \
@@ -1288,6 +1489,7 @@ jobs:
                   | [
                       .tag_name,
                       (.assets | length),
+                      ([.assets[].name] | sort | join(",")),
                       ([
                         .assets[]
                         | select(
@@ -1322,7 +1524,7 @@ jobs:
                   | @tsv
                 '
             )"
-            IFS=$'\t' read -r pointer_tag asset_count pointer_count \
+            IFS=$'\t' read -r pointer_tag asset_count asset_names pointer_count \
               pointer_asset_id pointer_asset_name <<<"$pointer"
             pointer_key="${pointer_tag#docs-pages-deployment-v1-}"
             pointer_run_id="${pointer_key%-*}"
@@ -1352,6 +1554,8 @@ jobs:
             expected_pointer_run_attempt="$(
               jq -r '.deploymentRunAttempt // empty' prior-deployment.json
             )"
+            archive_name="github-pages-${recovery_run_id}-${recovery_run_attempt}.tar"
+            checksum_name="${archive_name}.sha256"
             if ! jq -e \
               --argjson deploymentRunId "$pointer_run_id" \
               --argjson deploymentRunAttempt "$pointer_run_attempt" \
@@ -1362,7 +1566,12 @@ jobs:
               echo "The last known-good deployment pointer is invalid." >&2
               exit 1
             fi
-            if [[ "$recovery_run_id" == "$REQUESTED_ROLLBACK_RUN_ID" &&
+            if [[ "$asset_names" != "${pointer_asset_name},${archive_name},${checksum_name}" ]]; then
+              echo "The last known-good deployment assets are invalid." >&2
+              exit 1
+            fi
+            if [[ "$SMOKE_RESULT" == failure &&
+                  "$recovery_run_id" == "$REQUESTED_ROLLBACK_RUN_ID" &&
                   "$recovery_run_attempt" == "$REQUESTED_ROLLBACK_RUN_ATTEMPT" ]]; then
               echo "The last known-good artifact also failed smoke; automatic recovery stopped." >&2
               exit 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,8 +11,16 @@ on:
         description: Redeploy the retained artifact from this documentation run
         required: false
         type: string
+      rollback_run_attempt:
+        description: Exact attempt of the retained documentation run
+        required: false
+        type: string
       expected_pointer_run_id:
         description: Automation guard for a queued recovery
+        required: false
+        type: string
+      expected_pointer_run_attempt:
+        description: Exact attempt guarded by queued recovery
         required: false
         type: string
 
@@ -173,12 +181,19 @@ jobs:
         id: rollback-source
         if: inputs.rollback_run_id != ''
         env:
+          EXPECTED_POINTER_RUN_ATTEMPT: >-
+            ${{ inputs.expected_pointer_run_attempt }}
           EXPECTED_POINTER_RUN_ID: ${{ inputs.expected_pointer_run_id }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLLBACK_RUN_ATTEMPT: ${{ inputs.rollback_run_attempt }}
           ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
         run: |
           if [[ ! "$ROLLBACK_RUN_ID" =~ ^[0-9]+$ ]]; then
             echo "Rollback run ID must be numeric." >&2
+            exit 1
+          fi
+          if [[ ! "$ROLLBACK_RUN_ATTEMPT" =~ ^[0-9]+$ ]]; then
+            echo "Rollback run attempt must be numeric." >&2
             exit 1
           fi
           if [[ -n "$EXPECTED_POINTER_RUN_ID" ]]; then
@@ -187,7 +202,17 @@ jobs:
               echo "Expected deployment pointer run ID is invalid." >&2
               exit 1
             fi
+            if [[ "$EXPECTED_POINTER_RUN_ID" == none ]]; then
+              if [[ "$EXPECTED_POINTER_RUN_ATTEMPT" != none ]]; then
+                echo "Expected deployment pointer attempt is invalid." >&2
+                exit 1
+              fi
+            elif [[ ! "$EXPECTED_POINTER_RUN_ATTEMPT" =~ ^[0-9]+$ ]]; then
+              echo "Expected deployment pointer attempt is invalid." >&2
+              exit 1
+            fi
             current_pointer_run_id=none
+            current_pointer_run_attempt=none
             pointer="$(
               gh api \
                 --paginate \
@@ -198,7 +223,7 @@ jobs:
                     .[][]
                     | select(
                         .tag_name
-                        | startswith("docs-pages-deployment-")
+                        | startswith("docs-pages-deployment-v1-")
                       )
                     | select(.draft == false and .immutable == true)
                   ]
@@ -207,19 +232,51 @@ jobs:
                   | [
                       .tag_name,
                       (.assets | length),
-                      (.assets[0].id // empty),
-                      (.assets[0].name // empty)
+                      ([
+                        .assets[]
+                        | select(
+                            .name
+                            | (
+                                startswith("deployment-")
+                                and endswith(".json")
+                              )
+                          )
+                      ] | length),
+                      ([
+                        .assets[]
+                        | select(
+                            .name
+                            | (
+                                startswith("deployment-")
+                                and endswith(".json")
+                              )
+                          )
+                      ][0].id // empty),
+                      ([
+                        .assets[]
+                        | select(
+                            .name
+                            | (
+                                startswith("deployment-")
+                                and endswith(".json")
+                              )
+                          )
+                      ][0].name // empty)
                     ]
                   | @tsv
                 '
             )"
             if [[ -n "$pointer" ]]; then
-              IFS=$'\t' read -r pointer_tag pointer_asset_count \
+              IFS=$'\t' read -r pointer_tag asset_count pointer_count \
                 pointer_asset_id pointer_asset_name <<<"$pointer"
-              current_pointer_run_id="${pointer_tag#docs-pages-deployment-}"
+              pointer_key="${pointer_tag#docs-pages-deployment-v1-}"
+              current_pointer_run_id="${pointer_key%-*}"
+              current_pointer_run_attempt="${pointer_key##*-}"
               if [[ ! "$current_pointer_run_id" =~ ^[0-9]+$ ||
-                    "$pointer_asset_count" != 1 ||
-                    "$pointer_asset_name" != "deployment-${current_pointer_run_id}.json" ||
+                    ! "$current_pointer_run_attempt" =~ ^[0-9]+$ ||
+                    "$asset_count" != 3 ||
+                    "$pointer_count" != 1 ||
+                    "$pointer_asset_name" != "deployment-${current_pointer_run_id}-${current_pointer_run_attempt}.json" ||
                     ! "$pointer_asset_id" =~ ^[0-9]+$ ]]; then
                 echo "Current deployment pointer release is invalid." >&2
                 exit 1
@@ -228,15 +285,19 @@ jobs:
                 -H "Accept: application/octet-stream" \
                 "repos/${GITHUB_REPOSITORY}/releases/assets/${pointer_asset_id}" \
                 > current-deployment.json
-              recorded_pointer_run_id="$(
-                jq -r '.deploymentRunId // empty' current-deployment.json
-              )"
-              if [[ "$recorded_pointer_run_id" != "$current_pointer_run_id" ]]; then
+              if ! jq -e \
+                --argjson deploymentRunId "$current_pointer_run_id" \
+                --argjson deploymentRunAttempt "$current_pointer_run_attempt" \
+                '.schemaVersion == 1
+                  and .deploymentRunId == $deploymentRunId
+                  and .deploymentRunAttempt == $deploymentRunAttempt' \
+                current-deployment.json >/dev/null; then
                 echo "Current deployment pointer is invalid." >&2
                 exit 1
               fi
             fi
-            if [[ "$current_pointer_run_id" != "$EXPECTED_POINTER_RUN_ID" ]]; then
+            if [[ "$current_pointer_run_id" != "$EXPECTED_POINTER_RUN_ID" ||
+                  "$current_pointer_run_attempt" != "$EXPECTED_POINTER_RUN_ATTEMPT" ]]; then
               echo "Recovery was superseded by a newer production result."
               echo "recovery_stale=true" >> "$GITHUB_OUTPUT"
               exit 0
@@ -245,12 +306,14 @@ jobs:
           source_run="$(
             gh api \
               "repos/${GITHUB_REPOSITORY}/actions/runs/${ROLLBACK_RUN_ID}" \
-              --jq '[.conclusion, .event, .head_branch, .path, .head_sha] | @tsv'
+              --jq '[.conclusion, .event, .head_branch, .path, .head_sha, .run_attempt] | @tsv'
           )"
-          IFS=$'\t' read -r conclusion event branch path source_sha <<<"$source_run"
+          IFS=$'\t' read -r conclusion event branch path source_sha run_attempt \
+            <<<"$source_run"
           if [[ "$conclusion" != success ||
                 "$event" != push ||
                 "$branch" != main ||
+                "$run_attempt" != "$ROLLBACK_RUN_ATTEMPT" ||
                 ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Rollback source must be a successful main push." >&2
             exit 1
@@ -311,17 +374,70 @@ jobs:
           steps.rollback-source.outputs.recovery_stale != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLLBACK_RUN_ATTEMPT: ${{ inputs.rollback_run_attempt }}
           ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
+          ROLLBACK_SOURCE_SHA: ${{ steps.rollback-source.outputs.source_sha }}
         run: |
           mkdir -p rollback
-          gh release download "docs-pages-archive-${ROLLBACK_RUN_ID}" \
+          archive_name="github-pages-${ROLLBACK_RUN_ID}.tar"
+          checksum_name="${archive_name}.sha256"
+          release_tag="$(
+            gh api \
+              --paginate \
+              --slurp \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+              jq -r \
+                --arg archive "$archive_name" \
+                --arg checksum "$checksum_name" \
+                --arg source "$ROLLBACK_SOURCE_SHA" '
+                  [
+                    .[][]
+                    | select(
+                        .draft == false
+                        and .immutable == true
+                        and .target_commitish == $source
+                      )
+                    | select(
+                        ([.assets[].name] | index($archive)) != null
+                        and ([.assets[].name] | index($checksum)) != null
+                        and (.assets | length) == 3
+                      )
+                  ]
+                  | sort_by(.published_at)
+                  | (last // empty)
+                  | .tag_name
+                '
+          )"
+          if [[ "$release_tag" != docs-pages-deployment-v1-* ]]; then
+            echo "Exact immutable rollback release is unavailable." >&2
+            exit 1
+          fi
+          deployment_key="${release_tag#docs-pages-deployment-v1-}"
+          deployment_run_id="${deployment_key%-*}"
+          deployment_run_attempt="${deployment_key##*-}"
+          pointer_name="deployment-${deployment_run_id}-${deployment_run_attempt}.json"
+          gh release download "$release_tag" \
             --pattern "github-pages-${ROLLBACK_RUN_ID}.tar" \
             --pattern "github-pages-${ROLLBACK_RUN_ID}.tar.sha256" \
+            --pattern "$pointer_name" \
             --dir rollback
           (
             cd rollback
             sha256sum -c "github-pages-${ROLLBACK_RUN_ID}.tar.sha256"
           )
+          jq -e \
+            --argjson archiveRunId "$ROLLBACK_RUN_ID" \
+            --argjson archiveRunAttempt "$ROLLBACK_RUN_ATTEMPT" \
+            --argjson deploymentRunId "$deployment_run_id" \
+            --argjson deploymentRunAttempt "$deployment_run_attempt" \
+            --arg sourceSha "$ROLLBACK_SOURCE_SHA" \
+            '.schemaVersion == 1
+              and .archiveRunId == $archiveRunId
+              and .archiveRunAttempt == $archiveRunAttempt
+              and .sourceSha == $sourceSha
+              and .deploymentRunId == $deploymentRunId
+              and .deploymentRunAttempt == $deploymentRunAttempt' \
+            "rollback/${pointer_name}" >/dev/null
 
       - name: Extract retained Pages artifact for verification
         if: >-
@@ -381,7 +497,9 @@ jobs:
   retain-pages-artifacts:
     if: github.event_name == 'push'
     outputs:
+      prior_deployment_run_attempt: ${{ steps.prior.outputs.deployment_run_attempt }}
       prior_deployment_run_id: ${{ steps.prior.outputs.deployment_run_id }}
+      prior_run_attempt: ${{ steps.prior.outputs.run_attempt }}
       prior_run_id: ${{ steps.prior.outputs.run_id }}
     runs-on: ubuntu-latest
     needs:
@@ -407,7 +525,7 @@ jobs:
                   .[][]
                   | select(
                       .tag_name
-                      | startswith("docs-pages-deployment-")
+                      | startswith("docs-pages-deployment-v1-")
                     )
                   | select(.draft == false and .immutable == true)
                 ]
@@ -416,19 +534,51 @@ jobs:
                 | [
                     .tag_name,
                     (.assets | length),
-                    (.assets[0].id // empty),
-                    (.assets[0].name // empty)
+                    ([
+                      .assets[]
+                      | select(
+                          .name
+                          | (
+                              startswith("deployment-")
+                              and endswith(".json")
+                            )
+                        )
+                    ] | length),
+                    ([
+                      .assets[]
+                      | select(
+                          .name
+                          | (
+                              startswith("deployment-")
+                              and endswith(".json")
+                            )
+                        )
+                    ][0].id // empty),
+                    ([
+                      .assets[]
+                      | select(
+                          .name
+                          | (
+                              startswith("deployment-")
+                              and endswith(".json")
+                            )
+                        )
+                    ][0].name // empty)
                   ]
                 | @tsv
               '
           )"
           if [[ -n "$pointer" ]]; then
-            IFS=$'\t' read -r pointer_tag pointer_asset_count \
+            IFS=$'\t' read -r pointer_tag asset_count pointer_count \
               pointer_asset_id pointer_asset_name <<<"$pointer"
-            pointer_run_id="${pointer_tag#docs-pages-deployment-}"
+            pointer_key="${pointer_tag#docs-pages-deployment-v1-}"
+            pointer_run_id="${pointer_key%-*}"
+            pointer_run_attempt="${pointer_key##*-}"
             if [[ ! "$pointer_run_id" =~ ^[0-9]+$ ||
-                  "$pointer_asset_count" != 1 ||
-                  "$pointer_asset_name" != "deployment-${pointer_run_id}.json" ||
+                  ! "$pointer_run_attempt" =~ ^[0-9]+$ ||
+                  "$asset_count" != 3 ||
+                  "$pointer_count" != 1 ||
+                  "$pointer_asset_name" != "deployment-${pointer_run_id}-${pointer_run_attempt}.json" ||
                   ! "$pointer_asset_id" =~ ^[0-9]+$ ]]; then
               echo "Latest deployment pointer release is invalid." >&2
               exit 1
@@ -438,39 +588,52 @@ jobs:
                 "repos/${GITHUB_REPOSITORY}/releases/assets/${pointer_asset_id}" \
                 > prior-deployment.json
               prior="$(
-                jq -r \
-                  '[.archiveRunId, .sourceSha, ".github/workflows/docs.yml", .deploymentRunId] | @tsv' \
-                  prior-deployment.json
+                jq -r '
+                  select(.schemaVersion == 1)
+                  | [
+                      .archiveRunId,
+                      .archiveRunAttempt,
+                      .sourceSha,
+                      ".github/workflows/docs.yml",
+                      .deploymentRunId,
+                      .deploymentRunAttempt
+                    ]
+                  | @tsv
+                ' prior-deployment.json
               )"
-              IFS=$'\t' read -r run_id source_sha source_path deployment_run_id \
-                <<<"$prior"
+              IFS=$'\t' read -r run_id run_attempt source_sha source_path \
+                deployment_run_id deployment_run_attempt <<<"$prior"
               if [[ ! "$run_id" =~ ^[0-9]+$ ||
+                    ! "$run_attempt" =~ ^[0-9]+$ ||
                     ! "$source_sha" =~ ^[0-9a-f]{40}$ ||
-                    "$deployment_run_id" != "$pointer_run_id" ]]; then
+                    "$deployment_run_id" != "$pointer_run_id" ||
+                    "$deployment_run_attempt" != "$pointer_run_attempt" ]]; then
                 echo "Latest deployment pointer is invalid." >&2
                 exit 1
               fi
               pointer_run="$(
                 gh api \
                   "repos/${GITHUB_REPOSITORY}/actions/runs/${deployment_run_id}" \
-                  --jq '[.conclusion, .event, .head_branch, .path] | @tsv'
+                  --jq '[.conclusion, .event, .head_branch, .path, .run_attempt] | @tsv'
               )"
-              if [[ "$pointer_run" != $'success\tpush\tmain\t.github/workflows/docs.yml' &&
-                    "$pointer_run" != $'success\tworkflow_dispatch\tmain\t.github/workflows/docs.yml' ]]; then
+              if [[ "$pointer_run" != $'success\tpush\tmain\t.github/workflows/docs.yml\t'"$deployment_run_attempt" &&
+                    "$pointer_run" != $'success\tworkflow_dispatch\tmain\t.github/workflows/docs.yml\t'"$deployment_run_attempt" ]]; then
                 echo "Latest deployment pointer is not backed by a successful main documentation run." >&2
                 exit 1
               fi
               archive_run="$(
                 gh api \
                   "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
-                  --jq '[.conclusion, .event, .head_branch, .path, .head_sha] | @tsv'
+                  --jq '[.conclusion, .event, .head_branch, .path, .head_sha, .run_attempt] | @tsv'
               )"
               IFS=$'\t' read -r archive_conclusion archive_event \
-                archive_branch archive_path archive_sha <<<"$archive_run"
+                archive_branch archive_path archive_sha archive_attempt \
+                <<<"$archive_run"
               if [[ "$archive_conclusion" != success ||
                     "$archive_event" != push ||
                     "$archive_branch" != main ||
                     "$archive_sha" != "$source_sha" ||
+                    "$archive_attempt" != "$run_attempt" ||
                     (
                       "$archive_path" != ".github/workflows/docs.yml" &&
                       "$archive_path" != ".github/workflows/jekyll-gh-pages.yml"
@@ -530,7 +693,7 @@ jobs:
                 ]
                 | sort_by(.created_at)
                 | (last // empty)
-                | [.id, .head_sha, .path]
+                | [.id, .run_attempt, .head_sha, .path]
                 | @tsv
               ' <<<"$runs"
             )"
@@ -543,21 +706,25 @@ jobs:
                   ]
                   | sort_by(.created_at)
                   | (last // empty)
-                  | [.id, .head_sha, .path]
+                  | [.id, .run_attempt, .head_sha, .path]
                   | @tsv
                 ' <<<"$runs"
               )"
             fi
           fi
-          IFS=$'\t' read -r run_id source_sha source_path <<<"$prior"
+          IFS=$'\t' read -r run_id run_attempt source_sha source_path \
+            deployment_run_id deployment_run_attempt <<<"$prior"
           if [[ ! "$run_id" =~ ^[0-9]+$ ||
+                ! "$run_attempt" =~ ^[0-9]+$ ||
                 ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "No successful main documentation deployment is available to retain." >&2
             exit 1
           fi
           echo "Retaining prior deployment ${run_id} from ${source_path}."
           {
-            echo "deployment_run_id=${deployment_run_id:-none}"
+            echo "deployment_run_attempt=${deployment_run_attempt:-$run_attempt}"
+            echo "deployment_run_id=${deployment_run_id:-$run_id}"
+            echo "run_attempt=${run_attempt}"
             echo "run_id=${run_id}"
             echo "source_sha=${source_sha}"
           } >> "$GITHUB_OUTPUT"
@@ -566,12 +733,16 @@ jobs:
         id: prior-archive
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRIOR_DEPLOYMENT_RUN_ATTEMPT: ${{ steps.prior.outputs.deployment_run_attempt }}
+          PRIOR_DEPLOYMENT_RUN_ID: ${{ steps.prior.outputs.deployment_run_id }}
+          PRIOR_RUN_ATTEMPT: ${{ steps.prior.outputs.run_attempt }}
           PRIOR_RUN_ID: ${{ steps.prior.outputs.run_id }}
           PRIOR_SOURCE_SHA: ${{ steps.prior.outputs.source_sha }}
         run: |
-          archive_tag="docs-pages-archive-${PRIOR_RUN_ID}"
+          archive_tag="docs-pages-deployment-v1-${PRIOR_DEPLOYMENT_RUN_ID}-${PRIOR_DEPLOYMENT_RUN_ATTEMPT}"
           archive_name="github-pages-${PRIOR_RUN_ID}.tar"
           checksum_name="${archive_name}.sha256"
+          pointer_name="deployment-${PRIOR_DEPLOYMENT_RUN_ID}-${PRIOR_DEPLOYMENT_RUN_ATTEMPT}.json"
           release="$(
             gh api \
               "repos/${GITHUB_REPOSITORY}/releases/tags/${archive_tag}" \
@@ -591,8 +762,8 @@ jobs:
               <<<"$release"
             if [[ "$immutable" != true ||
                   "$target" != "$PRIOR_SOURCE_SHA" ||
-                  "$asset_count" != 2 ||
-                  "$asset_names" != "${archive_name},${checksum_name}" ]]; then
+                  "$asset_count" != 3 ||
+                  "$asset_names" != "${pointer_name},${archive_name},${checksum_name}" ]]; then
               echo "Prior rollback release is invalid." >&2
               exit 1
             fi
@@ -600,11 +771,25 @@ jobs:
             gh release download "$archive_tag" \
               --pattern "$archive_name" \
               --pattern "$checksum_name" \
+              --pattern "$pointer_name" \
               --dir prior-archive
             (
               cd prior-archive
               sha256sum -c "$checksum_name"
             )
+            jq -e \
+              --argjson archiveRunId "$PRIOR_RUN_ID" \
+              --argjson archiveRunAttempt "$PRIOR_RUN_ATTEMPT" \
+              --arg sourceSha "$PRIOR_SOURCE_SHA" \
+              --argjson deploymentRunId "$PRIOR_DEPLOYMENT_RUN_ID" \
+              --argjson deploymentRunAttempt "$PRIOR_DEPLOYMENT_RUN_ATTEMPT" \
+              '.schemaVersion == 1
+                and .archiveRunId == $archiveRunId
+                and .archiveRunAttempt == $archiveRunAttempt
+                and .sourceSha == $sourceSha
+                and .deploymentRunId == $deploymentRunId
+                and .deploymentRunAttempt == $deploymentRunAttempt' \
+              "prior-archive/${pointer_name}" >/dev/null
             echo "download=false" >> "$GITHUB_OUTPUT"
           else
             echo "download=true" >> "$GITHUB_OUTPUT"
@@ -624,118 +809,226 @@ jobs:
         if: steps.prior-archive.outputs.download == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRIOR_DEPLOYMENT_RUN_ATTEMPT: ${{ steps.prior.outputs.deployment_run_attempt }}
+          PRIOR_DEPLOYMENT_RUN_ID: ${{ steps.prior.outputs.deployment_run_id }}
+          PRIOR_RUN_ATTEMPT: ${{ steps.prior.outputs.run_attempt }}
+          PRIOR_RUN_ID: ${{ steps.prior.outputs.run_id }}
           PRIOR_SOURCE_SHA: ${{ steps.prior.outputs.source_sha }}
         run: |
           mkdir -p prior-archive
-          archive_tag="docs-pages-archive-${PRIOR_RUN_ID}"
+          archive_tag="docs-pages-deployment-v1-${PRIOR_DEPLOYMENT_RUN_ID}-${PRIOR_DEPLOYMENT_RUN_ATTEMPT}"
           archive_name="github-pages-${PRIOR_RUN_ID}.tar"
           checksum_name="${archive_name}.sha256"
+          pointer_name="deployment-${PRIOR_DEPLOYMENT_RUN_ID}-${PRIOR_DEPLOYMENT_RUN_ATTEMPT}.json"
           mv prior-download/artifact.tar "prior-archive/${archive_name}"
           (
             cd prior-archive
             sha256sum "$archive_name" > "$checksum_name"
             sha256sum -c "$checksum_name"
           )
+          printf \
+            '{"schemaVersion":1,"archiveRunId":%s,"archiveRunAttempt":%s,"sourceSha":"%s","deploymentRunId":%s,"deploymentRunAttempt":%s}\n' \
+            "$PRIOR_RUN_ID" \
+            "$PRIOR_RUN_ATTEMPT" \
+            "$PRIOR_SOURCE_SHA" \
+            "$PRIOR_DEPLOYMENT_RUN_ID" \
+            "$PRIOR_DEPLOYMENT_RUN_ATTEMPT" \
+            > "prior-archive/${pointer_name}"
           gh release create "$archive_tag" \
             "prior-archive/${archive_name}" \
             "prior-archive/${checksum_name}" \
+            "prior-archive/${pointer_name}" \
             --latest=false \
             --prerelease \
             --target "$PRIOR_SOURCE_SHA" \
-            --title "Documentation deployment archive ${PRIOR_RUN_ID}" \
+            --title "Documentation deployment ${PRIOR_DEPLOYMENT_RUN_ID}/${PRIOR_DEPLOYMENT_RUN_ATTEMPT}" \
             --notes "Automation-owned Pages artifact for exact rollback."
           mkdir prior-verify
           gh release download "$archive_tag" \
             --pattern "$archive_name" \
             --pattern "$checksum_name" \
+            --pattern "$pointer_name" \
             --dir prior-verify
           (
             cd prior-verify
             sha256sum -c "$checksum_name"
           )
 
-      - name: Download current Pages artifact
+  stage-pages-release:
+    if: >-
+      always() &&
+      needs.build.result == 'success' &&
+      needs.build.outputs.recovery_stale != 'true' &&
+      (
+        inputs.rollback_run_id != '' ||
+        (
+          github.event_name == 'push' &&
+          needs.retain-pages-artifacts.result == 'success'
+        )
+      )
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - retain-pages-artifacts
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download candidate Pages artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: github-pages
-          path: current-archive
+          path: candidate
 
-      - name: Retain and verify current Pages artifact
+      - name: Stage and verify mutable deployment release
         env:
+          ARCHIVE_RUN_ATTEMPT: >-
+            ${{
+              inputs.rollback_run_id != '' &&
+              inputs.rollback_run_attempt ||
+              github.run_attempt
+            }}
+          ARCHIVE_RUN_ID: >-
+            ${{
+              inputs.rollback_run_id != '' &&
+              inputs.rollback_run_id ||
+              github.run_id
+            }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PRIOR_RUN_ID: ${{ steps.prior.outputs.run_id }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
         run: |
-          archive_tag="docs-pages-archive-${GITHUB_RUN_ID}"
-          archive_name="github-pages-${GITHUB_RUN_ID}.tar"
+          if [[ ! "$ARCHIVE_RUN_ID" =~ ^[0-9]+$ ||
+                ! "$ARCHIVE_RUN_ATTEMPT" =~ ^[0-9]+$ ||
+                ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Candidate deployment identity is invalid." >&2
+            exit 1
+          fi
+          release_tag="docs-pages-deployment-v1-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          archive_name="github-pages-${ARCHIVE_RUN_ID}.tar"
           checksum_name="${archive_name}.sha256"
-          mv current-archive/artifact.tar "current-archive/${archive_name}"
+          pointer_name="deployment-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
+          mv candidate/artifact.tar "candidate/${archive_name}"
           (
-            cd current-archive
+            cd candidate
             sha256sum "$archive_name" > "$checksum_name"
             sha256sum -c "$checksum_name"
           )
+          printf \
+            '{"schemaVersion":1,"archiveRunId":%s,"archiveRunAttempt":%s,"sourceSha":"%s","deploymentRunId":%s,"deploymentRunAttempt":%s}\n' \
+            "$ARCHIVE_RUN_ID" \
+            "$ARCHIVE_RUN_ATTEMPT" \
+            "$SOURCE_SHA" \
+            "$GITHUB_RUN_ID" \
+            "$GITHUB_RUN_ATTEMPT" \
+            > "candidate/${pointer_name}"
           release="$(
             gh api \
-              "repos/${GITHUB_REPOSITORY}/releases/tags/${archive_tag}" \
-              --jq '
+              --paginate \
+              --slurp \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+              jq -r --arg tag "$release_tag" '
                 [
-                  .immutable,
-                  .target_commitish,
-                  (.assets | length),
-                  ([.assets[].name] | sort | join(","))
+                  .[][]
+                  | select(.tag_name == $tag)
                 ]
+                | if length > 1 then
+                    error("duplicate candidate release")
+                  else
+                    (first // empty)
+                  end
+                | [
+                    .id,
+                    .draft,
+                    .immutable,
+                    .target_commitish,
+                    (.assets | length),
+                    ([.assets[].name] | sort | join(","))
+                  ]
                 | @tsv
-              ' 2>/dev/null ||
-              true
+              '
           )"
           if [[ -z "$release" ]]; then
-            gh release create "$archive_tag" \
-              "current-archive/${archive_name}" \
-              "current-archive/${checksum_name}" \
+            gh release create "$release_tag" \
+              "candidate/${archive_name}" \
+              "candidate/${checksum_name}" \
+              "candidate/${pointer_name}" \
+              --draft \
               --latest=false \
               --prerelease \
-              --target "$GITHUB_SHA" \
-              --title "Documentation deployment archive ${GITHUB_RUN_ID}" \
-              --notes "Automation-owned Pages artifact for exact rollback."
-          else
-            IFS=$'\t' read -r immutable target asset_count asset_names \
-              <<<"$release"
-            if [[ "$immutable" != true ||
-                  "$target" != "$GITHUB_SHA" ||
-                  "$asset_count" != 2 ||
-                  "$asset_names" != "${archive_name},${checksum_name}" ]]; then
-              echo "Current rollback release is invalid." >&2
-              exit 1
-            fi
-            mkdir current-existing
-            gh release download "$archive_tag" \
-              --pattern "$archive_name" \
-              --pattern "$checksum_name" \
-              --dir current-existing
-            (
-              cd current-existing
-              sha256sum -c "$checksum_name"
-            )
-            mkdir current-tree existing-tree
-            tar -xf "current-archive/${archive_name}" -C current-tree
-            tar -xf "current-existing/${archive_name}" -C existing-tree
-            diff --no-dereference --recursive current-tree existing-tree
+              --target "$SOURCE_SHA" \
+              --title "Documentation deployment ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" \
+              --notes "Automation-owned exact deployment candidate."
           fi
-
-          mkdir current-verify
-          gh release download "$archive_tag" \
-            --pattern "$archive_name" \
-            --pattern "$checksum_name" \
-            --dir current-verify
+          release="$(
+            gh api \
+              --paginate \
+              --slurp \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+              jq -r --arg tag "$release_tag" '
+                [
+                  .[][]
+                  | select(.tag_name == $tag)
+                ]
+                | if length != 1 then
+                    error("candidate release is unavailable or duplicated")
+                  else
+                    first
+                  end
+                | [
+                    .id,
+                    .draft,
+                    .immutable,
+                    .target_commitish,
+                    (.assets | length),
+                    ([.assets[].name] | sort | join(","))
+                  ]
+                | @tsv
+              '
+          )"
+          IFS=$'\t' read -r release_id draft immutable target \
+            asset_count asset_names <<<"$release"
+          if [[ ! "$release_id" =~ ^[0-9]+$ ||
+                "$target" != "$SOURCE_SHA" ||
+                "$asset_count" != 3 ||
+                "$asset_names" != "${pointer_name},${archive_name},${checksum_name}" ||
+                ! (
+                  (
+                    "$draft" == true &&
+                    "$immutable" == false
+                  ) ||
+                  (
+                    "$draft" == false &&
+                    "$immutable" == true
+                  )
+                ) ]]; then
+            echo "Candidate deployment release is invalid." >&2
+            exit 1
+          fi
+          mkdir candidate-verify
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+            --jq '.assets[] | [.name, .id] | @tsv' |
+            while IFS=$'\t' read -r name asset_id; do
+              gh api \
+                -H "Accept: application/octet-stream" \
+                "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" \
+                > "candidate-verify/${name}"
+            done
           (
-            cd current-verify
+            cd candidate-verify
             sha256sum -c "$checksum_name"
           )
+          cmp "candidate/${pointer_name}" "candidate-verify/${pointer_name}"
+          mkdir candidate-tree verify-tree
+          tar -xf "candidate/${archive_name}" -C candidate-tree
+          tar -xf "candidate-verify/${archive_name}" -C verify-tree
+          diff --no-dereference --recursive candidate-tree verify-tree
 
   deploy:
     if: >-
       always() &&
       needs.build.result == 'success' &&
+      needs.stage-pages-release.result == 'success' &&
       needs.build.outputs.recovery_stale != 'true' &&
       (
         inputs.rollback_run_id != '' ||
@@ -751,6 +1044,7 @@ jobs:
     needs:
       - build
       - retain-pages-artifacts
+      - stage-pages-release
     permissions:
       contents: read
       id-token: write
@@ -814,11 +1108,18 @@ jobs:
       - build
       - deploy
       - production-smoke
+      - stage-pages-release
     permissions:
       contents: write
     steps:
       - name: Record exact currently deployable archive
         env:
+          ARCHIVE_RUN_ATTEMPT: >-
+            ${{
+              inputs.rollback_run_id != '' &&
+              inputs.rollback_run_attempt ||
+              github.run_attempt
+            }}
           ARCHIVE_RUN_ID: >-
             ${{
               inputs.rollback_run_id != '' &&
@@ -829,65 +1130,93 @@ jobs:
           SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
         run: |
           if [[ ! "$ARCHIVE_RUN_ID" =~ ^[0-9]+$ ||
+                ! "$ARCHIVE_RUN_ATTEMPT" =~ ^[0-9]+$ ||
                 ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Deployment identity is invalid." >&2
             exit 1
           fi
-          pointer_name="deployment-${GITHUB_RUN_ID}.json"
-          printf \
-            '{"archiveRunId":"%s","sourceSha":"%s","deploymentRunId":"%s"}\n' \
-            "$ARCHIVE_RUN_ID" \
-            "$SOURCE_SHA" \
-            "$GITHUB_RUN_ID" \
-            > "$pointer_name"
-          pointer_tag="docs-pages-deployment-${GITHUB_RUN_ID}"
+          archive_name="github-pages-${ARCHIVE_RUN_ID}.tar"
+          checksum_name="${archive_name}.sha256"
+          pointer_name="deployment-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
+          pointer_tag="docs-pages-deployment-v1-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           release="$(
             gh api \
-              "repos/${GITHUB_REPOSITORY}/releases/tags/${pointer_tag}" \
-              --jq '
+              --paginate \
+              --slurp \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+              jq -r --arg tag "$pointer_tag" '
                 [
-                  .immutable,
-                  .target_commitish,
-                  (.assets | length),
-                  (.assets[0].id // empty),
-                  (.assets[0].name // empty)
+                  .[][]
+                  | select(.tag_name == $tag)
                 ]
+                | if length != 1 then
+                    error("candidate release is unavailable or duplicated")
+                  else
+                    first
+                  end
+                | [
+                    .id,
+                    .draft,
+                    .immutable,
+                    .target_commitish,
+                    (.assets | length),
+                    ([.assets[].name] | sort | join(","))
+                  ]
                 | @tsv
-              ' 2>/dev/null ||
-              true
+              '
           )"
-          if [[ -z "$release" ]]; then
-            gh release create "$pointer_tag" \
-              "$pointer_name" \
-              --latest=false \
-              --prerelease \
-              --target "$SOURCE_SHA" \
-              --title "Documentation deployment ${GITHUB_RUN_ID}" \
-              --notes "Automation-owned exact deployment pointer."
-          else
-            IFS=$'\t' read -r immutable target asset_count \
-              existing_asset_id existing_asset_name <<<"$release"
-            if [[ "$immutable" != true ||
-                  "$target" != "$SOURCE_SHA" ||
-                  "$asset_count" != 1 ||
-                  "$existing_asset_name" != "$pointer_name" ||
-                  ! "$existing_asset_id" =~ ^[0-9]+$ ]]; then
-              echo "Deployment pointer release is invalid." >&2
-              exit 1
-            fi
-            mkdir existing-pointer
+          IFS=$'\t' read -r release_id draft immutable target \
+            asset_count asset_names <<<"$release"
+          if [[ ! "$release_id" =~ ^[0-9]+$ ||
+                "$target" != "$SOURCE_SHA" ||
+                "$asset_count" != 3 ||
+                "$asset_names" != "${pointer_name},${archive_name},${checksum_name}" ||
+                ! (
+                  (
+                    "$draft" == true &&
+                    "$immutable" == false
+                  ) ||
+                  (
+                    "$draft" == false &&
+                    "$immutable" == true
+                  )
+                ) ]]; then
+            echo "Deployment candidate release is invalid." >&2
+            exit 1
+          fi
+          if [[ "$draft" == true ]]; then
             gh api \
-              -H "Accept: application/octet-stream" \
-              "repos/${GITHUB_REPOSITORY}/releases/assets/${existing_asset_id}" \
-              > "existing-pointer/${pointer_name}"
-            cmp "$pointer_name" "existing-pointer/${pointer_name}"
+              --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+              -F draft=false >/dev/null
+          fi
+          published="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+              --jq '[.draft, .immutable, .target_commitish, (.assets | length), ([.assets[].name] | sort | join(","))] | @tsv'
+          )"
+          IFS=$'\t' read -r draft immutable target asset_count asset_names \
+            <<<"$published"
+          if [[ "$draft" != false ||
+                "$immutable" != true ||
+                "$target" != "$SOURCE_SHA" ||
+                "$asset_count" != 3 ||
+                "$asset_names" != "${pointer_name},${archive_name},${checksum_name}" ]]; then
+            echo "Published deployment release is invalid." >&2
+            exit 1
           fi
 
-  recover-after-smoke-failure:
+  recover-after-production-failure:
     if: >-
       always() &&
       needs.deploy.result == 'success' &&
-      needs.production-smoke.result == 'failure' &&
+      (
+        needs.production-smoke.result == 'failure' ||
+        (
+          needs.production-smoke.result == 'success' &&
+          needs.record-production-deployment.result == 'failure'
+        )
+      ) &&
       (
         (
           github.event_name == 'push' &&
@@ -903,6 +1232,7 @@ jobs:
       - retain-pages-artifacts
       - deploy
       - production-smoke
+      - record-production-deployment
     permissions:
       actions: write
       contents: read
@@ -910,13 +1240,20 @@ jobs:
       - name: Dispatch exact retained recovery
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRIOR_DEPLOYMENT_RUN_ATTEMPT: >-
+            ${{ needs.retain-pages-artifacts.outputs.prior_deployment_run_attempt }}
           PRIOR_DEPLOYMENT_RUN_ID: >-
             ${{ needs.retain-pages-artifacts.outputs.prior_deployment_run_id }}
+          PRIOR_RUN_ATTEMPT: >-
+            ${{ needs.retain-pages-artifacts.outputs.prior_run_attempt }}
           PRIOR_RUN_ID: ${{ needs.retain-pages-artifacts.outputs.prior_run_id }}
+          REQUESTED_ROLLBACK_RUN_ATTEMPT: ${{ inputs.rollback_run_attempt }}
           REQUESTED_ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
         run: |
           recovery_run_id="$PRIOR_RUN_ID"
+          recovery_run_attempt="$PRIOR_RUN_ATTEMPT"
           expected_pointer_run_id="$PRIOR_DEPLOYMENT_RUN_ID"
+          expected_pointer_run_attempt="$PRIOR_DEPLOYMENT_RUN_ATTEMPT"
           if [[ -n "$REQUESTED_ROLLBACK_RUN_ID" ]]; then
             pointer="$(
               gh api \
@@ -928,7 +1265,7 @@ jobs:
                     .[][]
                     | select(
                         .tag_name
-                        | startswith("docs-pages-deployment-")
+                        | startswith("docs-pages-deployment-v1-")
                       )
                     | select(.draft == false and .immutable == true)
                   ]
@@ -937,18 +1274,50 @@ jobs:
                   | [
                       .tag_name,
                       (.assets | length),
-                      (.assets[0].id // empty),
-                      (.assets[0].name // empty)
+                      ([
+                        .assets[]
+                        | select(
+                            .name
+                            | (
+                                startswith("deployment-")
+                                and endswith(".json")
+                              )
+                          )
+                      ] | length),
+                      ([
+                        .assets[]
+                        | select(
+                            .name
+                            | (
+                                startswith("deployment-")
+                                and endswith(".json")
+                              )
+                          )
+                      ][0].id // empty),
+                      ([
+                        .assets[]
+                        | select(
+                            .name
+                            | (
+                                startswith("deployment-")
+                                and endswith(".json")
+                              )
+                          )
+                      ][0].name // empty)
                     ]
                   | @tsv
                 '
             )"
-            IFS=$'\t' read -r pointer_tag pointer_asset_count \
+            IFS=$'\t' read -r pointer_tag asset_count pointer_count \
               pointer_asset_id pointer_asset_name <<<"$pointer"
-            pointer_run_id="${pointer_tag#docs-pages-deployment-}"
+            pointer_key="${pointer_tag#docs-pages-deployment-v1-}"
+            pointer_run_id="${pointer_key%-*}"
+            pointer_run_attempt="${pointer_key##*-}"
             if [[ ! "$pointer_run_id" =~ ^[0-9]+$ ||
-                  "$pointer_asset_count" != 1 ||
-                  "$pointer_asset_name" != "deployment-${pointer_run_id}.json" ||
+                  ! "$pointer_run_attempt" =~ ^[0-9]+$ ||
+                  "$asset_count" != 3 ||
+                  "$pointer_count" != 1 ||
+                  "$pointer_asset_name" != "deployment-${pointer_run_id}-${pointer_run_attempt}.json" ||
                   ! "$pointer_asset_id" =~ ^[0-9]+$ ]]; then
               echo "The last known-good deployment pointer is unavailable." >&2
               exit 1
@@ -960,28 +1329,44 @@ jobs:
             recovery_run_id="$(
               jq -r '.archiveRunId // empty' prior-deployment.json
             )"
+            recovery_run_attempt="$(
+              jq -r '.archiveRunAttempt // empty' prior-deployment.json
+            )"
             expected_pointer_run_id="$(
               jq -r '.deploymentRunId // empty' prior-deployment.json
             )"
-            if [[ "$expected_pointer_run_id" != "$pointer_run_id" ]]; then
+            expected_pointer_run_attempt="$(
+              jq -r '.deploymentRunAttempt // empty' prior-deployment.json
+            )"
+            if ! jq -e \
+              --argjson deploymentRunId "$pointer_run_id" \
+              --argjson deploymentRunAttempt "$pointer_run_attempt" \
+              '.schemaVersion == 1
+                and .deploymentRunId == $deploymentRunId
+                and .deploymentRunAttempt == $deploymentRunAttempt' \
+              prior-deployment.json >/dev/null; then
               echo "The last known-good deployment pointer is invalid." >&2
               exit 1
             fi
-            if [[ "$recovery_run_id" == "$REQUESTED_ROLLBACK_RUN_ID" ]]; then
+            if [[ "$recovery_run_id" == "$REQUESTED_ROLLBACK_RUN_ID" &&
+                  "$recovery_run_attempt" == "$REQUESTED_ROLLBACK_RUN_ATTEMPT" ]]; then
               echo "The last known-good artifact also failed smoke; automatic recovery stopped." >&2
               exit 1
             fi
           fi
-          if [[ ! "$recovery_run_id" =~ ^[0-9]+$ ]]; then
-            echo "Retained recovery run ID is unavailable." >&2
+          if [[ ! "$recovery_run_id" =~ ^[0-9]+$ ||
+                ! "$recovery_run_attempt" =~ ^[0-9]+$ ]]; then
+            echo "Retained recovery run is unavailable." >&2
             exit 1
           fi
-          if [[ "$expected_pointer_run_id" != none &&
-                ! "$expected_pointer_run_id" =~ ^[0-9]+$ ]]; then
-            echo "Retained deployment pointer run ID is unavailable." >&2
+          if [[ ! "$expected_pointer_run_id" =~ ^[0-9]+$ ||
+                ! "$expected_pointer_run_attempt" =~ ^[0-9]+$ ]]; then
+            echo "Retained deployment pointer is unavailable." >&2
             exit 1
           fi
           gh workflow run docs.yml \
             --ref main \
             -f "rollback_run_id=${recovery_run_id}" \
-            -f "expected_pointer_run_id=${expected_pointer_run_id}"
+            -f "rollback_run_attempt=${recovery_run_attempt}" \
+            -f "expected_pointer_run_id=${expected_pointer_run_id}" \
+            -f "expected_pointer_run_attempt=${expected_pointer_run_attempt}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,53 @@ env:
   GH_REPO: ${{ github.repository }}
 
 jobs:
+  validate:
+    if: inputs.rollback_run_id == ''
+    strategy:
+      fail-fast: false
+      matrix:
+        gate:
+          - manifests
+          - runtime
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          global-json-file: global.json
+
+      - name: Cache immutable documentation packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: /tmp/humanizer-docs-nuget/**/*.nupkg
+          key: >-
+            docs-nuget-v2-${{ runner.os }}-${{
+              hashFiles(
+                'website/humanizer-versions.json',
+                'nuget.config',
+                '.config/dotnet-tools.json'
+              )
+            }}
+
+      - name: Restore documentation tools
+        run: dotnet tool restore
+
+      - name: Validate manifests, snapshots, APIs, and examples
+        if: matrix.gate == 'manifests'
+        shell: pwsh
+        run: ./tools/docs/build.ps1 -Mode Validate
+
+      - name: Validate snapshot transactions and Native AOT
+        if: matrix.gate == 'runtime'
+        shell: pwsh
+        run: ./tools/docs/test.ps1 -RequireNativeAot
+
   build:
     outputs:
       bootstrap_rollback: >-
@@ -86,37 +133,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: website/pnpm-lock.yaml
 
-      - name: Cache immutable documentation packages
-        if: inputs.rollback_run_id == ''
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: /tmp/humanizer-docs-nuget/**/*.nupkg
-          key: >-
-            docs-nuget-v2-${{ runner.os }}-${{
-              hashFiles(
-                'website/humanizer-versions.json',
-                'nuget.config',
-                '.config/dotnet-tools.json'
-              )
-            }}
-
-      - name: Restore documentation tools
-        if: inputs.rollback_run_id == ''
-        run: dotnet tool restore
-
       - name: Restore site dependencies
         if: inputs.rollback_run_id == ''
         run: pnpm --dir website install --frozen-lockfile
-
-      - name: Validate manifests, snapshots, APIs, and examples
-        if: inputs.rollback_run_id == ''
-        shell: pwsh
-        run: ./tools/docs/build.ps1 -Mode Validate
-
-      - name: Validate snapshot transactions and Native AOT
-        if: inputs.rollback_run_id == ''
-        shell: pwsh
-        run: ./tools/docs/test.ps1 -RequireNativeAot
 
       - name: Validate content
         if: inputs.rollback_run_id == ''
@@ -345,6 +364,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      - validate
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -371,7 +371,10 @@ jobs:
               jq -r '
                 [
                   .[].workflow_runs[]
-                  | select(.path == ".github/workflows/docs.yml")
+                  | select(
+                      .path == ".github/workflows/docs.yml"
+                      and .run_attempt == 1
+                    )
                 ]
                 | sort_by(.created_at)
                 | last
@@ -382,7 +385,10 @@ jobs:
               jq -r '
                 [
                   .[].workflow_runs[]
-                  | select(.path == ".github/workflows/jekyll-gh-pages.yml")
+                  | select(
+                      .path == ".github/workflows/jekyll-gh-pages.yml"
+                      and .run_attempt == 1
+                    )
                 ]
                 | sort_by(.created_at)
                 | last
@@ -920,7 +926,10 @@ jobs:
                   jq -r '
                     [
                       .[].workflow_runs[]
-                      | select(.path == ".github/workflows/docs.yml")
+                      | select(
+                          .path == ".github/workflows/docs.yml"
+                          and .run_attempt == 1
+                        )
                     ]
                     | sort_by(.created_at)
                     | last
@@ -931,7 +940,10 @@ jobs:
                   jq -r '
                     [
                       .[].workflow_runs[]
-                      | select(.path == ".github/workflows/jekyll-gh-pages.yml")
+                      | select(
+                          .path == ".github/workflows/jekyll-gh-pages.yml"
+                          and .run_attempt == 1
+                        )
                     ]
                     | sort_by(.created_at)
                     | last
@@ -957,7 +969,10 @@ jobs:
               jq -r '
                 [
                   .[].workflow_runs[]
-                  | select(.path == ".github/workflows/docs.yml")
+                  | select(
+                      .path == ".github/workflows/docs.yml"
+                      and .run_attempt == 1
+                    )
                 ]
                 | sort_by(.created_at)
                 | (last // empty)
@@ -970,7 +985,10 @@ jobs:
                 jq -r '
                   [
                     .[].workflow_runs[]
-                    | select(.path == ".github/workflows/jekyll-gh-pages.yml")
+                    | select(
+                        .path == ".github/workflows/jekyll-gh-pages.yml"
+                        and .run_attempt == 1
+                      )
                   ]
                   | sort_by(.created_at)
                   | (last // empty)
@@ -1105,6 +1123,10 @@ jobs:
           checksum_name="${archive_name}.sha256"
           pointer_name="deployment-${PRIOR_DEPLOYMENT_RUN_ID}-${PRIOR_DEPLOYMENT_RUN_ATTEMPT}.json"
           if [[ "$PRIOR_SOURCE_PATH" == ".github/workflows/docs.yml" ]]; then
+            if [[ "$PRIOR_RUN_ATTEMPT" != 1 ]]; then
+              echo "A rerun pre-staging artifact cannot prove its exact attempt." >&2
+              exit 1
+            fi
             if ! tar -xOf prior-download/artifact.tar ./deployment.json \
               > prior-download/deployment.json; then
               echo "Prior Pages artifact has no deployment identity." >&2
@@ -1112,13 +1134,9 @@ jobs:
             fi
             if ! jq -e \
               --arg sourceSha "$PRIOR_SOURCE_SHA" \
-              --argjson archiveRunId "$PRIOR_RUN_ID" \
-              --argjson archiveRunAttempt "$PRIOR_RUN_ATTEMPT" \
-              '.sourceSha == $sourceSha
-                and .archiveRunId == $archiveRunId
-                and .archiveRunAttempt == $archiveRunAttempt' \
+              '.sourceSha == $sourceSha' \
               prior-download/deployment.json >/dev/null; then
-              echo "Prior Pages artifact does not match its selected workflow attempt." >&2
+              echo "Prior Pages artifact does not match its selected workflow source." >&2
               exit 1
             fi
           elif [[ "$PRIOR_SOURCE_PATH" == ".github/workflows/jekyll-gh-pages.yml" ]]; then

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -336,7 +336,7 @@ jobs:
                 "repos/${GITHUB_REPOSITORY}/actions/runs/${ROLLBACK_RUN_ID}/attempts/${ROLLBACK_RUN_ATTEMPT}/jobs?per_page=100" |
                 jq -r '
                   [
-                    .[][].jobs[]
+                    .[].jobs[]
                     | select(
                         .name == "build"
                         and .conclusion == "success"
@@ -560,7 +560,7 @@ jobs:
                   "repos/${GITHUB_REPOSITORY}/actions/runs/${deployment_run_id}/attempts/${phase_attempt}/jobs?per_page=100" |
                   jq -r --arg name "$phase_name" '
                     [
-                      .[][].jobs[]
+                      .[].jobs[]
                       | select(
                           .name == $name
                           and .conclusion == "success"
@@ -845,7 +845,7 @@ jobs:
                       "repos/${GITHUB_REPOSITORY}/actions/runs/${deployment_run_id}/attempts/${phase_attempt}/jobs?per_page=100" |
                       jq -r --arg name "$phase_name" '
                         [
-                          .[][].jobs[]
+                          .[].jobs[]
                           | select(
                               .name == $name
                               and .conclusion == "success"
@@ -897,7 +897,7 @@ jobs:
                     "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/attempts/${run_attempt}/jobs?per_page=100" |
                     jq -r '
                       [
-                        .[][].jobs[]
+                        .[].jobs[]
                         | select(
                             .name == "build"
                             and .conclusion == "success"
@@ -1559,7 +1559,7 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${stage_run_attempt}/jobs?per_page=100" |
               jq -r '
                 [
-                  .[][].jobs[]
+                  .[].jobs[]
                   | select(
                       .name == "stage-pages-release"
                       and .conclusion == "success"
@@ -1584,7 +1584,7 @@ jobs:
                 "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${attempt}/jobs?per_page=100" |
                 jq -r '
                   [
-                    .[][].jobs[]
+                    .[].jobs[]
                     | select(
                         (
                           .name == "deploy"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1410,6 +1410,7 @@ jobs:
       - production-smoke
       - stage-pages-release
     permissions:
+      actions: read
       contents: write
     steps:
       - name: Record exact currently deployable archive

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -979,17 +979,25 @@ jobs:
             if [[ -z "$prior" ]]; then
               prior="$(
                 jq -r '
-                  [
-                    .[].workflow_runs[]
-                    | select(
-                        .path == ".github/workflows/jekyll-gh-pages.yml"
-                        and .run_attempt == 1
-                      )
-                  ]
-                  | sort_by(.created_at)
-                  | (last // empty)
-                  | [.id, .run_attempt, .head_sha, .path]
-                  | @tsv
+                  . as $runs
+                  | if any(
+                      $runs[].workflow_runs[];
+                      .path == ".github/workflows/docs.yml"
+                    ) then
+                      empty
+                    else
+                      [
+                        $runs[].workflow_runs[]
+                        | select(
+                            .path == ".github/workflows/jekyll-gh-pages.yml"
+                            and .run_attempt == 1
+                          )
+                      ]
+                      | sort_by(.created_at)
+                      | (last // empty)
+                      | [.id, .run_attempt, .head_sha, .path]
+                      | @tsv
+                    end
                 ' <<<"$runs"
               )"
             fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -984,7 +984,11 @@ jobs:
             deployment_run_id deployment_run_attempt <<<"$prior"
           if [[ ! "$run_id" =~ ^[0-9]+$ ||
                 ! "$run_attempt" =~ ^[0-9]+$ ||
-                ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
+                ! "$source_sha" =~ ^[0-9a-f]{40}$ ||
+                (
+                  "$source_path" != ".github/workflows/docs.yml" &&
+                  "$source_path" != ".github/workflows/jekyll-gh-pages.yml"
+                ) ]]; then
             echo "No successful main documentation deployment is available to retain." >&2
             exit 1
           fi
@@ -995,6 +999,7 @@ jobs:
             echo "run_attempt=${run_attempt}"
             echo "run_id=${run_id}"
             echo "source_sha=${source_sha}"
+            echo "source_path=${source_path}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Inspect retained prior artifact
@@ -1092,12 +1097,39 @@ jobs:
           PRIOR_RUN_ATTEMPT: ${{ steps.prior.outputs.run_attempt }}
           PRIOR_RUN_ID: ${{ steps.prior.outputs.run_id }}
           PRIOR_SOURCE_SHA: ${{ steps.prior.outputs.source_sha }}
+          PRIOR_SOURCE_PATH: ${{ steps.prior.outputs.source_path }}
         run: |
           mkdir -p prior-archive
           archive_tag="docs-pages-deployment-v1-${PRIOR_DEPLOYMENT_RUN_ID}-${PRIOR_DEPLOYMENT_RUN_ATTEMPT}"
           archive_name="github-pages-${PRIOR_RUN_ID}-${PRIOR_RUN_ATTEMPT}.tar"
           checksum_name="${archive_name}.sha256"
           pointer_name="deployment-${PRIOR_DEPLOYMENT_RUN_ID}-${PRIOR_DEPLOYMENT_RUN_ATTEMPT}.json"
+          if [[ "$PRIOR_SOURCE_PATH" == ".github/workflows/docs.yml" ]]; then
+            if ! tar -xOf prior-download/artifact.tar ./deployment.json \
+              > prior-download/deployment.json; then
+              echo "Prior Pages artifact has no deployment identity." >&2
+              exit 1
+            fi
+            if ! jq -e \
+              --arg sourceSha "$PRIOR_SOURCE_SHA" \
+              --argjson archiveRunId "$PRIOR_RUN_ID" \
+              --argjson archiveRunAttempt "$PRIOR_RUN_ATTEMPT" \
+              '.sourceSha == $sourceSha
+                and .archiveRunId == $archiveRunId
+                and .archiveRunAttempt == $archiveRunAttempt' \
+              prior-download/deployment.json >/dev/null; then
+              echo "Prior Pages artifact does not match its selected workflow attempt." >&2
+              exit 1
+            fi
+          elif [[ "$PRIOR_SOURCE_PATH" == ".github/workflows/jekyll-gh-pages.yml" ]]; then
+            if [[ "$PRIOR_RUN_ATTEMPT" != 1 ]]; then
+              echo "A rerun legacy artifact cannot prove its exact attempt." >&2
+              exit 1
+            fi
+          else
+            echo "Prior Pages artifact has an invalid workflow source." >&2
+            exit 1
+          fi
           mv prior-download/artifact.tar "prior-archive/${archive_name}"
           (
             cd prior-archive

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -293,10 +293,10 @@ jobs:
                 > current-deployment.json
               if ! jq -e \
                 --argjson deploymentRunId "$current_pointer_run_id" \
-                --argjson deploymentRunAttempt "$current_pointer_run_attempt" \
+                --argjson publicationRunAttempt "$current_pointer_run_attempt" \
                 '.schemaVersion == 1
                   and .deploymentRunId == $deploymentRunId
-                  and .deploymentRunAttempt == $deploymentRunAttempt' \
+                  and .publicationRunAttempt == $publicationRunAttempt' \
                 current-deployment.json >/dev/null; then
                 echo "Current deployment pointer is invalid." >&2
                 exit 1
@@ -323,13 +323,10 @@ jobs:
             echo "Rollback source must be a successful main push." >&2
             exit 1
           fi
-          if [[ "$conclusion" != success ]]; then
-            if [[ "$conclusion" != failure ]]; then
+          if [[ "$path" == ".github/workflows/docs.yml" ]]; then
+            if [[ "$conclusion" != success &&
+                  "$conclusion" != failure ]]; then
               echo "Incomplete workflow attempts are not rollback sources." >&2
-              exit 1
-            fi
-            if [[ "$path" != ".github/workflows/docs.yml" ]]; then
-              echo "Failed workflow attempts are not rollback sources." >&2
               exit 1
             fi
             recovery_jobs="$(
@@ -341,12 +338,7 @@ jobs:
                   [
                     .[][].jobs[]
                     | select(
-                        (
-                          .name == "build"
-                          or .name == "stage-pages-release"
-                          or .name == "deploy"
-                          or .name == "production-smoke"
-                        )
+                        .name == "build"
                         and .conclusion == "success"
                       )
                     | .name
@@ -356,10 +348,13 @@ jobs:
                   | join(",")
                 '
             )"
-            if [[ "$recovery_jobs" != "build,deploy,production-smoke,stage-pages-release" ]]; then
-              echo "Failed workflow attempt lacks successful deployment evidence." >&2
+            if [[ "$recovery_jobs" != "build" ]]; then
+              echo "Workflow attempt lacks successful archive evidence." >&2
               exit 1
             fi
+          elif [[ "$conclusion" != success ]]; then
+            echo "Incomplete legacy workflow attempts are not rollback sources." >&2
+            exit 1
           fi
 
           bootstrap_rollback=false
@@ -416,6 +411,7 @@ jobs:
           inputs.rollback_run_id != '' &&
           steps.rollback-source.outputs.recovery_stale != 'true'
         env:
+          BOOTSTRAP_ROLLBACK: ${{ steps.rollback-source.outputs.bootstrap_rollback }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ROLLBACK_RUN_ATTEMPT: ${{ inputs.rollback_run_attempt }}
           ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
@@ -472,15 +468,88 @@ jobs:
             --argjson archiveRunId "$ROLLBACK_RUN_ID" \
             --argjson archiveRunAttempt "$ROLLBACK_RUN_ATTEMPT" \
             --argjson deploymentRunId "$deployment_run_id" \
-            --argjson deploymentRunAttempt "$deployment_run_attempt" \
+            --argjson publicationRunAttempt "$deployment_run_attempt" \
             --arg sourceSha "$ROLLBACK_SOURCE_SHA" \
             '.schemaVersion == 1
               and .archiveRunId == $archiveRunId
               and .archiveRunAttempt == $archiveRunAttempt
               and .sourceSha == $sourceSha
               and .deploymentRunId == $deploymentRunId
-              and .deploymentRunAttempt == $deploymentRunAttempt' \
+              and .publicationRunAttempt == $publicationRunAttempt' \
             "rollback/${pointer_name}" >/dev/null
+          if [[ "$BOOTSTRAP_ROLLBACK" != true ]]; then
+            phase_attempts="$(
+              jq -r '
+                [
+                  .stageRunAttempt,
+                  .deployRunAttempt,
+                  .smokeRunAttempt,
+                  .publicationRunAttempt
+                ]
+                | @tsv
+              ' "rollback/${pointer_name}"
+            )"
+            IFS=$'\t' read -r stage_run_attempt deploy_run_attempt \
+              smoke_run_attempt publication_run_attempt <<<"$phase_attempts"
+            if [[ "$publication_run_attempt" != "$deployment_run_attempt" ||
+                  ! "$stage_run_attempt" =~ ^[0-9]+$ ||
+                  ! "$deploy_run_attempt" =~ ^[0-9]+$ ||
+                  ! "$smoke_run_attempt" =~ ^[0-9]+$ ]]; then
+              echo "Rollback publication provenance is invalid." >&2
+              exit 1
+            fi
+            publication_run="$(
+              gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${deployment_run_id}/attempts/${publication_run_attempt}" \
+                --jq '[.conclusion, .event, .head_branch, .path, .run_attempt] | @tsv'
+            )"
+            IFS=$'\t' read -r publication_conclusion publication_event \
+              publication_branch publication_path publication_attempt \
+              <<<"$publication_run"
+            if [[ "$publication_branch" != main ||
+                  "$publication_path" != ".github/workflows/docs.yml" ||
+                  "$publication_attempt" != "$publication_run_attempt" ||
+                  (
+                    "$publication_event" != push &&
+                    "$publication_event" != workflow_dispatch
+                  ) ||
+                  (
+                    "$publication_conclusion" != success &&
+                    "$publication_conclusion" != failure
+                  ) ]]; then
+              echo "Rollback publication attempt is invalid." >&2
+              exit 1
+            fi
+            for phase in \
+              "stage-pages-release:${stage_run_attempt}" \
+              "deploy:${deploy_run_attempt}" \
+              "production-smoke:${smoke_run_attempt}"; do
+              phase_name="${phase%%:*}"
+              phase_attempt="${phase##*:}"
+              phase_jobs="$(
+                gh api \
+                  --paginate \
+                  --slurp \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs/${deployment_run_id}/attempts/${phase_attempt}/jobs?per_page=100" |
+                  jq -r --arg name "$phase_name" '
+                    [
+                      .[][].jobs[]
+                      | select(
+                          .name == $name
+                          and .conclusion == "success"
+                        )
+                      | .name
+                    ]
+                    | unique
+                    | join(",")
+                  '
+              )"
+              if [[ "$phase_jobs" != "$phase_name" ]]; then
+                echo "Rollback release lacks exact successful ${phase_name} evidence." >&2
+                exit 1
+              fi
+            done
+          fi
 
       - name: Extract retained Pages artifact for verification
         if: >-
@@ -664,18 +733,26 @@ jobs:
                       .sourceSha,
                       ".github/workflows/docs.yml",
                       .deploymentRunId,
-                      .deploymentRunAttempt
+                      .stageRunAttempt,
+                      .deployRunAttempt,
+                      .smokeRunAttempt,
+                      .publicationRunAttempt
                     ]
                   | @tsv
                 ' prior-deployment.json
               )"
               IFS=$'\t' read -r run_id run_attempt source_sha source_path \
-                deployment_run_id deployment_run_attempt <<<"$prior"
+                deployment_run_id stage_run_attempt deploy_run_attempt \
+                smoke_run_attempt publication_run_attempt <<<"$prior"
+              deployment_run_attempt="$publication_run_attempt"
               if [[ ! "$run_id" =~ ^[0-9]+$ ||
                     ! "$run_attempt" =~ ^[0-9]+$ ||
                     ! "$source_sha" =~ ^[0-9a-f]{40}$ ||
                     "$deployment_run_id" != "$pointer_run_id" ||
-                    "$deployment_run_attempt" != "$pointer_run_attempt" ]]; then
+                    "$publication_run_attempt" != "$pointer_run_attempt" ||
+                    ! "$stage_run_attempt" =~ ^[0-9]+$ ||
+                    ! "$deploy_run_attempt" =~ ^[0-9]+$ ||
+                    ! "$smoke_run_attempt" =~ ^[0-9]+$ ]]; then
                 echo "Latest deployment pointer is invalid." >&2
                 exit 1
               fi
@@ -703,42 +780,44 @@ jobs:
                 echo "Latest deployment pointer is not backed by a successful main documentation run." >&2
                 exit 1
               fi
-              if [[ "$pointer_conclusion" != success ]]; then
-                if [[ "$pointer_conclusion" != failure ]]; then
-                  echo "Incomplete workflow attempts are not deployment pointers." >&2
-                  exit 1
-                fi
-                if [[ "$pointer_path" != ".github/workflows/docs.yml" ]]; then
-                  echo "Failed legacy workflow attempts are not deployment pointers." >&2
-                  exit 1
-                fi
-                pointer_jobs="$(
-                  gh api \
-                    --paginate \
-                    --slurp \
-                    "repos/${GITHUB_REPOSITORY}/actions/runs/${deployment_run_id}/attempts/${deployment_run_attempt}/jobs?per_page=100" |
-                    jq -r '
-                      [
-                        .[][].jobs[]
-                        | select(
-                            (
-                              .name == "stage-pages-release"
-                              or .name == "deploy"
-                              or .name == "production-smoke"
+              if [[ "$pointer_conclusion" != success &&
+                    "$pointer_conclusion" != failure ]]; then
+                echo "Incomplete workflow attempts are not deployment pointers." >&2
+                exit 1
+              fi
+              if [[ "$pointer_path" == ".github/workflows/docs.yml" ]]; then
+                for phase in \
+                  "stage-pages-release:${stage_run_attempt}" \
+                  "deploy:${deploy_run_attempt}" \
+                  "production-smoke:${smoke_run_attempt}"; do
+                  phase_name="${phase%%:*}"
+                  phase_attempt="${phase##*:}"
+                  phase_jobs="$(
+                    gh api \
+                      --paginate \
+                      --slurp \
+                      "repos/${GITHUB_REPOSITORY}/actions/runs/${deployment_run_id}/attempts/${phase_attempt}/jobs?per_page=100" |
+                      jq -r --arg name "$phase_name" '
+                        [
+                          .[][].jobs[]
+                          | select(
+                              .name == $name
+                              and .conclusion == "success"
                             )
-                            and .conclusion == "success"
-                          )
-                        | .name
-                      ]
-                      | unique
-                      | sort
-                      | join(",")
-                    '
-                )"
-                if [[ "$pointer_jobs" != "deploy,production-smoke,stage-pages-release" ]]; then
-                  echo "Failed deployment attempt lacks successful publication evidence." >&2
-                  exit 1
-                fi
+                          | .name
+                        ]
+                        | unique
+                        | join(",")
+                      '
+                  )"
+                  if [[ "$phase_jobs" != "$phase_name" ]]; then
+                    echo "Deployment pointer lacks exact successful ${phase_name} evidence." >&2
+                    exit 1
+                  fi
+                done
+              elif [[ "$pointer_conclusion" != success ]]; then
+                echo "Failed legacy workflow attempts are not deployment pointers." >&2
+                exit 1
               fi
               archive_run="$(
                 gh api \
@@ -759,8 +838,9 @@ jobs:
                 echo "Latest deployment pointer names an invalid archive source." >&2
                 exit 1
               fi
-              if [[ "$archive_conclusion" != success ]]; then
-                if [[ "$archive_conclusion" != failure ]]; then
+              if [[ "$archive_path" == ".github/workflows/docs.yml" ]]; then
+                if [[ "$archive_conclusion" != success &&
+                      "$archive_conclusion" != failure ]]; then
                   echo "Incomplete workflow attempts are not archive sources." >&2
                   exit 1
                 fi
@@ -787,6 +867,9 @@ jobs:
                   echo "Latest deployment pointer lacks successful archive evidence." >&2
                   exit 1
                 fi
+              elif [[ "$archive_conclusion" != success ]]; then
+                echo "Incomplete legacy workflow attempts are not archive sources." >&2
+                exit 1
               fi
               if [[ "$archive_path" == ".github/workflows/jekyll-gh-pages.yml" ]]; then
                 bootstrap_runs="$(
@@ -939,13 +1022,13 @@ jobs:
               --argjson archiveRunAttempt "$PRIOR_RUN_ATTEMPT" \
               --arg sourceSha "$PRIOR_SOURCE_SHA" \
               --argjson deploymentRunId "$PRIOR_DEPLOYMENT_RUN_ID" \
-              --argjson deploymentRunAttempt "$PRIOR_DEPLOYMENT_RUN_ATTEMPT" \
+              --argjson publicationRunAttempt "$PRIOR_DEPLOYMENT_RUN_ATTEMPT" \
               '.schemaVersion == 1
                 and .archiveRunId == $archiveRunId
                 and .archiveRunAttempt == $archiveRunAttempt
                 and .sourceSha == $sourceSha
                 and .deploymentRunId == $deploymentRunId
-                and .deploymentRunAttempt == $deploymentRunAttempt' \
+                and .publicationRunAttempt == $publicationRunAttempt' \
               "prior-archive/${pointer_name}" >/dev/null
             echo "download=false" >> "$GITHUB_OUTPUT"
           else
@@ -984,11 +1067,14 @@ jobs:
             sha256sum -c "$checksum_name"
           )
           printf \
-            '{"schemaVersion":1,"archiveRunId":%s,"archiveRunAttempt":%s,"sourceSha":"%s","deploymentRunId":%s,"deploymentRunAttempt":%s}\n' \
+            '{"schemaVersion":1,"archiveRunId":%s,"archiveRunAttempt":%s,"sourceSha":"%s","deploymentRunId":%s,"stageRunAttempt":%s,"deployRunAttempt":%s,"smokeRunAttempt":%s,"publicationRunAttempt":%s}\n' \
             "$PRIOR_RUN_ID" \
             "$PRIOR_RUN_ATTEMPT" \
             "$PRIOR_SOURCE_SHA" \
             "$PRIOR_DEPLOYMENT_RUN_ID" \
+            "$PRIOR_DEPLOYMENT_RUN_ATTEMPT" \
+            "$PRIOR_DEPLOYMENT_RUN_ATTEMPT" \
+            "$PRIOR_DEPLOYMENT_RUN_ATTEMPT" \
             "$PRIOR_DEPLOYMENT_RUN_ATTEMPT" \
             > "prior-archive/${pointer_name}"
           gh release create "$archive_tag" \
@@ -1050,7 +1136,7 @@ jobs:
             echo "Candidate deployment identity is invalid." >&2
             exit 1
           fi
-          release_tag="docs-pages-deployment-v1-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          release_tag="docs-pages-candidate-v1-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           archive_name="github-pages-${ARCHIVE_RUN_ID}-${ARCHIVE_RUN_ATTEMPT}.tar"
           checksum_name="${archive_name}.sha256"
           pointer_name="deployment-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
@@ -1061,7 +1147,7 @@ jobs:
             sha256sum -c "$checksum_name"
           )
           printf \
-            '{"schemaVersion":1,"archiveRunId":%s,"archiveRunAttempt":%s,"sourceSha":"%s","deploymentRunId":%s,"deploymentRunAttempt":%s}\n' \
+            '{"schemaVersion":1,"archiveRunId":%s,"archiveRunAttempt":%s,"sourceSha":"%s","deploymentRunId":%s,"stageRunAttempt":%s}\n' \
             "$ARCHIVE_RUN_ID" \
             "$ARCHIVE_RUN_ATTEMPT" \
             "$SOURCE_SHA" \
@@ -1268,7 +1354,7 @@ jobs:
             echo "Deployment identity is invalid." >&2
             exit 1
           fi
-          release_prefix="docs-pages-deployment-v1-${GITHUB_RUN_ID}-"
+          release_prefix="docs-pages-candidate-v1-${GITHUB_RUN_ID}-"
           release="$(
             gh api \
               --paginate \
@@ -1357,13 +1443,13 @@ jobs:
                   .archiveRunAttempt,
                   .sourceSha,
                   .deploymentRunId,
-                  .deploymentRunAttempt
+                  .stageRunAttempt
                 ]
               | @tsv
             ' source-deployment.json
           )"
           IFS=$'\t' read -r archive_run_id archive_run_attempt source_sha \
-            deployment_run_id deployment_run_attempt <<<"$source_manifest"
+            deployment_run_id stage_run_attempt <<<"$source_manifest"
           archive_name="github-pages-${archive_run_id}-${archive_run_attempt}.tar"
           checksum_name="${archive_name}.sha256"
           source_pointer_name="deployment-${GITHUB_RUN_ID}-${source_attempt}.json"
@@ -1371,9 +1457,70 @@ jobs:
                 ! "$archive_run_attempt" =~ ^[0-9]+$ ||
                 "$source_sha" != "$SOURCE_SHA" ||
                 "$deployment_run_id" != "$GITHUB_RUN_ID" ||
-                "$deployment_run_attempt" != "$source_attempt" ||
+                "$stage_run_attempt" != "$source_attempt" ||
                 "$asset_names" != "${source_pointer_name},${archive_name},${checksum_name}" ]]; then
             echo "Deployment candidate manifest is invalid." >&2
+            exit 1
+          fi
+          stage_jobs="$(
+            gh api \
+              --paginate \
+              --slurp \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${stage_run_attempt}/jobs?per_page=100" |
+              jq -r '
+                [
+                  .[][].jobs[]
+                  | select(
+                      .name == "stage-pages-release"
+                      and .conclusion == "success"
+                    )
+                  | .name
+                ]
+                | unique
+                | join(",")
+              '
+          )"
+          if [[ "$stage_jobs" != "stage-pages-release" ]]; then
+            echo "Deployment candidate lacks successful staging evidence." >&2
+            exit 1
+          fi
+          deploy_run_attempt=
+          smoke_run_attempt=
+          for ((attempt = 1; attempt <= GITHUB_RUN_ATTEMPT; attempt++)); do
+            successful_jobs="$(
+              gh api \
+                --paginate \
+                --slurp \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${attempt}/jobs?per_page=100" |
+                jq -r '
+                  [
+                    .[][].jobs[]
+                    | select(
+                        (
+                          .name == "deploy"
+                          or .name == "production-smoke"
+                        )
+                        and .conclusion == "success"
+                      )
+                    | .name
+                  ]
+                  | unique
+                  | sort
+                  | join(",")
+                '
+            )"
+            if [[ "$successful_jobs" == "deploy" ||
+                  "$successful_jobs" == "deploy,production-smoke" ]]; then
+              deploy_run_attempt="$attempt"
+            fi
+            if [[ "$successful_jobs" == "deploy,production-smoke" ||
+                  "$successful_jobs" == "production-smoke" ]]; then
+              smoke_run_attempt="$attempt"
+            fi
+          done
+          if [[ ! "$deploy_run_attempt" =~ ^[0-9]+$ ||
+                ! "$smoke_run_attempt" =~ ^[0-9]+$ ]]; then
+            echo "Deployment candidate lacks successful production evidence." >&2
             exit 1
           fi
           curl \
@@ -1384,7 +1531,7 @@ jobs:
             --retry-delay 2 \
             --show-error \
             --silent \
-            "https://humanizr.net/deployment.json?run=${deployment_run_id}&attempt=${deployment_run_attempt}" \
+            "https://humanizr.net/deployment.json?run=${deployment_run_id}&attempt=${GITHUB_RUN_ATTEMPT}" \
             > current-production.json
           if ! jq -e \
             --arg sourceSha "$SOURCE_SHA" \
@@ -1398,8 +1545,102 @@ jobs:
             exit 1
           fi
 
-          pointer_name="$source_pointer_name"
-          pointer_tag="$source_tag"
+          mkdir final
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+            --jq '.assets[] | [.name, .id] | @tsv' |
+            while IFS=$'\t' read -r name asset_id; do
+              if [[ "$name" == "$archive_name" ||
+                    "$name" == "$checksum_name" ]]; then
+                gh api \
+                  -H "Accept: application/octet-stream" \
+                  "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" \
+                  > "final/${name}"
+              fi
+            done
+          (
+            cd final
+            sha256sum -c "$checksum_name"
+          )
+          pointer_name="deployment-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
+          printf \
+            '{"schemaVersion":1,"archiveRunId":%s,"archiveRunAttempt":%s,"sourceSha":"%s","deploymentRunId":%s,"stageRunAttempt":%s,"deployRunAttempt":%s,"smokeRunAttempt":%s,"publicationRunAttempt":%s}\n' \
+            "$archive_run_id" \
+            "$archive_run_attempt" \
+            "$SOURCE_SHA" \
+            "$GITHUB_RUN_ID" \
+            "$stage_run_attempt" \
+            "$deploy_run_attempt" \
+            "$smoke_run_attempt" \
+            "$GITHUB_RUN_ATTEMPT" \
+            > "final/${pointer_name}"
+          pointer_tag="docs-pages-deployment-v1-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          release="$(
+            gh api \
+              --paginate \
+              --slurp \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+              jq -r --arg tag "$pointer_tag" '
+                [
+                  .[][]
+                  | select(.tag_name == $tag)
+                ]
+                | if length > 1 then
+                    error("final release is duplicated")
+                  else
+                    (first // empty)
+                  end
+                | [
+                    .id,
+                    .draft,
+                    .immutable,
+                    .target_commitish,
+                    (.assets | length),
+                    ([.assets[].name] | sort | join(","))
+                  ]
+                | @tsv
+              '
+          )"
+          if [[ -z "$release" ]]; then
+            gh release create "$pointer_tag" \
+              "final/${archive_name}" \
+              "final/${checksum_name}" \
+              "final/${pointer_name}" \
+              --draft \
+              --latest=false \
+              --prerelease \
+              --target "$SOURCE_SHA" \
+              --title "Documentation deployment ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" \
+              --notes "Automation-owned exact deployment release."
+          fi
+          release="$(
+            gh api \
+              --paginate \
+              --slurp \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+              jq -r --arg tag "$pointer_tag" '
+                [
+                  .[][]
+                  | select(.tag_name == $tag)
+                ]
+                | if length != 1 then
+                    error("final release is unavailable or duplicated")
+                  else
+                    first
+                  end
+                | [
+                    .id,
+                    .draft,
+                    .immutable,
+                    .target_commitish,
+                    (.assets | length),
+                    ([.assets[].name] | sort | join(","))
+                  ]
+                | @tsv
+              '
+          )"
+          IFS=$'\t' read -r release_id draft immutable target \
+            asset_count asset_names <<<"$release"
           if [[ ! "$release_id" =~ ^[0-9]+$ ||
                 "$target" != "$SOURCE_SHA" ||
                 "$asset_count" != 3 ||
@@ -1417,6 +1658,21 @@ jobs:
             echo "Deployment publication candidate is invalid." >&2
             exit 1
           fi
+          mkdir final-verify
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+            --jq '.assets[] | [.name, .id] | @tsv' |
+            while IFS=$'\t' read -r name asset_id; do
+              gh api \
+                -H "Accept: application/octet-stream" \
+                "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" \
+                > "final-verify/${name}"
+            done
+          (
+            cd final-verify
+            sha256sum -c "$checksum_name"
+          )
+          cmp "final/${pointer_name}" "final-verify/${pointer_name}"
           if [[ "$draft" == true ]]; then
             gh api \
               --method PATCH \
@@ -1572,16 +1828,16 @@ jobs:
               jq -r '.deploymentRunId // empty' prior-deployment.json
             )"
             expected_pointer_run_attempt="$(
-              jq -r '.deploymentRunAttempt // empty' prior-deployment.json
+              jq -r '.publicationRunAttempt // empty' prior-deployment.json
             )"
             archive_name="github-pages-${recovery_run_id}-${recovery_run_attempt}.tar"
             checksum_name="${archive_name}.sha256"
             if ! jq -e \
               --argjson deploymentRunId "$pointer_run_id" \
-              --argjson deploymentRunAttempt "$pointer_run_attempt" \
+              --argjson publicationRunAttempt "$pointer_run_attempt" \
               '.schemaVersion == 1
                 and .deploymentRunId == $deploymentRunId
-                and .deploymentRunAttempt == $deploymentRunAttempt' \
+                and .publicationRunAttempt == $publicationRunAttempt' \
               prior-deployment.json >/dev/null; then
               echo "The last known-good deployment pointer is invalid." >&2
               exit 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,6 +43,9 @@ env:
 jobs:
   validate:
     if: inputs.rollback_run_id == ''
+    permissions:
+      actions: read
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -477,7 +477,30 @@ jobs:
               and .deploymentRunId == $deploymentRunId
               and .publicationRunAttempt == $publicationRunAttempt' \
             "rollback/${pointer_name}" >/dev/null
-          if [[ "$BOOTSTRAP_ROLLBACK" != true ]]; then
+          manifest_bootstrap="$(
+            jq -r '.bootstrapSource // false' "rollback/${pointer_name}"
+          )"
+          if [[ "$manifest_bootstrap" == true ]]; then
+            bootstrap_publication="$(
+              gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${deployment_run_id}/attempts/${deployment_run_attempt}" \
+                --jq '[.conclusion, .event, .head_branch, .path, .run_attempt] | @tsv'
+            )"
+            IFS=$'\t' read -r bootstrap_conclusion bootstrap_event \
+              bootstrap_branch bootstrap_path bootstrap_attempt \
+              <<<"$bootstrap_publication"
+            if [[ "$bootstrap_conclusion" != success ||
+                  "$bootstrap_event" != push ||
+                  "$bootstrap_branch" != main ||
+                  "$bootstrap_attempt" != "$deployment_run_attempt" ||
+                  (
+                    "$bootstrap_path" != ".github/workflows/docs.yml" &&
+                    "$bootstrap_path" != ".github/workflows/jekyll-gh-pages.yml"
+                  ) ]]; then
+              echo "Rollback bootstrap publication is invalid." >&2
+              exit 1
+            fi
+          elif [[ "$BOOTSTRAP_ROLLBACK" != true ]]; then
             phase_attempts="$(
               jq -r '
                 [
@@ -733,26 +756,36 @@ jobs:
                       .sourceSha,
                       ".github/workflows/docs.yml",
                       .deploymentRunId,
-                      .stageRunAttempt,
-                      .deployRunAttempt,
-                      .smokeRunAttempt,
-                      .publicationRunAttempt
+                      (.stageRunAttempt // 0),
+                      (.deployRunAttempt // 0),
+                      (.smokeRunAttempt // 0),
+                      .publicationRunAttempt,
+                      (.bootstrapSource // false)
                     ]
                   | @tsv
                 ' prior-deployment.json
               )"
               IFS=$'\t' read -r run_id run_attempt source_sha source_path \
                 deployment_run_id stage_run_attempt deploy_run_attempt \
-                smoke_run_attempt publication_run_attempt <<<"$prior"
+                smoke_run_attempt publication_run_attempt bootstrap_source \
+                <<<"$prior"
               deployment_run_attempt="$publication_run_attempt"
               if [[ ! "$run_id" =~ ^[0-9]+$ ||
                     ! "$run_attempt" =~ ^[0-9]+$ ||
                     ! "$source_sha" =~ ^[0-9a-f]{40}$ ||
                     "$deployment_run_id" != "$pointer_run_id" ||
                     "$publication_run_attempt" != "$pointer_run_attempt" ||
-                    ! "$stage_run_attempt" =~ ^[0-9]+$ ||
-                    ! "$deploy_run_attempt" =~ ^[0-9]+$ ||
-                    ! "$smoke_run_attempt" =~ ^[0-9]+$ ]]; then
+                    (
+                      "$bootstrap_source" != true &&
+                      (
+                        ! "$stage_run_attempt" =~ ^[0-9]+$ ||
+                        "$stage_run_attempt" == 0 ||
+                        ! "$deploy_run_attempt" =~ ^[0-9]+$ ||
+                        "$deploy_run_attempt" == 0 ||
+                        ! "$smoke_run_attempt" =~ ^[0-9]+$ ||
+                        "$smoke_run_attempt" == 0
+                      )
+                    ) ]]; then
                 echo "Latest deployment pointer is invalid." >&2
                 exit 1
               fi
@@ -785,7 +818,12 @@ jobs:
                 echo "Incomplete workflow attempts are not deployment pointers." >&2
                 exit 1
               fi
-              if [[ "$pointer_path" == ".github/workflows/docs.yml" ]]; then
+              if [[ "$bootstrap_source" == true ]]; then
+                if [[ "$pointer_conclusion" != success ]]; then
+                  echo "Bootstrap deployment pointers must be successful." >&2
+                  exit 1
+                fi
+              elif [[ "$pointer_path" == ".github/workflows/docs.yml" ]]; then
                 for phase in \
                   "stage-pages-release:${stage_run_attempt}" \
                   "deploy:${deploy_run_attempt}" \
@@ -1067,14 +1105,11 @@ jobs:
             sha256sum -c "$checksum_name"
           )
           printf \
-            '{"schemaVersion":1,"archiveRunId":%s,"archiveRunAttempt":%s,"sourceSha":"%s","deploymentRunId":%s,"stageRunAttempt":%s,"deployRunAttempt":%s,"smokeRunAttempt":%s,"publicationRunAttempt":%s}\n' \
+            '{"schemaVersion":1,"archiveRunId":%s,"archiveRunAttempt":%s,"sourceSha":"%s","deploymentRunId":%s,"publicationRunAttempt":%s,"bootstrapSource":true}\n' \
             "$PRIOR_RUN_ID" \
             "$PRIOR_RUN_ATTEMPT" \
             "$PRIOR_SOURCE_SHA" \
             "$PRIOR_DEPLOYMENT_RUN_ID" \
-            "$PRIOR_DEPLOYMENT_RUN_ATTEMPT" \
-            "$PRIOR_DEPLOYMENT_RUN_ATTEMPT" \
-            "$PRIOR_DEPLOYMENT_RUN_ATTEMPT" \
             "$PRIOR_DEPLOYMENT_RUN_ATTEMPT" \
             > "prior-archive/${pointer_name}"
           gh release create "$archive_tag" \

--- a/website/docs/contributing/documentation.mdx
+++ b/website/docs/contributing/documentation.mdx
@@ -121,13 +121,15 @@ passes. Failed or abandoned attempts therefore cannot become the current
 rollback source.
 
 To restore a retained artifact, find its successful documentation run ID and
-dispatch the same workflow from `main`:
+exact attempt from the run details, then dispatch the same workflow from
+`main`:
 
 ```console
 gh run list --workflow docs.yml --branch main
+gh run view 123456789 --json databaseId,attempt,conclusion
 gh workflow run docs.yml --ref main \
   -f rollback_run_id=123456789 \
-  -f rollback_run_attempt=1
+  -f rollback_run_attempt=<exact-attempt>
 ```
 
 The rollback run verifies the retained artifact's custom domain, stable,

--- a/website/docs/contributing/documentation.mdx
+++ b/website/docs/contributing/documentation.mdx
@@ -115,10 +115,11 @@ pwsh tools/docs/snapshot.ps1 -Version 3.0.10 \
 `.github/workflows/docs.yml` validates every pull request. A successful `main`
 run uploads the complete Docusaurus output as one Pages artifact. After the
 build passes, automation stages the archive, checksum, and deployment manifest
-together in a draft `docs-pages-deployment-v1-<run-id>-<attempt>` prerelease.
-The draft is published and made immutable only after the production smoke test
-passes. Failed or abandoned attempts therefore cannot become the current
-rollback source.
+together in a draft `docs-pages-candidate-v1-<run-id>-<attempt>` prerelease.
+After the production smoke test passes, automation creates and publishes a
+separate immutable `docs-pages-deployment-v1-<run-id>-<attempt>` release.
+Failed or abandoned attempts therefore cannot become the current rollback
+source.
 
 To restore a retained artifact, select its immutable deployment release and
 read the archive run ID and attempt from that release's manifest. These can

--- a/website/docs/contributing/documentation.mdx
+++ b/website/docs/contributing/documentation.mdx
@@ -114,11 +114,10 @@ pwsh tools/docs/snapshot.ps1 -Version 3.0.10 \
 
 `.github/workflows/docs.yml` validates every pull request. A successful `main`
 run uploads the complete Docusaurus output as one Pages artifact. After the
-production smoke test passes, automation stores that exact archive in the
-immutable `docs-pages-archive-<run-id>` prerelease and records the successful
-deployment in a separate immutable `docs-pages-deployment-<run-id>` prerelease.
-Each release publishes its complete asset set in one transaction. A failed gate
-cannot reach the environment-protected deployment job or become the current
+build passes, automation stages the archive, checksum, and deployment manifest
+together in a draft `docs-pages-deployment-v1-<run-id>-<attempt>` prerelease.
+The draft is published and made immutable only after the production smoke test
+passes. Failed or abandoned attempts therefore cannot become the current
 rollback source.
 
 To restore a retained artifact, find its successful documentation run ID and
@@ -126,7 +125,9 @@ dispatch the same workflow from `main`:
 
 ```console
 gh run list --workflow docs.yml --branch main
-gh workflow run docs.yml --ref main -f rollback_run_id=123456789
+gh workflow run docs.yml --ref main \
+  -f rollback_run_id=123456789 \
+  -f rollback_run_attempt=1
 ```
 
 The rollback run verifies the retained artifact's custom domain, stable,

--- a/website/docs/contributing/documentation.mdx
+++ b/website/docs/contributing/documentation.mdx
@@ -120,16 +120,20 @@ The draft is published and made immutable only after the production smoke test
 passes. Failed or abandoned attempts therefore cannot become the current
 rollback source.
 
-To restore a retained artifact, find its successful documentation run ID and
-exact attempt from the run details, then dispatch the same workflow from
-`main`:
+To restore a retained artifact, select its immutable deployment release and
+read the archive run ID and attempt from that release's manifest. These can
+differ from the deployment attempt after a failed-job rerun:
 
 ```console
-gh run list --workflow docs.yml --branch main
-gh run view 123456789 --json databaseId,attempt,conclusion
+release_tag=docs-pages-deployment-v1-123456789-2
+manifest=$(mktemp)
+gh release download "$release_tag" \
+  --pattern 'deployment-*.json' \
+  --output "$manifest"
+jq '{archiveRunId, archiveRunAttempt}' "$manifest"
 gh workflow run docs.yml --ref main \
-  -f rollback_run_id=123456789 \
-  -f rollback_run_attempt=<exact-attempt>
+  -f rollback_run_id="$(jq -r .archiveRunId "$manifest")" \
+  -f rollback_run_attempt="$(jq -r .archiveRunAttempt "$manifest")"
 ```
 
 The rollback run verifies the retained artifact's custom domain, stable,

--- a/website/docs/contributing/documentation.mdx
+++ b/website/docs/contributing/documentation.mdx
@@ -115,9 +115,11 @@ pwsh tools/docs/snapshot.ps1 -Version 3.0.10 \
 `.github/workflows/docs.yml` validates every pull request. A successful `main`
 run uploads the complete Docusaurus output as one Pages artifact. After the
 production smoke test passes, automation stores that exact archive in the
-`docs-pages-archive` prerelease, keyed by workflow run ID, and retains the ten
-newest known-good deployments. A failed gate cannot reach the
-environment-protected deployment job or enter the rollback archive.
+immutable `docs-pages-archive-<run-id>` prerelease and records the successful
+deployment in a separate immutable `docs-pages-deployment-<run-id>` prerelease.
+Each release publishes its complete asset set in one transaction. A failed gate
+cannot reach the environment-protected deployment job or become the current
+rollback source.
 
 To restore a retained artifact, find its successful documentation run ID and
 dispatch the same workflow from `main`:

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -57,6 +57,7 @@ function release({
   draft = false,
   immutable = true,
   publishedAt = deploymentAttempt,
+  sourceSha = '0123456789abcdef0123456789abcdef01234567',
 }) {
   const manifest = {
     archiveRunAttempt: archiveAttempt,
@@ -64,6 +65,7 @@ function release({
     deploymentRunAttempt: deploymentAttempt,
     deploymentRunId,
     schemaVersion: 1,
+    sourceSha,
   };
 
   return {
@@ -309,15 +311,42 @@ test('failed-job reruns roll the staged attempt forward', () => {
       {
         ...staged.manifest,
         deploymentRunId: 299,
-        deploymentRunAttempt: 1,
       },
       staged.manifest,
     ),
     false,
   );
+  assert.equal(
+    productionMatchesCandidate(
+      {...staged.manifest, deploymentRunAttempt: 2},
+      staged.manifest,
+    ),
+    false,
+  );
+  assert.equal(
+    productionMatchesCandidate(
+      {
+        ...staged.manifest,
+        sourceSha: 'fedcba9876543210fedcba9876543210fedcba98',
+      },
+      staged.manifest,
+    ),
+    false,
+  );
+  const record = normalizedWorkflow
+    .split('\n  record-production-deployment:\n')[1]
+    .split('\n  recover-after-production-failure:\n')[0];
+  const currentProductionGuard = record
+    .split('> current-production.json')[1]
+    ?.split('if [[ "$source_attempt" != "$GITHUB_RUN_ATTEMPT" ]]')[0];
+  assert.ok(currentProductionGuard);
   assert.match(
-    normalizedWorkflow,
-    /\.deploymentRunId == \$deploymentRunId\s+and \.deploymentRunAttempt == \$deploymentRunAttempt/,
+    currentProductionGuard,
+    /--arg sourceSha "\$SOURCE_SHA"[\s\S]*?--argjson deploymentRunId "\$deployment_run_id"[\s\S]*?--argjson deploymentRunAttempt "\$deployment_run_attempt"/,
+  );
+  assert.match(
+    currentProductionGuard,
+    /\.sourceSha == \$sourceSha\s+and \.deploymentRunId == \$deploymentRunId\s+and \.deploymentRunAttempt == \$deploymentRunAttempt[\s\S]*?current-production\.json/,
   );
 });
 

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -45,6 +45,23 @@ function selectRun(filter, workflowRuns) {
   return result.stdout.trimEnd();
 }
 
+function selectSuccessfulJobs(jobPages) {
+  const result = spawnSync(
+    'jq',
+    [
+      '-r',
+      '[.[].jobs[] | select(.conclusion == "success") | .name] | sort | join(",")',
+    ],
+    {
+      encoding: 'utf8',
+      input: JSON.stringify(jobPages),
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trimEnd();
+}
+
 function selectPrior(workflowRuns) {
   const documentation = selectRun(filters[0], workflowRuns);
   return documentation || selectRun(filters[1], workflowRuns);
@@ -474,6 +491,35 @@ test('release operations have repository context without a checkout', () => {
   assert.match(workflowEnv, /^  GH_REPO: \$\{\{ github\.repository \}\}$/m);
   assert.match(normalizedWorkflow, /defaults:\n  run:\n    shell: bash/);
   assert.doesNotMatch(normalizedWorkflow, /2>\/dev\/null \|\|\n\s+true/);
+});
+
+test('workflow job queries use the actual paginated slurp response shape', () => {
+  const jobPages = [
+    {
+      jobs: [
+        {conclusion: 'success', name: 'deploy'},
+        {conclusion: 'failure', name: 'record-production-deployment'},
+      ],
+      total_count: 3,
+    },
+    {
+      jobs: [{conclusion: 'success', name: 'production-smoke'}],
+      total_count: 3,
+    },
+  ];
+  const endpointCount =
+    normalizedWorkflow.match(/\/jobs\?per_page=100/g)?.length ?? 0;
+  const iteratorCount =
+    normalizedWorkflow.match(/\.\[\]\.jobs\[\]/g)?.length ?? 0;
+
+  assert.equal(
+    selectSuccessfulJobs(jobPages),
+    'deploy,production-smoke',
+  );
+  assert.ok(endpointCount > 0);
+  assert.equal(iteratorCount, endpointCount);
+  assert.doesNotMatch(normalizedWorkflow, /\.\[\]\[\]\.jobs\[\]/);
+  assert.match(normalizedWorkflow, /\.\[\]\.workflow_runs\[\]/);
 });
 
 test('expensive documentation gates run in parallel before retention', () => {

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -8,6 +8,7 @@ const workflow = readFileSync(
   fileURLToPath(new URL('../../.github/workflows/docs.yml', import.meta.url)),
   'utf8',
 );
+const normalizedWorkflow = workflow.replaceAll('\r\n', '\n');
 const locateStep = workflow
   .split('- name: Locate the currently deployable Pages run')[1]
   .split('- name: Inspect retained prior artifact')[0];
@@ -68,6 +69,16 @@ test('missing deployment history fails closed', () => {
 });
 
 test('release operations have repository context without a checkout', () => {
-  const workflowEnv = workflow.replaceAll('\r\n', '\n').match(/^env:\n([\s\S]*?)^\S/m)?.[1];
+  const workflowEnv = normalizedWorkflow.match(/^env:\n([\s\S]*?)^\S/m)?.[1];
   assert.match(workflowEnv, /^  GH_REPO: \$\{\{ github\.repository \}\}$/m);
+});
+
+test('expensive documentation gates run in parallel before retention', () => {
+  const validation = normalizedWorkflow.split('\n  validate:\n')[1].split('\n  build:\n')[0];
+  const retention = normalizedWorkflow
+    .split('\n  retain-pages-artifacts:\n')[1]
+    .split('\n  deploy:\n')[0];
+
+  assert.match(validation, /gate:\n          - manifests\n          - runtime/);
+  assert.match(retention, /needs:\n      - build\n      - validate/);
 });

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -42,7 +42,7 @@ function selectPrior(workflowRuns) {
 
 function deploymentAssets(manifest) {
   return [
-    `deployment-${manifest.deploymentRunId}-${manifest.deploymentRunAttempt}.json`,
+    `deployment-${manifest.deploymentRunId}-${manifest.publicationRunAttempt}.json`,
     `github-pages-${manifest.archiveRunId}-${manifest.archiveRunAttempt}.tar`,
     `github-pages-${manifest.archiveRunId}-${manifest.archiveRunAttempt}.tar.sha256`,
   ].sort();
@@ -53,19 +53,25 @@ function release({
   archiveRunId = 100,
   deploymentAttempt = 1,
   deploymentRunId = 200,
+  deployAttempt = deploymentAttempt,
   digestValid = true,
   draft = false,
   immutable = true,
   publishedAt = deploymentAttempt,
+  smokeAttempt = deploymentAttempt,
   sourceSha = '0123456789abcdef0123456789abcdef01234567',
+  stageAttempt = deploymentAttempt,
 }) {
   const manifest = {
     archiveRunAttempt: archiveAttempt,
     archiveRunId,
-    deploymentRunAttempt: deploymentAttempt,
     deploymentRunId,
+    deployRunAttempt: deployAttempt,
+    publicationRunAttempt: deploymentAttempt,
     schemaVersion: 1,
+    smokeRunAttempt: smokeAttempt,
     sourceSha,
+    stageRunAttempt: stageAttempt,
   };
 
   return {
@@ -87,7 +93,7 @@ function validRelease(candidate) {
     candidate.digestValid &&
     manifest.schemaVersion === 1 &&
     candidate.tag ===
-      `docs-pages-deployment-v1-${manifest.deploymentRunId}-${manifest.deploymentRunAttempt}` &&
+      `docs-pages-deployment-v1-${manifest.deploymentRunId}-${manifest.publicationRunAttempt}` &&
     candidate.assets.join() === deploymentAssets(manifest).join()
   );
 }
@@ -104,11 +110,18 @@ function selectRollback(releases, runId, attempt) {
     .at(-1);
 }
 
-function validAttempt({conclusion, jobs, required}) {
+function validEvidence(candidate, {archiveAttempts, deploymentAttempts}) {
+  const manifest = candidate.manifest;
+  const publication = deploymentAttempts[manifest.publicationRunAttempt];
   return (
-    conclusion === 'success' ||
-    (conclusion === 'failure' &&
-      required.every((name) => jobs[name] === 'success'))
+    validRelease(candidate) &&
+    ['success', 'failure'].includes(publication?.conclusion) &&
+    archiveAttempts[manifest.archiveRunAttempt]?.build === 'success' &&
+    deploymentAttempts[manifest.stageRunAttempt]?.['stage-pages-release'] ===
+      'success' &&
+    deploymentAttempts[manifest.deployRunAttempt]?.deploy === 'success' &&
+    deploymentAttempts[manifest.smokeRunAttempt]?.['production-smoke'] ===
+      'success'
   );
 }
 
@@ -194,7 +207,7 @@ test('deployment release stays draft until production is verified', () => {
     .split('\n  record-production-deployment:\n')[1]
     .split('\n  recover-after-production-failure:\n')[0];
 
-  assert.match(stage, /docs-pages-deployment-v1-\$\{GITHUB_RUN_ID\}-\$\{GITHUB_RUN_ATTEMPT\}/);
+  assert.match(stage, /docs-pages-candidate-v1-\$\{GITHUB_RUN_ID\}-\$\{GITHUB_RUN_ATTEMPT\}/);
   assert.match(stage, /gh release create "\$release_tag"[\s\S]*?--draft/);
   assert.match(deploy, /needs\.stage-pages-release\.result == 'success'/);
   assert.match(record, /needs\.production-smoke\.result == 'success'/);
@@ -208,6 +221,10 @@ test('immutable releases contain exactly archive, checksum, and manifest', () =>
   assert.match(
     normalizedWorkflow,
     /gh release create "\$release_tag" \\\n\s+"candidate\/\$\{archive_name\}" \\\n\s+"candidate\/\$\{checksum_name\}" \\\n\s+"candidate\/\$\{pointer_name\}"/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /gh release create "\$pointer_tag" \\\n\s+"final\/\$\{archive_name\}" \\\n\s+"final\/\$\{checksum_name\}" \\\n\s+"final\/\$\{pointer_name\}"/,
   );
   assert.match(normalizedWorkflow, /"\$asset_count" != 3/);
   assert.match(
@@ -290,25 +307,79 @@ test('failed smoke or publication dispatches exact prior recovery', () => {
   );
 });
 
-test('failed-job reruns preserve the staged archive and release identity', () => {
-  const staged = release({
-    deploymentAttempt: 1,
+test('stage attempt one can publish after deploy and smoke succeed on attempt two', () => {
+  const published = release({
+    deploymentAttempt: 2,
     deploymentRunId: 300,
-    draft: true,
-    immutable: false,
+    deployAttempt: 2,
+    smokeAttempt: 2,
+    stageAttempt: 1,
   });
-  const currentAttempt = 2;
+  const evidence = {
+    archiveAttempts: {1: {build: 'success'}},
+    deploymentAttempts: {
+      1: {
+        conclusion: 'failure',
+        deploy: 'failure',
+        'stage-pages-release': 'success',
+      },
+      2: {
+        conclusion: 'success',
+        deploy: 'success',
+        'production-smoke': 'success',
+        'record-production-deployment': 'success',
+      },
+    },
+  };
 
-  assert.equal(staged.manifest.deploymentRunAttempt, 1);
-  assert.notEqual(staged.manifest.deploymentRunAttempt, currentAttempt);
-  assert.doesNotMatch(
+  assert.equal(validEvidence(published, evidence), true);
+  assert.equal(published.manifest.stageRunAttempt, 1);
+  assert.equal(published.manifest.deployRunAttempt, 2);
+  assert.equal(published.manifest.smokeRunAttempt, 2);
+  assert.equal(published.manifest.publicationRunAttempt, 2);
+  assert.match(
     normalizedWorkflow,
-    /if \[\[ "\$source_attempt" != "\$GITHUB_RUN_ATTEMPT" \]\]; then/,
+    /release_prefix="docs-pages-candidate-v1-\$\{GITHUB_RUN_ID\}-"/,
   );
   assert.match(
     normalizedWorkflow,
-    /pointer_tag="\$source_tag"/,
+    /pointer_tag="docs-pages-deployment-v1-\$\{GITHUB_RUN_ID\}-\$\{GITHUB_RUN_ATTEMPT\}"/,
   );
+});
+
+test('stage and deploy attempt one can publish after smoke succeeds on attempt two', () => {
+  const published = release({
+    deploymentAttempt: 2,
+    deploymentRunId: 301,
+    deployAttempt: 1,
+    smokeAttempt: 2,
+    stageAttempt: 1,
+  });
+  const evidence = {
+    archiveAttempts: {1: {build: 'success'}},
+    deploymentAttempts: {
+      1: {
+        conclusion: 'failure',
+        deploy: 'success',
+        'production-smoke': 'failure',
+        'stage-pages-release': 'success',
+      },
+      2: {
+        conclusion: 'success',
+        'production-smoke': 'success',
+        'record-production-deployment': 'success',
+      },
+    },
+  };
+
+  assert.equal(validEvidence(published, evidence), true);
+  assert.equal(published.manifest.deployRunAttempt, 1);
+  assert.equal(published.manifest.smokeRunAttempt, 2);
+});
+
+test('publication remains bound to exact archive production identity', () => {
+  const staged = release({deploymentRunId: 302});
+
   assert.match(
     normalizedWorkflow,
     /ARCHIVE_RUN_ATTEMPT: \$\{\{ needs\.build\.outputs\.archive_run_attempt \}\}/,
@@ -350,7 +421,7 @@ test('failed-job reruns preserve the staged archive and release identity', () =>
     .split('\n  recover-after-production-failure:\n')[0];
   const currentProductionGuard = record
     .split('> current-production.json')[1]
-    ?.split('pointer_name="$source_pointer_name"')[0];
+    ?.split('mkdir final')[0];
   assert.ok(currentProductionGuard);
   assert.match(
     currentProductionGuard,
@@ -381,79 +452,96 @@ test('ambiguous publication recovers the remotely published candidate', () => {
   );
 });
 
-test('future selection accepts a published pointer after record failure', () => {
-  const jobs = {
-    build: 'success',
-    deploy: 'success',
-    'production-smoke': 'success',
-    'record-production-deployment': 'failure',
-    'stage-pages-release': 'success',
+test('remote publication remains selectable after the record client fails', () => {
+  const published = release({deploymentRunId: 400});
+  const evidence = {
+    archiveAttempts: {1: {build: 'success'}},
+    deploymentAttempts: {
+      1: {
+        conclusion: 'failure',
+        deploy: 'success',
+        'production-smoke': 'success',
+        'record-production-deployment': 'failure',
+        'stage-pages-release': 'success',
+      },
+    },
   };
 
-  assert.equal(
-    validAttempt({
-      conclusion: 'failure',
-      jobs,
-      required: ['deploy', 'production-smoke', 'stage-pages-release'],
-    }),
-    true,
-  );
-  assert.equal(
-    validAttempt({
-      conclusion: 'failure',
-      jobs,
-      required: ['build'],
-    }),
-    true,
-  );
-  assert.equal(
-    validAttempt({
-      conclusion: 'failure',
-      jobs: {...jobs, 'production-smoke': 'failure'},
-      required: ['deploy', 'production-smoke', 'stage-pages-release'],
-    }),
-    false,
-  );
-  assert.equal(
-    validAttempt({
-      conclusion: 'cancelled',
-      jobs,
-      required: ['deploy', 'production-smoke', 'stage-pages-release'],
-    }),
-    false,
-  );
-  assert.equal(
-    validAttempt({
-      conclusion: 'timed_out',
-      jobs,
-      required: ['build'],
-    }),
-    false,
-  );
+  assert.equal(validEvidence(published, evidence), true);
   assert.match(
     normalizedWorkflow,
-    /actions\/runs\/\$\{deployment_run_id\}\/attempts\/\$\{deployment_run_attempt\}\/jobs/,
+    /"\$pointer_conclusion" != success &&\s+"\$pointer_conclusion" != failure/,
   );
+});
+
+test('every publication phase rejects missing or non-success evidence', () => {
+  const published = release({deploymentRunId: 401});
+  const valid = {
+    archiveAttempts: {1: {build: 'success'}},
+    deploymentAttempts: {
+      1: {
+        conclusion: 'success',
+        deploy: 'success',
+        'production-smoke': 'success',
+        'stage-pages-release': 'success',
+      },
+    },
+  };
+
+  for (const status of [
+    undefined,
+    'failure',
+    'cancelled',
+    'timed_out',
+    'action_required',
+    null,
+  ]) {
+    for (const phase of [
+      ['archiveAttempts', 'build'],
+      ['deploymentAttempts', 'stage-pages-release'],
+      ['deploymentAttempts', 'deploy'],
+      ['deploymentAttempts', 'production-smoke'],
+    ]) {
+      const evidence = structuredClone(valid);
+      evidence[phase[0]][1][phase[1]] = status;
+      assert.equal(validEvidence(published, evidence), false);
+    }
+  }
+  for (const conclusion of [
+    undefined,
+    'cancelled',
+    'timed_out',
+    'action_required',
+    null,
+  ]) {
+    const evidence = structuredClone(valid);
+    evidence.deploymentAttempts[1].conclusion = conclusion;
+    assert.equal(validEvidence(published, evidence), false);
+  }
   assert.match(
     normalizedWorkflow,
-    /"\$pointer_jobs" != "deploy,production-smoke,stage-pages-release"/,
+    /actions\/runs\/\$\{deployment_run_id\}\/attempts\/\$\{phase_attempt\}\/jobs/,
   );
   assert.match(
     normalizedWorkflow,
     /"\$archive_jobs" != "build"/,
   );
-  assert.match(
-    normalizedWorkflow,
-    /"\$conclusion" != failure[\s\S]*?Incomplete workflow attempts are not rollback sources/,
-  );
-  assert.match(
-    normalizedWorkflow,
-    /"\$pointer_conclusion" != failure[\s\S]*?Incomplete workflow attempts are not deployment pointers/,
-  );
-  assert.match(
-    normalizedWorkflow,
-    /"\$archive_conclusion" != failure[\s\S]*?Incomplete workflow attempts are not archive sources/,
-  );
+});
+
+test('a full rerun publishes its new attempt-two candidate', () => {
+  const first = release({deploymentRunId: 402});
+  const second = release({
+    archiveAttempt: 2,
+    deploymentAttempt: 2,
+    deploymentRunId: 402,
+    deployAttempt: 2,
+    smokeAttempt: 2,
+    stageAttempt: 2,
+  });
+
+  assert.equal(second.manifest.stageRunAttempt, 2);
+  assert.notEqual(second.assets.join(), first.assets.join());
+  assert.match(normalizedWorkflow, /sort_by\(\.deployment_attempt\)[\s\S]*?\(last \/\/ empty\)/);
 });
 
 test('older attempts remain exact rollback sources after reruns', () => {
@@ -495,7 +583,7 @@ test('rollback guidance uses the archive identity after redeployment', () => {
 
   assert.notEqual(
     rolledForward.manifest.archiveRunAttempt,
-    rolledForward.manifest.deploymentRunAttempt,
+    rolledForward.manifest.publicationRunAttempt,
   );
   assert.match(deploymentGuide, /jq -r \.archiveRunId/);
   assert.match(deploymentGuide, /jq -r \.archiveRunAttempt/);

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -158,9 +158,8 @@ function downloadedArtifactMatches(selected, embedded) {
 
   return (
     selected.path === '.github/workflows/docs.yml' &&
-    embedded.sourceSha === selected.sourceSha &&
-    embedded.archiveRunId === selected.runId &&
-    embedded.archiveRunAttempt === selected.attempt
+    selected.attempt === 1 &&
+    embedded.sourceSha === selected.sourceSha
   );
 }
 
@@ -262,26 +261,24 @@ test('pre-staging documentation archives remain honest bootstrap sources', () =>
   );
 });
 
-test('bootstrap retention rejects an artifact from a different rerun attempt', () => {
+test('bootstrap retention accepts only single-attempt artifacts with the historical identity shape', () => {
   const selected = {
     attempt: 1,
     path: '.github/workflows/docs.yml',
-    runId: 30386738318,
-    sourceSha: legacyRun.head_sha,
+    runId: 30418201624,
+    sourceSha: '567fa79f7d3f0563910bb73ed9ad27db5e82d58c',
   };
   const embedded = {
-    archiveRunAttempt: 2,
-    archiveRunId: selected.runId,
     sourceSha: selected.sourceSha,
   };
 
-  assert.equal(downloadedArtifactMatches(selected, embedded), false);
+  assert.equal(downloadedArtifactMatches(selected, embedded), true);
+  assert.equal(downloadedArtifactMatches({...selected, attempt: 2}, embedded), false);
   assert.equal(
     downloadedArtifactMatches(selected, {
-      ...embedded,
-      archiveRunAttempt: selected.attempt,
+      sourceSha: '0123456789abcdef0123456789abcdef01234567',
     }),
-    true,
+    false,
   );
   assert.equal(
     downloadedArtifactMatches(
@@ -306,12 +303,49 @@ test('bootstrap retention rejects an artifact from a different rerun attempt', (
     /tar -xOf prior-download\/artifact\.tar \.\/deployment\.json/,
   );
   assert.match(
+    normalizedWorkflow,
+    /- name: Download prior Pages artifact[\s\S]*?run-id: \$\{\{ steps\.prior\.outputs\.run_id \}\}/,
+  );
+  assert.match(
     retainStep,
-    /\.sourceSha == \$sourceSha\s+and \.archiveRunId == \$archiveRunId\s+and \.archiveRunAttempt == \$archiveRunAttempt[\s\S]*?prior-download\/deployment\.json/,
+    /\.sourceSha == \$sourceSha' \\\n\s+prior-download\/deployment\.json/,
+  );
+  assert.match(
+    retainStep,
+    /"\$PRIOR_RUN_ATTEMPT" != 1[\s\S]*?rerun pre-staging artifact cannot prove its exact attempt/,
   );
   assert.match(
     retainStep,
     /"\$PRIOR_RUN_ATTEMPT" != 1[\s\S]*?rerun legacy artifact cannot prove its exact attempt/,
+  );
+});
+
+test('bootstrap selection skips reruns and continues to an older provable source', () => {
+  const olderDocumentation = {
+    ...legacyRun,
+    created_at: '2026-07-29T01:00:00Z',
+    head_sha: '0123456789abcdef0123456789abcdef01234567',
+    id: 30410000000,
+    path: '.github/workflows/docs.yml',
+  };
+  const rerun = {
+    ...olderDocumentation,
+    created_at: '2026-07-29T02:00:00Z',
+    id: 30420000000,
+    run_attempt: 2,
+  };
+
+  assert.equal(
+    selectPrior([legacyRun, olderDocumentation, rerun]),
+    `${olderDocumentation.id}\t1\t${olderDocumentation.head_sha}\t${olderDocumentation.path}`,
+  );
+  assert.equal(
+    selectPrior([legacyRun, rerun]),
+    `${legacyRun.id}\t1\t${legacyRun.head_sha}\t${legacyRun.path}`,
+  );
+  assert.equal(
+    filters.every((filter) => filter.includes('.run_attempt == 1')),
+    true,
   );
 });
 

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -132,6 +132,18 @@ test('rollback is bound to an exact successful run attempt', () => {
   );
   assert.match(
     normalizedWorkflow,
+    /actions\/runs\/\$\{ROLLBACK_RUN_ID\}\/attempts\/\$\{ROLLBACK_RUN_ATTEMPT\}/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /actions\/runs\/\$\{deployment_run_id\}\/attempts\/\$\{deployment_run_attempt\}/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /actions\/runs\/\$\{run_id\}\/attempts\/\$\{run_attempt\}/,
+  );
+  assert.match(
+    normalizedWorkflow,
     /\.archiveRunAttempt == \$archiveRunAttempt/,
   );
   assert.match(

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -107,7 +107,8 @@ function selectRollback(releases, runId, attempt) {
 function validAttempt({conclusion, jobs, required}) {
   return (
     conclusion === 'success' ||
-    required.every((name) => jobs[name] === 'success')
+    (conclusion === 'failure' &&
+      required.every((name) => jobs[name] === 'success'))
   );
 }
 
@@ -413,6 +414,22 @@ test('future selection accepts a published pointer after record failure', () => 
     }),
     false,
   );
+  assert.equal(
+    validAttempt({
+      conclusion: 'cancelled',
+      jobs,
+      required: ['deploy', 'production-smoke', 'stage-pages-release'],
+    }),
+    false,
+  );
+  assert.equal(
+    validAttempt({
+      conclusion: 'timed_out',
+      jobs,
+      required: ['build'],
+    }),
+    false,
+  );
   assert.match(
     normalizedWorkflow,
     /actions\/runs\/\$\{deployment_run_id\}\/attempts\/\$\{deployment_run_attempt\}\/jobs/,
@@ -424,6 +441,18 @@ test('future selection accepts a published pointer after record failure', () => 
   assert.match(
     normalizedWorkflow,
     /"\$archive_jobs" != "build"/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /"\$conclusion" != failure[\s\S]*?Incomplete workflow attempts are not rollback sources/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /"\$pointer_conclusion" != failure[\s\S]*?Incomplete workflow attempts are not deployment pointers/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /"\$archive_conclusion" != failure[\s\S]*?Incomplete workflow attempts are not archive sources/,
   );
 });
 

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -147,6 +147,7 @@ function validEvidence(candidate, {archiveAttempts, deploymentAttempts}) {
   if (manifest.bootstrapSource) {
     return (
       validRelease(candidate) &&
+      manifest.archiveRunAttempt === 1 &&
       publication?.conclusion === 'success' &&
       archiveIsValid
     );
@@ -242,6 +243,21 @@ test('pre-staging documentation archives remain honest bootstrap sources', () =>
   });
 
   assert.equal(validEvidence(bootstrap, bootstrapEvidence), true);
+  assert.equal(
+    validEvidence(
+      release({
+        archiveAttempt: 2,
+        archiveRunId: bootstrap.manifest.archiveRunId,
+        bootstrapSource: true,
+        deploymentRunId: bootstrap.manifest.deploymentRunId,
+      }),
+      {
+        archiveAttempts: {2: {build: 'success'}},
+        deploymentAttempts: {1: {conclusion: 'success'}},
+      },
+    ),
+    false,
+  );
   assert.equal(validEvidence(failedFirstDeployment, phasedEvidence), false);
   assert.equal(
     selectRollback(
@@ -277,6 +293,14 @@ test('pre-staging documentation archives remain honest bootstrap sources', () =>
   assert.match(
     normalizedWorkflow,
     /manifest_bootstrap[\s\S]*?Rollback bootstrap publication is invalid/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /manifest_bootstrap[\s\S]*?"\$ROLLBACK_RUN_ATTEMPT" != 1[\s\S]*?Rollback bootstrap releases must use attempt one/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /"\$bootstrap_source" == true &&\s+"\$run_attempt" != 1/,
   );
 });
 

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -84,3 +84,17 @@ test('expensive documentation gates run in parallel before retention', () => {
   assert.match(validation, /\}\}-\$\{\{ matrix\.gate \}\}/);
   assert.match(retention, /needs:\n      - build\n      - validate/);
 });
+
+test('immutable rollback releases publish complete assets initially', () => {
+  assert.doesNotMatch(normalizedWorkflow, /gh release upload/);
+  assert.match(
+    normalizedWorkflow,
+    /gh release create "\$archive_tag" \\\n\s+"[^"]*\$\{archive_name\}" \\\n\s+"[^"]*\$\{checksum_name\}"/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /gh release create "\$pointer_tag" \\\n\s+"\$pointer_name"/,
+  );
+  assert.match(normalizedWorkflow, /docs-pages-archive-\$\{GITHUB_RUN_ID\}/);
+  assert.match(normalizedWorkflow, /docs-pages-deployment-\$\{GITHUB_RUN_ID\}/);
+});

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -9,7 +9,7 @@ const workflow = readFileSync(
   'utf8',
 );
 const normalizedWorkflow = workflow.replaceAll('\r\n', '\n');
-const locateStep = workflow
+const locateStep = normalizedWorkflow
   .split('- name: Locate the currently deployable Pages run')[1]
   .split('- name: Inspect retained prior artifact')[0];
 const fallbackSelection = locateStep.slice(
@@ -80,5 +80,6 @@ test('expensive documentation gates run in parallel before retention', () => {
     .split('\n  deploy:\n')[0];
 
   assert.match(validation, /gate:\n          - manifests\n          - runtime/);
+  assert.match(validation, /permissions:\n      actions: read\n      contents: read/);
   assert.match(retention, /needs:\n      - build\n      - validate/);
 });

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -85,6 +85,7 @@ test('expensive documentation gates run in parallel before retention', () => {
   assert.match(validation, /gate:\n          - manifests\n          - runtime/);
   assert.match(validation, /permissions:\n      actions: read\n      contents: read/);
   assert.match(validation, /\}\}-\$\{\{ matrix\.gate \}\}/);
+  assert.doesNotMatch(validation, /^    needs:/m);
   assert.match(retention, /needs:\n      - build\n      - validate/);
 });
 

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -34,6 +34,68 @@ function selectPrior(workflowRuns) {
   return documentation || selectRun(filters[1], workflowRuns);
 }
 
+function deploymentAssets(manifest) {
+  return [
+    `deployment-${manifest.deploymentRunId}-${manifest.deploymentRunAttempt}.json`,
+    `github-pages-${manifest.archiveRunId}-${manifest.archiveRunAttempt}.tar`,
+    `github-pages-${manifest.archiveRunId}-${manifest.archiveRunAttempt}.tar.sha256`,
+  ].sort();
+}
+
+function release({
+  archiveAttempt = 1,
+  archiveRunId = 100,
+  deploymentAttempt = 1,
+  deploymentRunId = 200,
+  digestValid = true,
+  draft = false,
+  immutable = true,
+  publishedAt = deploymentAttempt,
+}) {
+  const manifest = {
+    archiveRunAttempt: archiveAttempt,
+    archiveRunId,
+    deploymentRunAttempt: deploymentAttempt,
+    deploymentRunId,
+    schemaVersion: 1,
+  };
+
+  return {
+    assets: deploymentAssets(manifest),
+    digestValid,
+    draft,
+    immutable,
+    manifest,
+    publishedAt,
+    tag: `docs-pages-deployment-v1-${deploymentRunId}-${deploymentAttempt}`,
+  };
+}
+
+function validRelease(candidate) {
+  const manifest = candidate.manifest;
+  return (
+    !candidate.draft &&
+    candidate.immutable &&
+    candidate.digestValid &&
+    manifest.schemaVersion === 1 &&
+    candidate.tag ===
+      `docs-pages-deployment-v1-${manifest.deploymentRunId}-${manifest.deploymentRunAttempt}` &&
+    candidate.assets.join() === deploymentAssets(manifest).join()
+  );
+}
+
+function selectRollback(releases, runId, attempt) {
+  return releases
+    .filter(validRelease)
+    .filter(
+      ({manifest}) =>
+        manifest.archiveRunId === runId &&
+        manifest.archiveRunAttempt === attempt,
+    )
+    .sort((left, right) => left.publishedAt - right.publishedAt)
+    .at(-1);
+}
+
 const legacyRun = {
   created_at: '2026-07-28T18:17:11Z',
   head_sha: 'e7a24480ea2e5f796a0528842ef3f2743af4e59a',
@@ -47,6 +109,10 @@ test('first documentation deployment retains the latest legacy deployment', () =
   assert.equal(
     selectPrior([legacyRun]),
     `${legacyRun.id}\t${legacyRun.run_attempt}\t${legacyRun.head_sha}\t${legacyRun.path}`,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /\$'success\\tpush\\tmain\\t\.github\/workflows\/jekyll-gh-pages\.yml\\t'/,
   );
 });
 
@@ -144,6 +210,10 @@ test('rollback is bound to an exact successful run attempt', () => {
   );
   assert.match(
     normalizedWorkflow,
+    /github-pages-\$\{ROLLBACK_RUN_ID\}-\$\{ROLLBACK_RUN_ATTEMPT\}\.tar/,
+  );
+  assert.match(
+    normalizedWorkflow,
     /\.archiveRunAttempt == \$archiveRunAttempt/,
   );
   assert.match(
@@ -166,6 +236,10 @@ test('draft, malformed, incomplete, and digest-mismatched releases fail closed',
   assert.match(selection, /"\$asset_count" != 3/);
   assert.match(selection, /"\$pointer_count" != 1/);
   assert.match(normalizedWorkflow, /sha256sum -c "\$checksum_name"/);
+
+  assert.equal(validRelease(release({draft: true, immutable: false})), false);
+  assert.equal(validRelease({...release({}), assets: []}), false);
+  assert.equal(validRelease(release({digestValid: false})), false);
 });
 
 test('failed smoke or publication dispatches exact prior recovery', () => {
@@ -182,4 +256,73 @@ test('failed smoke or publication dispatches exact prior recovery', () => {
     recovery,
     /"\$recovery_run_id" == "\$REQUESTED_ROLLBACK_RUN_ID" &&\n\s+"\$recovery_run_attempt" == "\$REQUESTED_ROLLBACK_RUN_ATTEMPT"/,
   );
+});
+
+test('failed-job reruns roll the staged attempt forward', () => {
+  const staged = release({
+    deploymentAttempt: 1,
+    deploymentRunId: 300,
+    draft: true,
+    immutable: false,
+  });
+  const currentAttempt = 2;
+
+  assert.equal(staged.manifest.deploymentRunAttempt, 1);
+  assert.notEqual(staged.manifest.deploymentRunAttempt, currentAttempt);
+  assert.match(
+    normalizedWorkflow,
+    /if \[\[ "\$source_attempt" != "\$GITHUB_RUN_ATTEMPT" \]\]; then/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /pointer_tag="\$\{release_prefix\}\$\{GITHUB_RUN_ATTEMPT\}"/,
+  );
+});
+
+test('ambiguous publication recovers the remotely published candidate', () => {
+  const prior = release({deploymentRunId: 399, publishedAt: 1});
+  const remotelyPublished = release({
+    archiveRunId: 400,
+    deploymentRunId: 400,
+    publishedAt: 2,
+  });
+
+  assert.equal(selectRollback([prior, remotelyPublished], 400, 1), remotelyPublished);
+  assert.match(
+    normalizedWorkflow,
+    /"\$RECORD_RESULT" == failure/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /needs\.record-production-deployment\.result == 'failure'/,
+  );
+});
+
+test('older attempts remain exact rollback sources after reruns', () => {
+  const first = release({
+    archiveAttempt: 1,
+    archiveRunId: 500,
+    deploymentAttempt: 1,
+    deploymentRunId: 500,
+  });
+  const second = release({
+    archiveAttempt: 2,
+    archiveRunId: 500,
+    deploymentAttempt: 2,
+    deploymentRunId: 500,
+  });
+
+  assert.equal(selectRollback([first, second], 500, 1), first);
+  assert.equal(selectRollback([first, second], 500, 2), second);
+  assert.notEqual(first.assets[1], second.assets[1]);
+});
+
+test('stored attempt one is not replaced by latest rerun attempt two', () => {
+  const runId = 600;
+  const storedAttempt = 1;
+  const latestAttempt = 2;
+  const endpoint = `actions/runs/${runId}/attempts/${storedAttempt}`;
+
+  assert.match(endpoint, /\/attempts\/1$/);
+  assert.doesNotMatch(endpoint, new RegExp(`/attempts/${latestAttempt}$`));
 });

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -152,6 +152,18 @@ function productionMatchesCandidate(production, candidate) {
   );
 }
 
+function downloadedArtifactMatches(selected, embedded) {
+  if (selected.path === '.github/workflows/jekyll-gh-pages.yml')
+    return selected.attempt === 1;
+
+  return (
+    selected.path === '.github/workflows/docs.yml' &&
+    embedded.sourceSha === selected.sourceSha &&
+    embedded.archiveRunId === selected.runId &&
+    embedded.archiveRunAttempt === selected.attempt
+  );
+}
+
 const legacyRun = {
   created_at: '2026-07-28T18:17:11Z',
   head_sha: 'e7a24480ea2e5f796a0528842ef3f2743af4e59a',
@@ -247,6 +259,59 @@ test('pre-staging documentation archives remain honest bootstrap sources', () =>
   assert.match(
     normalizedWorkflow,
     /manifest_bootstrap[\s\S]*?Rollback bootstrap publication is invalid/,
+  );
+});
+
+test('bootstrap retention rejects an artifact from a different rerun attempt', () => {
+  const selected = {
+    attempt: 1,
+    path: '.github/workflows/docs.yml',
+    runId: 30386738318,
+    sourceSha: legacyRun.head_sha,
+  };
+  const embedded = {
+    archiveRunAttempt: 2,
+    archiveRunId: selected.runId,
+    sourceSha: selected.sourceSha,
+  };
+
+  assert.equal(downloadedArtifactMatches(selected, embedded), false);
+  assert.equal(
+    downloadedArtifactMatches(selected, {
+      ...embedded,
+      archiveRunAttempt: selected.attempt,
+    }),
+    true,
+  );
+  assert.equal(
+    downloadedArtifactMatches(
+      {...selected, path: '.github/workflows/jekyll-gh-pages.yml'},
+      {},
+    ),
+    true,
+  );
+  assert.equal(
+    downloadedArtifactMatches(
+      {
+        ...selected,
+        attempt: 2,
+        path: '.github/workflows/jekyll-gh-pages.yml',
+      },
+      {},
+    ),
+    false,
+  );
+  assert.match(
+    retainStep,
+    /tar -xOf prior-download\/artifact\.tar \.\/deployment\.json/,
+  );
+  assert.match(
+    retainStep,
+    /\.sourceSha == \$sourceSha\s+and \.archiveRunId == \$archiveRunId\s+and \.archiveRunAttempt == \$archiveRunAttempt[\s\S]*?prior-download\/deployment\.json/,
+  );
+  assert.match(
+    retainStep,
+    /"\$PRIOR_RUN_ATTEMPT" != 1[\s\S]*?rerun legacy artifact cannot prove its exact attempt/,
   );
 });
 

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -81,5 +81,6 @@ test('expensive documentation gates run in parallel before retention', () => {
 
   assert.match(validation, /gate:\n          - manifests\n          - runtime/);
   assert.match(validation, /permissions:\n      actions: read\n      contents: read/);
+  assert.match(validation, /\}\}-\$\{\{ matrix\.gate \}\}/);
   assert.match(retention, /needs:\n      - build\n      - validate/);
 });

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -104,8 +104,7 @@ function selectRollback(releases, runId, attempt) {
     .at(-1);
 }
 
-function validAttempt({conclusion, jobs}) {
-  const required = ['build', 'deploy', 'production-smoke', 'stage-pages-release'];
+function validAttempt({conclusion, jobs, required}) {
   return (
     conclusion === 'success' ||
     required.every((name) => jobs[name] === 'success')
@@ -115,8 +114,8 @@ function validAttempt({conclusion, jobs}) {
 function productionMatchesCandidate(production, candidate) {
   return (
     production.sourceSha === candidate.sourceSha &&
-    production.deploymentRunId === candidate.deploymentRunId &&
-    production.deploymentRunAttempt === candidate.deploymentRunAttempt
+    production.archiveRunId === candidate.archiveRunId &&
+    production.archiveRunAttempt === candidate.archiveRunAttempt
   );
 }
 
@@ -284,9 +283,13 @@ test('failed smoke or publication dispatches exact prior recovery', () => {
     recovery,
     /"\$recovery_run_id" == "\$REQUESTED_ROLLBACK_RUN_ID" &&\n\s+"\$recovery_run_attempt" == "\$REQUESTED_ROLLBACK_RUN_ATTEMPT"/,
   );
+  assert.doesNotMatch(
+    recovery,
+    /SMOKE_RESULT[\s\S]*?"\$recovery_run_id" == "\$REQUESTED_ROLLBACK_RUN_ID"/,
+  );
 });
 
-test('failed-job reruns roll the staged attempt forward', () => {
+test('failed-job reruns preserve the staged archive and release identity', () => {
   const staged = release({
     deploymentAttempt: 1,
     deploymentRunId: 300,
@@ -297,20 +300,28 @@ test('failed-job reruns roll the staged attempt forward', () => {
 
   assert.equal(staged.manifest.deploymentRunAttempt, 1);
   assert.notEqual(staged.manifest.deploymentRunAttempt, currentAttempt);
-  assert.match(
+  assert.doesNotMatch(
     normalizedWorkflow,
     /if \[\[ "\$source_attempt" != "\$GITHUB_RUN_ATTEMPT" \]\]; then/,
   );
   assert.match(
     normalizedWorkflow,
-    /pointer_tag="\$\{release_prefix\}\$\{GITHUB_RUN_ATTEMPT\}"/,
+    /pointer_tag="\$source_tag"/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /ARCHIVE_RUN_ATTEMPT: \$\{\{ needs\.build\.outputs\.archive_run_attempt \}\}/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /ARCHIVE_RUN_ID: \$\{\{ needs\.build\.outputs\.archive_run_id \}\}/,
   );
   assert.equal(productionMatchesCandidate(staged.manifest, staged.manifest), true);
   assert.equal(
     productionMatchesCandidate(
       {
         ...staged.manifest,
-        deploymentRunId: 299,
+        archiveRunId: 99,
       },
       staged.manifest,
     ),
@@ -318,7 +329,7 @@ test('failed-job reruns roll the staged attempt forward', () => {
   );
   assert.equal(
     productionMatchesCandidate(
-      {...staged.manifest, deploymentRunAttempt: 2},
+      {...staged.manifest, archiveRunAttempt: 2},
       staged.manifest,
     ),
     false,
@@ -338,15 +349,15 @@ test('failed-job reruns roll the staged attempt forward', () => {
     .split('\n  recover-after-production-failure:\n')[0];
   const currentProductionGuard = record
     .split('> current-production.json')[1]
-    ?.split('if [[ "$source_attempt" != "$GITHUB_RUN_ATTEMPT" ]]')[0];
+    ?.split('pointer_name="$source_pointer_name"')[0];
   assert.ok(currentProductionGuard);
   assert.match(
     currentProductionGuard,
-    /--arg sourceSha "\$SOURCE_SHA"[\s\S]*?--argjson deploymentRunId "\$deployment_run_id"[\s\S]*?--argjson deploymentRunAttempt "\$deployment_run_attempt"/,
+    /--arg sourceSha "\$SOURCE_SHA"[\s\S]*?--argjson archiveRunId "\$archive_run_id"[\s\S]*?--argjson archiveRunAttempt "\$archive_run_attempt"/,
   );
   assert.match(
     currentProductionGuard,
-    /\.sourceSha == \$sourceSha\s+and \.deploymentRunId == \$deploymentRunId\s+and \.deploymentRunAttempt == \$deploymentRunAttempt[\s\S]*?current-production\.json/,
+    /\.sourceSha == \$sourceSha\s+and \.archiveRunId == \$archiveRunId\s+and \.archiveRunAttempt == \$archiveRunAttempt[\s\S]*?current-production\.json/,
   );
 });
 
@@ -378,11 +389,27 @@ test('future selection accepts a published pointer after record failure', () => 
     'stage-pages-release': 'success',
   };
 
-  assert.equal(validAttempt({conclusion: 'failure', jobs}), true);
+  assert.equal(
+    validAttempt({
+      conclusion: 'failure',
+      jobs,
+      required: ['deploy', 'production-smoke', 'stage-pages-release'],
+    }),
+    true,
+  );
+  assert.equal(
+    validAttempt({
+      conclusion: 'failure',
+      jobs,
+      required: ['build'],
+    }),
+    true,
+  );
   assert.equal(
     validAttempt({
       conclusion: 'failure',
       jobs: {...jobs, 'production-smoke': 'failure'},
+      required: ['deploy', 'production-smoke', 'stage-pages-release'],
     }),
     false,
   );
@@ -392,7 +419,11 @@ test('future selection accepts a published pointer after record failure', () => 
   );
   assert.match(
     normalizedWorkflow,
-    /"\$pointer_jobs" != "build,deploy,production-smoke,stage-pages-release"/,
+    /"\$pointer_jobs" != "deploy,production-smoke,stage-pages-release"/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /"\$archive_jobs" != "build"/,
   );
 });
 
@@ -425,7 +456,7 @@ test('stored attempt one is not replaced by latest rerun attempt two', () => {
   assert.doesNotMatch(endpoint, new RegExp(`/attempts/${latestAttempt}$`));
 });
 
-test('rollback guidance uses the archive identity after roll-forward', () => {
+test('rollback guidance uses the archive identity after redeployment', () => {
   const rolledForward = release({
     archiveAttempt: 1,
     archiveRunId: 700,

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -62,6 +62,22 @@ function legacyIsCurrent(workflowRuns, legacyId) {
   return documentation.length === 0 && latestLegacy?.id === legacyId;
 }
 
+function bootstrapLifecycle(workflowRuns) {
+  const retained = selectPrior(workflowRuns);
+  if (!retained)
+    return {recoverable: false, reselected: '', retained};
+
+  const [runId, , , path] = retained.split('\t');
+  const recoverable =
+    path === '.github/workflows/docs.yml' ||
+    legacyIsCurrent(workflowRuns, Number(runId));
+  return {
+    recoverable,
+    reselected: recoverable ? retained : '',
+    retained,
+  };
+}
+
 function deploymentAssets(manifest) {
   return [
     `deployment-${manifest.deploymentRunId}-${manifest.publicationRunAttempt}.json`,
@@ -384,7 +400,7 @@ test('bootstrap selection skips reruns and continues to an older provable source
   );
   assert.equal(
     selectPrior([legacyRun, rerun]),
-    `${legacyRun.id}\t1\t${legacyRun.head_sha}\t${legacyRun.path}`,
+    '',
   );
   assert.equal(
     filters.every((filter) => filter.includes('.run_attempt == 1')),
@@ -392,7 +408,7 @@ test('bootstrap selection skips reruns and continues to an older provable source
   );
 });
 
-test('a modern attempt-two deployment supersedes legacy policy but is not a bootstrap download', () => {
+test('retain, recovery, and reselection agree after a modern attempt-two deployment', () => {
   const modernRerun = {
     ...legacyRun,
     created_at: '2026-07-29T02:00:00Z',
@@ -408,15 +424,29 @@ test('a modern attempt-two deployment supersedes legacy policy but is not a boot
     .split('latest_legacy_run="$(')[0];
 
   assert.equal(legacyIsCurrent([legacyRun, modernRerun], legacyRun.id), false);
-  assert.equal(
-    selectPrior([legacyRun, modernRerun]),
-    `${legacyRun.id}\t1\t${legacyRun.head_sha}\t${legacyRun.path}`,
+  assert.deepEqual(
+    bootstrapLifecycle([legacyRun, modernRerun]),
+    {recoverable: false, reselected: '', retained: ''},
+  );
+  const legacyIdentity =
+    `${legacyRun.id}\t1\t${legacyRun.head_sha}\t${legacyRun.path}`;
+  assert.deepEqual(
+    bootstrapLifecycle([legacyRun]),
+    {
+      recoverable: true,
+      reselected: legacyIdentity,
+      retained: legacyIdentity,
+    },
   );
   assert.doesNotMatch(rollbackSupersession, /run_attempt == 1/);
   assert.doesNotMatch(pointerSupersession, /run_attempt == 1/);
   assert.equal(
     filters.every((filter) => filter.includes('.run_attempt == 1')),
     true,
+  );
+  assert.match(
+    filters[1],
+    /if any\([\s\S]*?\.github\/workflows\/docs\.yml[\s\S]*?\) then\s+empty/,
   );
 });
 

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -21,6 +21,9 @@ const locateStep = normalizedWorkflow
 const fallbackSelection = locateStep.slice(
   locateStep.indexOf('if [[ -z "$prior" ]]; then'),
 );
+const retainStep = normalizedWorkflow
+  .split('- name: Retain and verify prior Pages artifact')[1]
+  .split('  stage-pages-release:')[0];
 const filters = [
   ...fallbackSelection.matchAll(/jq -r '\n([\s\S]*?)\n\s+' <<<"\$runs"/g),
 ].map((match) => match[1]);
@@ -51,6 +54,7 @@ function deploymentAssets(manifest) {
 function release({
   archiveAttempt = 1,
   archiveRunId = 100,
+  bootstrapSource = false,
   deploymentAttempt = 1,
   deploymentRunId = 200,
   deployAttempt = deploymentAttempt,
@@ -73,6 +77,12 @@ function release({
     sourceSha,
     stageRunAttempt: stageAttempt,
   };
+  if (bootstrapSource) {
+    manifest.bootstrapSource = true;
+    delete manifest.deployRunAttempt;
+    delete manifest.smokeRunAttempt;
+    delete manifest.stageRunAttempt;
+  }
 
   return {
     assets: deploymentAssets(manifest),
@@ -113,10 +123,19 @@ function selectRollback(releases, runId, attempt) {
 function validEvidence(candidate, {archiveAttempts, deploymentAttempts}) {
   const manifest = candidate.manifest;
   const publication = deploymentAttempts[manifest.publicationRunAttempt];
+  const archiveIsValid =
+    archiveAttempts[manifest.archiveRunAttempt]?.build === 'success';
+  if (manifest.bootstrapSource) {
+    return (
+      validRelease(candidate) &&
+      publication?.conclusion === 'success' &&
+      archiveIsValid
+    );
+  }
   return (
     validRelease(candidate) &&
     ['success', 'failure'].includes(publication?.conclusion) &&
-    archiveAttempts[manifest.archiveRunAttempt]?.build === 'success' &&
+    archiveIsValid &&
     deploymentAttempts[manifest.stageRunAttempt]?.['stage-pages-release'] ===
       'success' &&
     deploymentAttempts[manifest.deployRunAttempt]?.deploy === 'success' &&
@@ -154,6 +173,80 @@ test('first documentation deployment retains the latest legacy deployment', () =
   assert.match(
     normalizedWorkflow,
     /"\$pointer_path" == "\.github\/workflows\/jekyll-gh-pages\.yml" &&\s+"\$pointer_event" != push/,
+  );
+});
+
+test('pre-staging documentation archives remain honest bootstrap sources', () => {
+  const bootstrap = release({
+    archiveRunId: 30386738318,
+    bootstrapSource: true,
+    deploymentRunId: 30386738318,
+    publishedAt: 1,
+  });
+  const bootstrapEvidence = {
+    archiveAttempts: {1: {build: 'success'}},
+    deploymentAttempts: {1: {conclusion: 'success'}},
+  };
+  const phased = release({
+    archiveRunId: 30430000000,
+    deploymentRunId: 30430000000,
+    publishedAt: 2,
+  });
+  const phasedEvidence = {
+    archiveAttempts: {1: {build: 'success'}},
+    deploymentAttempts: {
+      1: {
+        conclusion: 'success',
+        deploy: 'success',
+        'production-smoke': 'success',
+        'stage-pages-release': 'success',
+      },
+    },
+  };
+  const failedFirstDeployment = release({
+    archiveRunId: 30420000000,
+    deploymentRunId: 30420000000,
+    draft: true,
+    immutable: false,
+    publishedAt: 2,
+  });
+
+  assert.equal(validEvidence(bootstrap, bootstrapEvidence), true);
+  assert.equal(validEvidence(failedFirstDeployment, phasedEvidence), false);
+  assert.equal(
+    selectRollback(
+      [bootstrap, failedFirstDeployment],
+      bootstrap.manifest.archiveRunId,
+      bootstrap.manifest.archiveRunAttempt,
+    ),
+    bootstrap,
+  );
+  assert.equal(
+    validEvidence(bootstrap, {
+      ...bootstrapEvidence,
+      deploymentAttempts: {1: {conclusion: 'failure'}},
+    }),
+    false,
+  );
+  assert.equal(validEvidence(phased, phasedEvidence), true);
+  assert.equal(
+    [bootstrap, phased].sort(
+      (left, right) => left.publishedAt - right.publishedAt,
+    ).at(-1),
+    phased,
+  );
+  assert.match(retainStep, /"bootstrapSource":true/);
+  assert.doesNotMatch(
+    retainStep,
+    /"stageRunAttempt"|"deployRunAttempt"|"smokeRunAttempt"/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /"\$bootstrap_source" == true[\s\S]*?"\$pointer_conclusion" != success/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /manifest_bootstrap[\s\S]*?Rollback bootstrap publication is invalid/,
   );
 });
 
@@ -588,4 +681,19 @@ test('rollback guidance uses the archive identity after redeployment', () => {
   assert.match(deploymentGuide, /jq -r \.archiveRunId/);
   assert.match(deploymentGuide, /jq -r \.archiveRunAttempt/);
   assert.doesNotMatch(deploymentGuide, /gh run view .*--json .*attempt/);
+});
+
+test('deployment guidance distinguishes staged candidates from final releases', () => {
+  assert.match(
+    deploymentGuide,
+    /draft `docs-pages-candidate-v1-<run-id>-<attempt>` prerelease/,
+  );
+  assert.match(
+    deploymentGuide,
+    /creates and publishes a[\s\S]*?`docs-pages-deployment-v1-<run-id>-<attempt>` release/,
+  );
+  assert.doesNotMatch(
+    deploymentGuide,
+    /draft `docs-pages-deployment-v1-<run-id>-<attempt>` prerelease/,
+  );
 });

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -369,6 +369,7 @@ test('deployment release stays draft until production is verified', () => {
   assert.match(stage, /gh release create "\$release_tag"[\s\S]*?--draft/);
   assert.match(deploy, /needs\.stage-pages-release\.result == 'success'/);
   assert.match(record, /needs\.production-smoke\.result == 'success'/);
+  assert.match(record, /permissions:\n      actions: read\n      contents: write/);
   assert.match(record, /--method PATCH[\s\S]*?-F draft=false/);
   assert.match(record, /"\$draft" != false[\s\S]*?"\$immutable" != true/);
 });

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -72,6 +72,8 @@ test('missing deployment history fails closed', () => {
 test('release operations have repository context without a checkout', () => {
   const workflowEnv = normalizedWorkflow.match(/^env:\n([\s\S]*?)^\S/m)?.[1];
   assert.match(workflowEnv, /^  GH_REPO: \$\{\{ github\.repository \}\}$/m);
+  assert.match(normalizedWorkflow, /defaults:\n  run:\n    shell: bash/);
+  assert.doesNotMatch(normalizedWorkflow, /2>\/dev\/null \|\|\n\s+true/);
 });
 
 test('expensive documentation gates run in parallel before retention', () => {

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -110,6 +110,14 @@ function validAttempt({conclusion, jobs}) {
   );
 }
 
+function productionMatchesCandidate(production, candidate) {
+  return (
+    production.sourceSha === candidate.sourceSha &&
+    production.deploymentRunId === candidate.deploymentRunId &&
+    production.deploymentRunAttempt === candidate.deploymentRunAttempt
+  );
+}
+
 const legacyRun = {
   created_at: '2026-07-28T18:17:11Z',
   head_sha: 'e7a24480ea2e5f796a0528842ef3f2743af4e59a',
@@ -294,6 +302,22 @@ test('failed-job reruns roll the staged attempt forward', () => {
   assert.match(
     normalizedWorkflow,
     /pointer_tag="\$\{release_prefix\}\$\{GITHUB_RUN_ATTEMPT\}"/,
+  );
+  assert.equal(productionMatchesCandidate(staged.manifest, staged.manifest), true);
+  assert.equal(
+    productionMatchesCandidate(
+      {
+        ...staged.manifest,
+        deploymentRunId: 299,
+        deploymentRunAttempt: 1,
+      },
+      staged.manifest,
+    ),
+    false,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /\.deploymentRunId == \$deploymentRunId\s+and \.deploymentRunAttempt == \$deploymentRunAttempt/,
   );
 });
 

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -21,6 +21,13 @@ const locateStep = normalizedWorkflow
 const fallbackSelection = locateStep.slice(
   locateStep.indexOf('if [[ -z "$prior" ]]; then'),
 );
+const legacyPointerPolicy = locateStep.slice(
+  0,
+  locateStep.indexOf('if [[ -z "$prior" ]]; then'),
+);
+const rollbackSourceStep = normalizedWorkflow
+  .split('- name: Validate rollback source')[1]
+  .split('- name: Restore retained Pages artifact')[0];
 const retainStep = normalizedWorkflow
   .split('- name: Retain and verify prior Pages artifact')[1]
   .split('  stage-pages-release:')[0];
@@ -41,6 +48,18 @@ function selectRun(filter, workflowRuns) {
 function selectPrior(workflowRuns) {
   const documentation = selectRun(filters[0], workflowRuns);
   return documentation || selectRun(filters[1], workflowRuns);
+}
+
+function legacyIsCurrent(workflowRuns, legacyId) {
+  const documentation = workflowRuns.filter(
+    ({path}) => path === '.github/workflows/docs.yml',
+  );
+  const latestLegacy = workflowRuns
+    .filter(({path}) => path === '.github/workflows/jekyll-gh-pages.yml')
+    .sort((left, right) => left.created_at.localeCompare(right.created_at))
+    .at(-1);
+
+  return documentation.length === 0 && latestLegacy?.id === legacyId;
 }
 
 function deploymentAssets(manifest) {
@@ -343,6 +362,34 @@ test('bootstrap selection skips reruns and continues to an older provable source
     selectPrior([legacyRun, rerun]),
     `${legacyRun.id}\t1\t${legacyRun.head_sha}\t${legacyRun.path}`,
   );
+  assert.equal(
+    filters.every((filter) => filter.includes('.run_attempt == 1')),
+    true,
+  );
+});
+
+test('a modern attempt-two deployment supersedes legacy policy but is not a bootstrap download', () => {
+  const modernRerun = {
+    ...legacyRun,
+    created_at: '2026-07-29T02:00:00Z',
+    id: 30420000000,
+    path: '.github/workflows/docs.yml',
+    run_attempt: 2,
+  };
+  const rollbackSupersession = rollbackSourceStep
+    .split('latest_docs_run="$(')[1]
+    .split('latest_legacy_run="$(')[0];
+  const pointerSupersession = legacyPointerPolicy
+    .split('latest_docs_run="$(')[1]
+    .split('latest_legacy_run="$(')[0];
+
+  assert.equal(legacyIsCurrent([legacyRun, modernRerun], legacyRun.id), false);
+  assert.equal(
+    selectPrior([legacyRun, modernRerun]),
+    `${legacyRun.id}\t1\t${legacyRun.head_sha}\t${legacyRun.path}`,
+  );
+  assert.doesNotMatch(rollbackSupersession, /run_attempt == 1/);
+  assert.doesNotMatch(pointerSupersession, /run_attempt == 1/);
   assert.equal(
     filters.every((filter) => filter.includes('.run_attempt == 1')),
     true,

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -9,6 +9,12 @@ const workflow = readFileSync(
   'utf8',
 );
 const normalizedWorkflow = workflow.replaceAll('\r\n', '\n');
+const deploymentGuide = readFileSync(
+  fileURLToPath(
+    new URL('../docs/contributing/documentation.mdx', import.meta.url),
+  ),
+  'utf8',
+);
 const locateStep = normalizedWorkflow
   .split('- name: Locate the currently deployable Pages run')[1]
   .split('- name: Inspect retained prior artifact')[0];
@@ -325,4 +331,21 @@ test('stored attempt one is not replaced by latest rerun attempt two', () => {
 
   assert.match(endpoint, /\/attempts\/1$/);
   assert.doesNotMatch(endpoint, new RegExp(`/attempts/${latestAttempt}$`));
+});
+
+test('rollback guidance uses the archive identity after roll-forward', () => {
+  const rolledForward = release({
+    archiveAttempt: 1,
+    archiveRunId: 700,
+    deploymentAttempt: 2,
+    deploymentRunId: 700,
+  });
+
+  assert.notEqual(
+    rolledForward.manifest.archiveRunAttempt,
+    rolledForward.manifest.deploymentRunAttempt,
+  );
+  assert.match(deploymentGuide, /jq -r \.archiveRunId/);
+  assert.match(deploymentGuide, /jq -r \.archiveRunAttempt/);
+  assert.doesNotMatch(deploymentGuide, /gh run view .*--json .*attempt/);
 });

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -102,6 +102,14 @@ function selectRollback(releases, runId, attempt) {
     .at(-1);
 }
 
+function validAttempt({conclusion, jobs}) {
+  const required = ['build', 'deploy', 'production-smoke', 'stage-pages-release'];
+  return (
+    conclusion === 'success' ||
+    required.every((name) => jobs[name] === 'success')
+  );
+}
+
 const legacyRun = {
   created_at: '2026-07-28T18:17:11Z',
   head_sha: 'e7a24480ea2e5f796a0528842ef3f2743af4e59a',
@@ -118,7 +126,11 @@ test('first documentation deployment retains the latest legacy deployment', () =
   );
   assert.match(
     normalizedWorkflow,
-    /\$'success\\tpush\\tmain\\t\.github\/workflows\/jekyll-gh-pages\.yml\\t'/,
+    /"\$pointer_path" == "\.github\/workflows\/jekyll-gh-pages\.yml"/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /"\$pointer_path" == "\.github\/workflows\/jekyll-gh-pages\.yml" &&\s+"\$pointer_event" != push/,
   );
 });
 
@@ -301,6 +313,33 @@ test('ambiguous publication recovers the remotely published candidate', () => {
   assert.match(
     normalizedWorkflow,
     /needs\.record-production-deployment\.result == 'failure'/,
+  );
+});
+
+test('future selection accepts a published pointer after record failure', () => {
+  const jobs = {
+    build: 'success',
+    deploy: 'success',
+    'production-smoke': 'success',
+    'record-production-deployment': 'failure',
+    'stage-pages-release': 'success',
+  };
+
+  assert.equal(validAttempt({conclusion: 'failure', jobs}), true);
+  assert.equal(
+    validAttempt({
+      conclusion: 'failure',
+      jobs: {...jobs, 'production-smoke': 'failure'},
+    }),
+    false,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /actions\/runs\/\$\{deployment_run_id\}\/attempts\/\$\{deployment_run_attempt\}\/jobs/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /"\$pointer_jobs" != "build,deploy,production-smoke,stage-pages-release"/,
   );
 });
 

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -62,6 +62,32 @@ function selectSuccessfulJobs(jobPages) {
   return result.stdout.trimEnd();
 }
 
+function parsePriorTsv(prior, pointer) {
+  const script = `
+set -euo pipefail
+prior=$1
+if [[ $2 == pointer ]]; then
+  IFS=$'\\t' read -r run_id run_attempt source_sha source_path \\
+    deployment_run_id stage_run_attempt deploy_run_attempt \\
+    smoke_run_attempt publication_run_attempt bootstrap_source <<<"$prior"
+  deployment_run_attempt=$publication_run_attempt
+else
+  IFS=$'\\t' read -r run_id run_attempt source_sha source_path <<<"$prior"
+  deployment_run_id=$run_id
+  deployment_run_attempt=$run_attempt
+fi
+printf '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' \\
+  "$run_id" "$run_attempt" "$source_sha" "$source_path" \\
+  "$deployment_run_id" "$deployment_run_attempt"
+`;
+  const result = spawnSync('bash', ['-c', script, 'bash', prior, pointer], {
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trimEnd();
+}
+
 function selectPrior(workflowRuns) {
   const documentation = selectRun(filters[0], workflowRuns);
   return documentation || selectRun(filters[1], workflowRuns);
@@ -520,6 +546,45 @@ test('workflow job queries use the actual paginated slurp response shape', () =>
   assert.equal(iteratorCount, endpointCount);
   assert.doesNotMatch(normalizedWorkflow, /\.\[\]\[\]\.jobs\[\]/);
   assert.match(normalizedWorkflow, /\.\[\]\.workflow_runs\[\]/);
+});
+
+test('pointer and fallback TSVs preserve their distinct deployment identities', () => {
+  const sourceSha = '0123456789abcdef0123456789abcdef01234567';
+  const pointer = [
+    100,
+    1,
+    sourceSha,
+    '.github/workflows/docs.yml',
+    200,
+    1,
+    2,
+    2,
+    3,
+    false,
+  ].join('\t');
+  const fallback = [
+    300,
+    1,
+    sourceSha,
+    '.github/workflows/jekyll-gh-pages.yml',
+  ].join('\t');
+
+  assert.equal(
+    parsePriorTsv(pointer, 'pointer'),
+    `100\t1\t${sourceSha}\t.github/workflows/docs.yml\t200\t3`,
+  );
+  assert.equal(
+    parsePriorTsv(fallback, 'fallback'),
+    `300\t1\t${sourceSha}\t.github/workflows/jekyll-gh-pages.yml\t300\t1`,
+  );
+  assert.match(
+    fallbackSelection,
+    /read -r run_id run_attempt source_sha source_path \\\n\s+<<<"\$prior"[\s\S]*?deployment_run_id="\$run_id"[\s\S]*?deployment_run_attempt="\$run_attempt"/,
+  );
+  assert.doesNotMatch(
+    fallbackSelection,
+    /source_path \\\n\s+deployment_run_id deployment_run_attempt <<<"\$prior"/,
+  );
 });
 
 test('expensive documentation gates run in parallel before retention', () => {

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -39,13 +39,14 @@ const legacyRun = {
   head_sha: 'e7a24480ea2e5f796a0528842ef3f2743af4e59a',
   id: 30386738318,
   path: '.github/workflows/jekyll-gh-pages.yml',
+  run_attempt: 1,
 };
 
 test('first documentation deployment retains the latest legacy deployment', () => {
   assert.equal(filters.length, 2);
   assert.equal(
     selectPrior([legacyRun]),
-    `${legacyRun.id}\t${legacyRun.head_sha}\t${legacyRun.path}`,
+    `${legacyRun.id}\t${legacyRun.run_attempt}\t${legacyRun.head_sha}\t${legacyRun.path}`,
   );
 });
 
@@ -60,7 +61,7 @@ test('subsequent deployments retain the latest successful documentation run', ()
 
   assert.equal(
     selectPrior([legacyRun, documentationRun]),
-    `${documentationRun.id}\t${documentationRun.head_sha}\t${documentationRun.path}`,
+    `${documentationRun.id}\t${documentationRun.run_attempt}\t${documentationRun.head_sha}\t${documentationRun.path}`,
   );
 });
 
@@ -85,16 +86,85 @@ test('expensive documentation gates run in parallel before retention', () => {
   assert.match(retention, /needs:\n      - build\n      - validate/);
 });
 
-test('immutable rollback releases publish complete assets initially', () => {
+test('deployment release stays draft until production is verified', () => {
+  const stage = normalizedWorkflow
+    .split('\n  stage-pages-release:\n')[1]
+    .split('\n  deploy:\n')[0];
+  const deploy = normalizedWorkflow
+    .split('\n  deploy:\n')[1]
+    .split('\n  production-smoke:\n')[0];
+  const record = normalizedWorkflow
+    .split('\n  record-production-deployment:\n')[1]
+    .split('\n  recover-after-production-failure:\n')[0];
+
+  assert.match(stage, /docs-pages-deployment-v1-\$\{GITHUB_RUN_ID\}-\$\{GITHUB_RUN_ATTEMPT\}/);
+  assert.match(stage, /gh release create "\$release_tag"[\s\S]*?--draft/);
+  assert.match(deploy, /needs\.stage-pages-release\.result == 'success'/);
+  assert.match(record, /needs\.production-smoke\.result == 'success'/);
+  assert.match(record, /--method PATCH[\s\S]*?-F draft=false/);
+  assert.match(record, /"\$draft" != false[\s\S]*?"\$immutable" != true/);
+});
+
+test('immutable releases contain exactly archive, checksum, and manifest', () => {
   assert.doesNotMatch(normalizedWorkflow, /gh release upload/);
+  assert.doesNotMatch(normalizedWorkflow, /--method DELETE/);
   assert.match(
     normalizedWorkflow,
-    /gh release create "\$archive_tag" \\\n\s+"[^"]*\$\{archive_name\}" \\\n\s+"[^"]*\$\{checksum_name\}"/,
+    /gh release create "\$release_tag" \\\n\s+"candidate\/\$\{archive_name\}" \\\n\s+"candidate\/\$\{checksum_name\}" \\\n\s+"candidate\/\$\{pointer_name\}"/,
+  );
+  assert.match(normalizedWorkflow, /"\$asset_count" != 3/);
+  assert.match(
+    normalizedWorkflow,
+    /"\$asset_names" != "\$\{pointer_name\},\$\{archive_name\},\$\{checksum_name\}"/,
+  );
+  assert.match(normalizedWorkflow, /sha256sum -c "\$checksum_name"/);
+  assert.match(normalizedWorkflow, /cmp "candidate\/\$\{pointer_name\}"/);
+});
+
+test('rollback is bound to an exact successful run attempt', () => {
+  assert.match(normalizedWorkflow, /inputs:\n\s+rollback_run_id:[\s\S]*?rollback_run_attempt:/);
+  assert.match(
+    normalizedWorkflow,
+    /"\$run_attempt" != "\$ROLLBACK_RUN_ATTEMPT"/,
   );
   assert.match(
     normalizedWorkflow,
-    /gh release create "\$pointer_tag" \\\n\s+"\$pointer_name"/,
+    /\.archiveRunAttempt == \$archiveRunAttempt/,
   );
-  assert.match(normalizedWorkflow, /docs-pages-archive-\$\{GITHUB_RUN_ID\}/);
-  assert.match(normalizedWorkflow, /docs-pages-deployment-\$\{GITHUB_RUN_ID\}/);
+  assert.match(
+    normalizedWorkflow,
+    /-f "rollback_run_attempt=\$\{recovery_run_attempt\}"/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /-f "expected_pointer_run_attempt=\$\{expected_pointer_run_attempt\}"/,
+  );
+});
+
+test('draft, malformed, incomplete, and digest-mismatched releases fail closed', () => {
+  const selection = normalizedWorkflow
+    .split('- name: Locate the currently deployable Pages run')[1]
+    .split('- name: Inspect retained prior artifact')[0];
+
+  assert.match(selection, /select\(\.draft == false and \.immutable == true\)/);
+  assert.match(selection, /select\(\.schemaVersion == 1\)/);
+  assert.match(selection, /"\$asset_count" != 3/);
+  assert.match(selection, /"\$pointer_count" != 1/);
+  assert.match(normalizedWorkflow, /sha256sum -c "\$checksum_name"/);
+});
+
+test('failed smoke or publication dispatches exact prior recovery', () => {
+  const recovery = normalizedWorkflow.split(
+    '\n  recover-after-production-failure:\n',
+  )[1];
+
+  assert.match(recovery, /needs\.production-smoke\.result == 'failure'/);
+  assert.match(
+    recovery,
+    /needs\.record-production-deployment\.result == 'failure'/,
+  );
+  assert.match(
+    recovery,
+    /"\$recovery_run_id" == "\$REQUESTED_ROLLBACK_RUN_ID" &&\n\s+"\$recovery_run_attempt" == "\$REQUESTED_ROLLBACK_RUN_ATTEMPT"/,
+  );
 });


### PR DESCRIPTION
## Summary

- run manifest/API validation, Native AOT/runtime validation, and the site build in parallel with per-lane immutable caches
- stage each Pages artifact as a draft `docs-pages-candidate-v1-<run-id>-<attempt>` prerelease containing exactly the archive, SHA-256 checksum, and schema-validated staging manifest
- after deploy and smoke, create and publish a separate final `docs-pages-deployment-v1-<run-id>-<publication-attempt>` release with exact archive, stage, deploy, smoke, and publication provenance
- select only published immutable releases whose archive/build and stage/deploy/smoke evidence succeeds at every exact recorded attempt
- keep partial reruns valid when successful stage, deploy, smoke, and publication jobs span different workflow attempts
- bind publication to the exact archive identity still served in production so a completed recovery cannot be overwritten by a stale rerun
- reconcile an ambiguous publish by recovering the remotely published exact candidate when deploy and smoke evidence are already successful
- retain a remotely published final release after recording failure only when every recorded phase has exact successful job evidence
- classify pre-staging documentation archives as bootstrap sources without fabricating stage, deploy, or smoke evidence, then replace them with fully phased releases
- retain only single-attempt pre-staging runs, verify the downloaded artifact's historical embedded SHA, and skip reruns in favor of an older provable source
- let every successful modern deployment, including attempt-two reruns, supersede legacy rollback policy even though rerun artifacts are ineligible for bootstrap download
- reject existing bootstrap releases that claim an unverifiable archive attempt other than one in both future selection and rollback
- after any modern docs success, never fall back across the migration boundary to legacy; use an older provable modern source or fail closed
- parse every paginated workflow-jobs response as the actual slurped object array while keeping workflow-run pagination distinct
- keep existing-pointer and fallback TSV shapes separate so publication attempt/tag identity survives retention and recovery
- recover after either production smoke or deployment-recording failure while preserving non-canceling Pages concurrency
- leave the audited empty immutable `docs-pages-archive` tombstone untouched

## Failure evidence

- main run `30415997847` built successfully and verified the legacy artifact checksum, then failed retention with HTTP 422: `Cannot upload assets to an immutable release`
- exact audit of release ID `361480912`: tag `docs-pages-archive`, immutable, zero assets, target `e7a24480ea2e5f796a0528842ef3f2743af4e59a`
- earlier main runs `30405284519`, `30407080221`, and `30408908449` exposed the empty-history bootstrap boundary; run `30413601589` then exposed missing repository context
- the last valid legacy Pages source remains run `30386738318`, attempt `1`, SHA `e7a24480ea2e5f796a0528842ef3f2743af4e59a`, artifact `8699250030`

## Validation

- workflow YAML parse plus `bash -n` for every Bash step
- `pnpm --dir website test:unit` (43 passed)
- `pnpm --dir website check:content`
- `pnpm --dir website typecheck`
- `pnpm --dir website build`
- `pnpm --dir website check:links`
- `pnpm --dir website check:search-budget`
- `pnpm --dir website check:artifact`
- earlier exact-head validation also passed `pwsh ./tools/docs/build.ps1 -Mode Validate` and `pwsh ./tools/docs/test.ps1 -RequireNativeAot`
- contract coverage exercises empty-history and pre-staging bootstrap recovery, historical SHA validation, connected retain/recovery/reselection after reruns, fail-closed migration boundaries, real workflow-jobs pagination shape, executable pointer/fallback TSV identity, modern-rerun legacy supersession, replacement by fully phased releases, per-gate caches, draft/publication ordering, exact asset/checksum/manifest shape, malformed/incomplete rejection, failed-job reruns, remote-success/client-failure publication, exact older-attempt rollback, manifest-derived operator rollback, and recovery after smoke or recording failure

## Post-merge verification

A fresh main Documentation run must complete `retain-pages-artifacts`, `stage-pages-release`, `deploy`, `production-smoke`, and `record-production-deployment`. Afterward, the unique release target, immutable state, exact three assets, checksum, manifest, run attempt, and production `deployment.json` will be audited before cleanup.

## Checklist

- [x] Existing artifact, SHA, manifest, and checksum validations remain fail-closed
- [x] Published releases are never uploaded to, rewritten, or deleted
- [x] Abandoned drafts cannot become rollback sources
- [x] Recovery is guarded by exact archive and deployment run attempts
- [x] Parallel validation retains every existing gate
