### PR TITLE
fix(docs): retry draft release discovery

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1247,7 +1247,7 @@ jobs:
             "$GITHUB_RUN_ID" \
             "$GITHUB_RUN_ATTEMPT" \
             > "candidate/${pointer_name}"
-          release="$(
+          find_candidate_release() {
             gh api \
               --paginate \
               --slurp \
@@ -1272,7 +1272,8 @@ jobs:
                   ]
                 | @tsv
               '
-          )"
+          }
+          release="$(find_candidate_release)"
           if [[ -z "$release" ]]; then
             gh release create "$release_tag" \
               "candidate/${archive_name}" \
@@ -1284,33 +1285,16 @@ jobs:
               --target "$SOURCE_SHA" \
               --title "Documentation deployment ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" \
               --notes "Automation-owned exact deployment candidate."
+            for attempt in {1..10}; do
+              release="$(find_candidate_release)"
+              [[ -n "$release" ]] && break
+              sleep 1
+            done
           fi
-          release="$(
-            gh api \
-              --paginate \
-              --slurp \
-              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
-              jq -r --arg tag "$release_tag" '
-                [
-                  .[][]
-                  | select(.tag_name == $tag)
-                ]
-                | if length != 1 then
-                    error("candidate release is unavailable or duplicated")
-                  else
-                    first
-                  end
-                | [
-                    .id,
-                    .draft,
-                    .immutable,
-                    .target_commitish,
-                    (.assets | length),
-                    ([.assets[].name] | sort | join(","))
-                  ]
-                | @tsv
-              '
-          )"
+          if [[ -z "$release" ]]; then
+            echo "Candidate release did not become visible." >&2
+            exit 1
+          fi
           IFS=$'\t' read -r release_id draft immutable target \
             asset_count asset_names <<<"$release"
           if [[ ! "$release_id" =~ ^[0-9]+$ ||

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -620,6 +620,52 @@ test('deployment release stays draft until production is verified', () => {
   assert.match(record, /"\$draft" != false[\s\S]*?"\$immutable" != true/);
 });
 
+test('candidate staging tolerates eventual release-list visibility', () => {
+  const sourceSha = '0123456789abcdef0123456789abcdef01234567';
+  const stage = normalizedWorkflow
+    .split('\n  stage-pages-release:\n')[1]
+    .split('\n  deploy:\n')[0];
+  const filter = stage.match(
+    /jq -r --arg tag "\$release_tag" '\n([\s\S]*?)\n\s+'/,
+  )?.[1];
+  assert.ok(filter);
+  assert.match(
+    stage,
+    /for attempt in \{1\.\.10\}; do[\s\S]*?release="\$\(find_candidate_release\)"[\s\S]*?\[\[ -n "\$release" \]\] && break[\s\S]*?sleep 1/,
+  );
+
+  const candidate = {
+    assets: [
+      {name: 'github-pages-100-1.tar.sha256'},
+      {name: 'deployment-200-1.json'},
+      {name: 'github-pages-100-1.tar'},
+    ],
+    draft: true,
+    id: 300,
+    immutable: false,
+    tag_name: 'docs-pages-candidate-v1-200-1',
+    target_commitish: sourceSha,
+  };
+  const select = (pages) =>
+    spawnSync(
+      'jq',
+      ['-r', '--arg', 'tag', candidate.tag_name, filter],
+      {
+        encoding: 'utf8',
+        input: JSON.stringify(pages),
+      },
+    );
+
+  assert.equal(select([[]]).stdout, '');
+  const visible = select([[], [candidate]]);
+  assert.equal(visible.status, 0, visible.stderr);
+  assert.equal(
+    visible.stdout.trimEnd(),
+    `300\ttrue\tfalse\t${sourceSha}\t3\tdeployment-200-1.json,github-pages-100-1.tar,github-pages-100-1.tar.sha256`,
+  );
+  assert.notEqual(select([[candidate, candidate]]).status, 0);
+});
+
 test('immutable releases contain exactly archive, checksum, and manifest', () => {
   assert.doesNotMatch(normalizedWorkflow, /gh release upload/);
   assert.doesNotMatch(normalizedWorkflow, /--method DELETE/);

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -656,8 +656,10 @@ test('candidate staging tolerates eventual release-list visibility', () => {
       },
     );
 
-  assert.equal(select([[]]).stdout, '');
-  const visible = select([[], [candidate]]);
+  const absent = select([[]]);
+  assert.equal(absent.status, 0, absent.stderr);
+  assert.equal(absent.stdout, '');
+  const visible = select([[candidate]]);
   assert.equal(visible.status, 0, visible.stderr);
   assert.equal(
     visible.stdout.trimEnd(),


### PR DESCRIPTION
## Summary

- reuse the exact candidate release selector before and after draft creation
- retry draft visibility for at most ten seconds after `gh release create`
- preserve duplicate, target SHA, asset count/name, mutability, checksum, manifest, and archive validation

Main Documentation run 30429120666 passed build, manifests, runtime, and retention. `stage-pages-release` created draft `docs-pages-candidate-v1-30429120666-1` with all three assets, but the immediate paginated release-list query did not expose it yet and failed closed. The draft is now visible and remains untouched.

## Validation

- `node --test website/tests/pages-run-selection.test.mjs` (28 passed)
- `pnpm --dir website run test:unit` (44 passed)
- `pnpm --dir website run check:content`
- `pnpm --dir website run typecheck`

The new executable contract runs the workflow jq selector against an empty list, later visible candidate, and duplicate candidates.

## Checklist

- [x] Implementation is focused and fail-closed
- [x] Rebased onto current `main`
- [x] Applicable docs workflow contracts passed
- [x] No existing draft/release was modified or deleted

After merge, a fresh main Documentation run will be watched through retention, staging, deploy, production smoke, and final immutable publication.