### PR TITLE
Fix final documentation release visibility

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1653,7 +1653,7 @@ jobs:
             "$GITHUB_RUN_ATTEMPT" \
             > "final/${pointer_name}"
           pointer_tag="docs-pages-deployment-v1-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          release="$(
+          find_final_release() {
             gh api \
               --paginate \
               --slurp \
@@ -1675,10 +1675,11 @@ jobs:
                     .target_commitish,
                     (.assets | length),
                     ([.assets[].name] | sort | join(","))
-                  ]
+                ]
                 | @tsv
               '
-          )"
+          }
+          release="$(find_final_release)"
           if [[ -z "$release" ]]; then
             gh release create "$pointer_tag" \
               "final/${archive_name}" \
@@ -1690,33 +1691,16 @@ jobs:
               --target "$SOURCE_SHA" \
               --title "Documentation deployment ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" \
               --notes "Automation-owned exact deployment release."
+            for attempt in {1..10}; do
+              release="$(find_final_release)"
+              [[ -n "$release" ]] && break
+              sleep 1
+            done
           fi
-          release="$(
-            gh api \
-              --paginate \
-              --slurp \
-              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
-              jq -r --arg tag "$pointer_tag" '
-                [
-                  .[][]
-                  | select(.tag_name == $tag)
-                ]
-                | if length != 1 then
-                    error("final release is unavailable or duplicated")
-                  else
-                    first
-                  end
-                | [
-                    .id,
-                    .draft,
-                    .immutable,
-                    .target_commitish,
-                    (.assets | length),
-                    ([.assets[].name] | sort | join(","))
-                  ]
-                | @tsv
-              '
-          )"
+          if [[ -z "$release" ]]; then
+            echo "Final release did not become visible." >&2
+            exit 1
+          fi
           IFS=$'\t' read -r release_id draft immutable target \
             asset_count asset_names <<<"$release"
           if [[ ! "$release_id" =~ ^[0-9]+$ ||

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -668,6 +668,54 @@ test('candidate staging tolerates eventual release-list visibility', () => {
   assert.notEqual(select([[candidate, candidate]]).status, 0);
 });
 
+test('final publication tolerates eventual release-list visibility', () => {
+  const sourceSha = '0123456789abcdef0123456789abcdef01234567';
+  const record = normalizedWorkflow
+    .split('\n  record-production-deployment:\n')[1]
+    .split('\n  recover-after-production-failure:\n')[0];
+  const filter = record.match(
+    /jq -r --arg tag "\$pointer_tag" '\n([\s\S]*?)\n\s+'/,
+  )?.[1];
+  assert.ok(filter);
+  assert.match(
+    record,
+    /for attempt in \{1\.\.10\}; do[\s\S]*?release="\$\(find_final_release\)"[\s\S]*?\[\[ -n "\$release" \]\] && break[\s\S]*?sleep 1/,
+  );
+
+  const finalRelease = {
+    assets: [
+      {name: 'github-pages-200-1.tar.sha256'},
+      {name: 'deployment-200-1.json'},
+      {name: 'github-pages-200-1.tar'},
+    ],
+    draft: true,
+    id: 400,
+    immutable: false,
+    tag_name: 'docs-pages-deployment-v1-200-1',
+    target_commitish: sourceSha,
+  };
+  const select = (pages) =>
+    spawnSync(
+      'jq',
+      ['-r', '--arg', 'tag', finalRelease.tag_name, filter],
+      {
+        encoding: 'utf8',
+        input: JSON.stringify(pages),
+      },
+    );
+
+  const absent = select([[]]);
+  assert.equal(absent.status, 0, absent.stderr);
+  assert.equal(absent.stdout, '');
+  const visible = select([[finalRelease]]);
+  assert.equal(visible.status, 0, visible.stderr);
+  assert.equal(
+    visible.stdout.trimEnd(),
+    `400\ttrue\tfalse\t${sourceSha}\t3\tdeployment-200-1.json,github-pages-200-1.tar,github-pages-200-1.tar.sha256`,
+  );
+  assert.notEqual(select([[finalRelease, finalRelease]]).status, 0);
+});
+
 test('immutable releases contain exactly archive, checksum, and manifest', () => {
   assert.doesNotMatch(normalizedWorkflow, /gh release upload/);
   assert.doesNotMatch(normalizedWorkflow, /--method DELETE/);


### PR DESCRIPTION
## Summary

- retry exact final-release discovery after GitHub creates the draft but before it becomes visible in the paginated Releases list
- reuse the existing draft on reruns and preserve exact tag, SHA, asset, checksum, and immutable publication validation
- add executable coverage for absent, eventually visible, and duplicate final releases

## Failure evidence

Main Documentation run 30431909271 passed build, retention, staging, deploy, and production smoke. `record-production-deployment` job 90513964988 then created draft release `docs-pages-deployment-v1-30431909271-1` (ID 361581081) with all three exact assets, but the immediate list lookup failed with `final release is unavailable or duplicated`. Recovery job 90514031998 succeeded.

## Validation

- `node --test website/tests/pages-run-selection.test.mjs` (29/29)
- `pnpm --dir website run test:unit` (45/45)
- `pnpm --dir website run check:content`
- `pnpm --dir website run typecheck`
- `git diff --check`

## Post-merge verification

Watch a fresh main Documentation run through build, immutable retention, staging, deploy, production smoke, and final immutable release publication.