### PR TITLE
fix(docs): preserve legacy fragments after static redirects

### DIFF
--- a/website/src/theme/legacyRedirects.mjs
+++ b/website/src/theme/legacyRedirects.mjs
@@ -83,8 +83,9 @@ export function resolveLegacyFragmentFromReferrer(
   const redirect = redirects.find(
     ({from, referrers = []}) =>
       referrerPathnames.some(
-        (pathname) =>
-          from.includes(pathname) || referrers.includes(pathname),
+        (referrerPathname) =>
+          from.includes(referrerPathname) ||
+          referrers.includes(referrerPathname),
       ),
   );
   if (!redirect || redirect.to !== pathname) {

--- a/website/src/theme/legacyRedirects.mjs
+++ b/website/src/theme/legacyRedirects.mjs
@@ -76,10 +76,16 @@ export function resolveLegacyFragmentFromReferrer(
     return undefined;
   }
 
+  const referrerPathnames = [
+    referrerUrl.pathname,
+    referrerUrl.pathname.replace(/\/$/, ''),
+  ];
   const redirect = redirects.find(
     ({from, referrers = []}) =>
-      from.includes(referrerUrl.pathname) ||
-      referrers.includes(referrerUrl.pathname),
+      referrerPathnames.some(
+        (pathname) =>
+          from.includes(pathname) || referrers.includes(pathname),
+      ),
   );
   if (!redirect || redirect.to !== pathname) {
     return undefined;

--- a/website/tests/e2e/reader-shell.spec.ts
+++ b/website/tests/e2e/reader-shell.spec.ts
@@ -530,7 +530,10 @@ test('static redirect documents remap fragments after directory normalization', 
   await page.route('**/docs/quick-start.md/**', (route) =>
     route.fulfill({
       contentType: 'text/html',
-      path: path.resolve('build/docs/quick-start.md/index.html'),
+      path: path.resolve(
+        __dirname,
+        '../../build/docs/quick-start.md/index.html',
+      ),
     }),
   );
 

--- a/website/tests/e2e/reader-shell.spec.ts
+++ b/website/tests/e2e/reader-shell.spec.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import {expect, test, type Route} from '@playwright/test';
 import versionManifest from '../../humanizer-versions.json';
 
@@ -521,6 +522,23 @@ test('legacy URLs preserve supported destinations, queries, and fragments', asyn
   const prefixResponse = await page.goto('/docs/localization.md/extra');
   expect(prefixResponse?.status()).toBe(404);
   await expect(page).toHaveURL('/docs/localization.md/extra/');
+});
+
+test('static redirect documents remap fragments after directory normalization', async ({
+  page,
+}) => {
+  await page.route('**/docs/quick-start.md/**', (route) =>
+    route.fulfill({
+      contentType: 'text/html',
+      path: path.resolve('build/docs/quick-start.md/index.html'),
+    }),
+  );
+
+  await page.goto('/docs/quick-start.md/?source=legacy#basic-examples');
+  await expect(page).toHaveURL(
+    '/docs/start/quick-start/?source=legacy#example',
+  );
+  await expect(page.locator('#example')).toBeVisible();
 });
 
 test('version dropdown exposes every manifest snapshot and preview', async ({

--- a/website/tests/legacyRedirects.test.mjs
+++ b/website/tests/legacyRedirects.test.mjs
@@ -31,6 +31,16 @@ test('same-origin exact legacy referrers can migrate a fragment', () => {
     ),
     '/docs/start/installation/?source=legacy#example',
   );
+  assert.equal(
+    resolveLegacyFragmentFromReferrer(
+      '/docs/start/quick-start/',
+      '?source=legacy',
+      '#basic-examples',
+      `${origin}/docs/quick-start.md/?source=legacy`,
+      origin,
+    ),
+    '/docs/start/quick-start/?source=legacy#example',
+  );
 });
 
 test('direct canonical visits and unrelated referrers cannot migrate fragments', () => {


### PR DESCRIPTION
## Summary

- normalize same-origin legacy referrer paths after static hosting adds a trailing slash
- preserve the historical `basic-examples` to `example` fragment mapping for generated `.md` redirects
- cover the actual generated redirect document in Playwright

Main Documentation run 30426109465 deployed successfully, then production smoke failed because `/docs/quick-start.md?source=production#basic-examples` retained the old fragment. Recovery job 90495374504 completed successfully and publication remained blocked.

## Validation

- `pnpm --dir website run test:unit` (43 passed)
- `pnpm --dir website run build`
- `pnpm --dir website run typecheck`
- `pnpm --dir website run check:content`
- `pnpm --dir website run check:links`
- `pnpm --dir website run check:artifact`
- `pnpm --dir website run test:e2e` (13 passed)
- built static redirect served with WEBrick and verified in Chromium

## Checklist

- [x] Implementation is clean
- [x] Code follows existing standards
- [x] Proper unit and browser coverage is included
- [x] Rebased onto current `main`
- [x] Applicable documentation gates passed
- [x] No copied code
- [x] No public API or README change required

After merge, a fresh main Documentation run will be watched through retention, staging, deploy, production smoke, recovery disposition, and final immutable publication.