### PR TITLE
docs: document full number word ranges

### DIFF
--- a/website/docs/_examples/scenarios-numbers/Program.cs
+++ b/website/docs/_examples/scenarios-numbers/Program.cs
@@ -17,6 +17,8 @@ AssertEqual("-9223372036854775808th", long.MinValue.Ordinalize(culture));
 AssertEqual("biljard", 1_000_000_000_000_000L.ToWords(estonian));
 AssertEqual("dy biliarë", 2_000_000_000_000_000L.ToWords(albanian));
 AssertEqual("triljon", 1_000_000_000_000_000_000L.ToWords(estonian));
+AssertNotEmpty(long.MaxValue.ToWords(estonian));
+AssertNotEmpty(long.MinValue.ToWords(estonian));
 AssertEqual("one arab", 1_000_000_000L.ToIndianWords());
 AssertEqual(
     "one hundred crore",
@@ -42,6 +44,12 @@ static void AssertEqual<T>(T expected, T actual)
 {
     if (!EqualityComparer<T>.Default.Equals(actual, expected))
         throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
+}
+
+static void AssertNotEmpty(string actual)
+{
+    if (string.IsNullOrWhiteSpace(actual))
+        throw new InvalidOperationException("Expected localized number words.");
 }
 
 static void AssertThrows<TException>(Action action)

--- a/website/docs/scenarios/numbers-in-words-and-ordinals.mdx
+++ b/website/docs/scenarios/numbers-in-words-and-ordinals.mdx
@@ -96,8 +96,11 @@ domain policy separately.
 On `main/preview`, every built-in number-word locale supports the full signed
 `long` range. Estonian follows its authored scale names through `triljon`;
 Albanian uses `miliar`, `bilion`, `biliar`, and `trilion`, with their plural
-forms. Custom converters can retain narrower ranges when their profiles do not
-define the required scale words.
+forms. The executable above calls `ToWords` for both `long.MaxValue` and
+`long.MinValue`; supported built-in locales no longer use magnitude ceilings
+or `NotImplementedException` as a partial-coverage boundary. Custom converters
+can retain narrower ranges when their profiles do not define the required
+scale words.
 
 ## Pitfall
 


### PR DESCRIPTION
## Summary

- document full signed-`long` support for built-in number-word locales
- exercise `long.MaxValue` and `long.MinValue` in the runnable number-word example
- remove the old magnitude-ceiling and `NotImplementedException` partial-coverage guidance

This is the parity-owned documentation follow-up to #1889. Auto-merge completed #1889 while its final documentation validation was still running; this PR contains only the validated number-word documentation delta.

## Validation

- `dotnet format Humanizer.slnx --include website/docs/_examples/scenarios-numbers/Program.cs --verify-no-changes --verbosity diagnostic`
- `pwsh tools/docs/generate-language-coverage.ps1 -Check`
- `pwsh tools/docs/build.ps1 -Mode Validate`
- `git diff --check`

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings introduced
- [x] Proper executable documentation coverage is included
- [x] XML documentation is not applicable
- [x] The change is based on the exact merged #1889 tree plus this docs-only commit
- [x] Documentation gates were run