### PR TITLE
docs(ui): add responsive no-scroll tables

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,11 +1,16 @@
 :root {
-  --humanizer-paper: #f7f3e9;
-  --humanizer-paper-raised: #fffdf7;
-  --humanizer-ink: #172026;
-  --humanizer-ink-muted: #566269;
-  --humanizer-rule: #c9c4b8;
-  --humanizer-accent: #056b84;
-  --humanizer-accent-warm: #ad3e2a;
+  --humanizer-paper: #f4fbff;
+  --humanizer-paper-raised: #fff;
+  --humanizer-ink: #0b2a3d;
+  --humanizer-ink-muted: #3f6175;
+  --humanizer-rule: #add7e8;
+  --humanizer-accent: #006b95;
+  --humanizer-accent-warm: #c62f43;
+  --humanizer-accent-deep: #045b7b;
+  --humanizer-logo-blue: #00afef;
+  --humanizer-panel: #082f49;
+  --humanizer-panel-ink: #f4fbff;
+  --humanizer-panel-accent: #71d8ff;
   --humanizer-all-versions-width: 7.5rem;
   --pf-input-height: 2.75rem;
   --humanizer-display:
@@ -16,13 +21,13 @@
   --ifm-background-surface-color: var(--humanizer-paper-raised);
   --ifm-color-content: var(--humanizer-ink);
   --ifm-color-content-secondary: var(--humanizer-ink-muted);
-  --ifm-color-primary: #056b84;
-  --ifm-color-primary-dark: #056078;
-  --ifm-color-primary-darker: #055b71;
-  --ifm-color-primary-darkest: #044b5e;
-  --ifm-color-primary-light: #067690;
-  --ifm-color-primary-lighter: #087e9b;
-  --ifm-color-primary-lightest: #0b94b2;
+  --ifm-color-primary: #006b95;
+  --ifm-color-primary-dark: #006086;
+  --ifm-color-primary-darker: #005b7f;
+  --ifm-color-primary-darkest: #004b69;
+  --ifm-color-primary-light: #0076a4;
+  --ifm-color-primary-lighter: #007bab;
+  --ifm-color-primary-lightest: #008bc2;
   --ifm-font-family-base: var(--humanizer-body);
   --ifm-heading-font-family: var(--humanizer-display);
   --ifm-heading-font-weight: 600;
@@ -34,32 +39,36 @@
     transparent
   );
   --ifm-navbar-shadow: 0 1px 0 var(--humanizer-rule);
-  --ifm-footer-background-color: #172026;
-  --ifm-footer-color: #edf3f2;
+  --ifm-footer-background-color: #082f49;
+  --ifm-footer-color: #f4fbff;
   --ifm-toc-border-color: var(--humanizer-rule);
 }
 
 [data-theme='dark'] {
-  --humanizer-paper: #11191c;
-  --humanizer-paper-raised: #192327;
-  --humanizer-ink: #edf3f2;
-  --humanizer-ink-muted: #a9b9b9;
-  --humanizer-rule: #3a494d;
-  --humanizer-accent: #63c4d8;
-  --humanizer-accent-warm: #f28b73;
-  --ifm-color-primary: #63c4d8;
-  --ifm-color-primary-dark: #47b9d0;
-  --ifm-color-primary-darker: #3ab5cd;
-  --ifm-color-primary-darkest: #2b96ab;
-  --ifm-color-primary-light: #7fcede;
-  --ifm-color-primary-lighter: #8dd3e1;
-  --ifm-color-primary-lightest: #b7e4ed;
+  --humanizer-paper: #061b2a;
+  --humanizer-paper-raised: #0c2a3c;
+  --humanizer-ink: #f4fbff;
+  --humanizer-ink-muted: #b8d5e2;
+  --humanizer-rule: #315b6f;
+  --humanizer-accent: #56d0ff;
+  --humanizer-accent-warm: #ff7e8b;
+  --humanizer-accent-deep: #073e5a;
+  --humanizer-panel: #031522;
+  --humanizer-panel-ink: #f4fbff;
+  --humanizer-panel-accent: #71d8ff;
+  --ifm-color-primary: #56d0ff;
+  --ifm-color-primary-dark: #38c7ff;
+  --ifm-color-primary-darker: #29c3ff;
+  --ifm-color-primary-darkest: #00a8e7;
+  --ifm-color-primary-light: #74d9ff;
+  --ifm-color-primary-lighter: #83ddff;
+  --ifm-color-primary-lightest: #b0eaff;
   --ifm-navbar-background-color: color-mix(
     in srgb,
     var(--humanizer-paper) 94%,
     transparent
   );
-  --ifm-footer-background-color: #0b1113;
+  --ifm-footer-background-color: #03111b;
 }
 
 html {
@@ -96,11 +105,11 @@ input {
 
 .navbar .aa-Autocomplete {
   --aa-muted-color-alpha: 1;
-  --aa-muted-color-rgb: 86, 98, 105;
+  --aa-muted-color-rgb: 63, 97, 117;
 }
 
 [data-theme='dark'] .navbar .aa-Autocomplete {
-  --aa-muted-color-rgb: 169, 185, 185;
+  --aa-muted-color-rgb: 184, 213, 226;
 }
 
 .navbar__brand,
@@ -123,10 +132,8 @@ input {
 }
 
 .navbar__logo img {
-  background: #fff;
-  box-sizing: border-box;
+  display: block;
   height: 1.9rem;
-  padding: 0.1rem;
   width: 1.9rem;
 }
 
@@ -240,7 +247,7 @@ body:has(.navbar-sidebar--show) .humanizerAllVersionsShell {
   padding-top: 1rem;
 }
 
-.theme-doc-markdown :is(pre, table) {
+.theme-doc-markdown :is(pre, .humanizerResponsiveTableFrame, table) {
   max-width: 100%;
 }
 
@@ -249,29 +256,34 @@ body:has(.navbar-sidebar--show) .humanizerAllVersionsShell {
   overscroll-behavior-inline: contain;
 }
 
-.theme-doc-markdown table {
-  display: block;
-  overflow-x: auto;
-  white-space: nowrap;
+.humanizerResponsiveTableFrame {
+  align-self: center;
+  max-width: 100%;
+  overflow: visible;
+  width: 100%;
+}
+
+.humanizerResponsiveTable {
+  border-collapse: collapse;
+  display: table;
+  overflow: visible;
+  table-layout: fixed;
+  white-space: normal;
+  width: 100%;
+}
+
+.humanizerResponsiveTable :is(th, td) {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .theme-doc-markdown .languageCoverageRegion {
-  border: 1px solid var(--humanizer-rule);
-  max-height: min(70vh, 42rem);
   max-width: 100%;
-  overflow: auto;
-  overscroll-behavior: contain;
 }
 
 .theme-doc-markdown .languageCoverageRegion table {
-  border-collapse: separate;
-  border-spacing: 0;
-  display: table;
   margin: 0;
-  min-width: 100%;
-  overflow: visible;
-  white-space: nowrap;
-  width: max-content;
 }
 
 .languageCoverageRegion caption {
@@ -279,24 +291,6 @@ body:has(.navbar-sidebar--show) .humanizerAllVersionsShell {
   font-weight: 700;
   padding: 0.75rem 1rem;
   text-align: left;
-}
-
-.languageCoverageRegion thead th {
-  background: var(--humanizer-paper-raised);
-  position: sticky;
-  top: 0;
-  z-index: 2;
-}
-
-.languageCoverageRegion :is(th, td):first-child {
-  background: var(--humanizer-paper-raised);
-  left: 0;
-  position: sticky;
-  z-index: 1;
-}
-
-.languageCoverageRegion thead th:first-child {
-  z-index: 3;
 }
 
 .supportedCultureList {
@@ -406,25 +400,89 @@ body:has(.navbar-sidebar--show) .humanizerAllVersionsShell {
 }
 
 html:root:not([data-theme='dark']) {
-  --pf-text-muted: #626262;
-  --pf-text-secondary: #4f5358;
+  --pf-text-muted: #496a7d;
+  --pf-text-secondary: #34556a;
 }
 
 html:root[data-theme='dark'] {
-  --pf-background: #22242e;
-  --pf-border: #55596b;
-  --pf-border-focus: #a7b1d6;
-  --pf-hover: #303340;
-  --pf-mark: #ffffff;
-  --pf-skeleton: #393c4a;
-  --pf-skeleton-shine: #474a5a;
-  --pf-text: #f8f8f2;
-  --pf-text-muted: #c4c8d4;
-  --pf-text-secondary: #d7dae2;
+  --pf-background: #0c2a3c;
+  --pf-border: #315b6f;
+  --pf-border-focus: #71d8ff;
+  --pf-hover: #12384e;
+  --pf-mark: #f4fbff;
+  --pf-skeleton: #173e53;
+  --pf-skeleton-shine: #1d4a61;
+  --pf-text: #f4fbff;
+  --pf-text-muted: #b8d5e2;
+  --pf-text-secondary: #d8edf5;
 }
 
 html[data-theme='dark'] .prism-code .token.comment {
-  color: #a7b1d6 !important;
+  color: var(--humanizer-ink-muted) !important;
+}
+
+@media (max-width: 996px) {
+  .humanizerResponsiveTable {
+    border: 0;
+    display: block;
+  }
+
+  .humanizerResponsiveTable thead {
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+
+  .humanizerResponsiveTable caption {
+    display: block;
+  }
+
+  .humanizerResponsiveTable tbody {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .humanizerResponsiveTable tbody tr {
+    border: 1px solid var(--humanizer-rule);
+    display: grid;
+  }
+
+  .humanizerResponsiveTable tbody :is(th, td) {
+    border: 0;
+    border-bottom: 1px solid var(--humanizer-rule);
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: minmax(6.5rem, 35%) minmax(0, 1fr);
+    padding: 0.65rem 0.75rem;
+    width: 100%;
+  }
+
+  .humanizerResponsiveTable tbody th[scope='row'] {
+    background: var(--humanizer-paper-raised);
+    display: block;
+  }
+
+  .humanizerResponsiveTable tbody :is(th, td):last-child {
+    border-bottom: 0;
+  }
+
+  .humanizerResponsiveTable tbody td::before {
+    color: var(--humanizer-ink-muted);
+    content: attr(data-label);
+    font-size: 0.78rem;
+    font-weight: 800;
+  }
+
+  .humanizerResponsiveTable tbody td[data-label=''] {
+    grid-template-columns: 1fr;
+  }
+
+  .humanizerResponsiveTable tbody td[data-label='']::before {
+    content: none;
+  }
 }
 
 @media (min-width: 997px) {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -421,12 +421,12 @@ html[data-theme='dark'] .prism-code .token.comment {
 }
 
 @media (max-width: 996px) {
-  .humanizerResponsiveTable {
+  .humanizerResponsiveTable--enhanced {
     border: 0;
     display: block;
   }
 
-  .humanizerResponsiveTable thead {
+  .humanizerResponsiveTable--enhanced thead {
     clip-path: inset(50%);
     height: 1px;
     overflow: hidden;
@@ -435,21 +435,21 @@ html[data-theme='dark'] .prism-code .token.comment {
     width: 1px;
   }
 
-  .humanizerResponsiveTable caption {
+  .humanizerResponsiveTable--enhanced caption {
     display: block;
   }
 
-  .humanizerResponsiveTable tbody {
+  .humanizerResponsiveTable--enhanced tbody {
     display: grid;
     gap: 0.75rem;
   }
 
-  .humanizerResponsiveTable tbody tr {
+  .humanizerResponsiveTable--enhanced tbody tr {
     border: 1px solid var(--humanizer-rule);
     display: grid;
   }
 
-  .humanizerResponsiveTable tbody :is(th, td) {
+  .humanizerResponsiveTable--enhanced tbody :is(th, td) {
     border: 0;
     border-bottom: 1px solid var(--humanizer-rule);
     display: grid;
@@ -459,27 +459,29 @@ html[data-theme='dark'] .prism-code .token.comment {
     width: 100%;
   }
 
-  .humanizerResponsiveTable tbody th[scope='row'] {
+  .humanizerResponsiveTable--enhanced tbody th[scope='row'] {
     background: var(--humanizer-paper-raised);
     display: block;
   }
 
-  .humanizerResponsiveTable tbody :is(th, td):last-child {
+  .humanizerResponsiveTable--enhanced tbody :is(th, td):last-child {
     border-bottom: 0;
   }
 
-  .humanizerResponsiveTable tbody td::before {
+  .humanizerResponsiveTable--enhanced tbody td::before {
     color: var(--humanizer-ink-muted);
     content: attr(data-label);
     font-size: 0.78rem;
     font-weight: 800;
   }
 
-  .humanizerResponsiveTable tbody td:is([data-label=''], :not([data-label])) {
+  .humanizerResponsiveTable--enhanced
+    tbody
+    td:is([data-label=''], :not([data-label])) {
     grid-template-columns: 1fr;
   }
 
-  .humanizerResponsiveTable
+  .humanizerResponsiveTable--enhanced
     tbody
     td:is([data-label=''], :not([data-label]))::before {
     content: none;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -39,8 +39,8 @@
     transparent
   );
   --ifm-navbar-shadow: 0 1px 0 var(--humanizer-rule);
-  --ifm-footer-background-color: #082f49;
-  --ifm-footer-color: #f4fbff;
+  --ifm-footer-background-color: var(--humanizer-panel);
+  --ifm-footer-color: var(--humanizer-panel-ink);
   --ifm-toc-border-color: var(--humanizer-rule);
 }
 
@@ -68,7 +68,6 @@
     var(--humanizer-paper) 94%,
     transparent
   );
-  --ifm-footer-background-color: #03111b;
 }
 
 html {
@@ -476,11 +475,13 @@ html[data-theme='dark'] .prism-code .token.comment {
     font-weight: 800;
   }
 
-  .humanizerResponsiveTable tbody td[data-label=''] {
+  .humanizerResponsiveTable tbody td:is([data-label=''], :not([data-label])) {
     grid-template-columns: 1fr;
   }
 
-  .humanizerResponsiveTable tbody td[data-label='']::before {
+  .humanizerResponsiveTable
+    tbody
+    td:is([data-label=''], :not([data-label]))::before {
     content: none;
   }
 }

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -120,11 +120,8 @@
 
 .proof {
   background: var(--humanizer-panel);
-  border-collapse: collapse;
   color: var(--humanizer-panel-ink);
   min-width: 0;
-  table-layout: fixed;
-  width: 100%;
 }
 
 .proofCaption {

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -1,7 +1,5 @@
 .home {
   --home-gutter: clamp(1rem, 4vw, 4rem);
-
-  overflow: hidden;
 }
 
 .hero,
@@ -15,9 +13,8 @@
 
 .hero {
   display: grid;
-  gap: clamp(3rem, 7vw, 7rem);
-  min-height: min(52rem, calc(100svh - var(--ifm-navbar-height)));
-  padding-block: clamp(3.5rem, 8vw, 7.5rem);
+  gap: clamp(2rem, 5vw, 4rem);
+  padding-block: clamp(1.75rem, 4vw, 4rem);
 }
 
 .heroCopy {
@@ -31,33 +28,31 @@
   font-size: 0.9rem;
   font-weight: 750;
   gap: 0.85rem;
-  margin-bottom: clamp(2rem, 5vw, 4rem);
+  margin-bottom: 1.25rem;
 }
 
 .logo {
-  background: #fff;
-  box-sizing: content-box;
+  display: block;
   height: 3.5rem;
-  padding: 0.2rem;
   width: 3.5rem;
 }
 
 .hero h1 {
   font-family: var(--humanizer-body);
-  font-size: clamp(3rem, 8vw, 6rem);
+  font-size: clamp(2.25rem, 7vw, 4.5rem);
   font-weight: 760;
   letter-spacing: -0.04em;
-  line-height: 0.98;
+  line-height: 1;
   margin: 0;
-  max-width: 12ch;
+  max-width: 11ch;
   text-wrap: balance;
 }
 
 .lede {
   color: var(--humanizer-ink-muted);
   font-size: clamp(1.1rem, 2vw, 1.35rem);
-  margin-block: 2rem;
-  max-width: 42rem;
+  margin-block: 1.25rem;
+  max-width: 38rem;
 }
 
 .heroActions,
@@ -80,12 +75,34 @@
   color: var(--humanizer-accent);
 }
 
+.releaseCue {
+  align-items: center;
+  background: var(--humanizer-paper-raised);
+  border-left: 0.25rem solid var(--humanizer-accent-warm);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.75rem;
+  margin-top: 1.25rem;
+  padding: 0.55rem 0.75rem;
+  width: fit-content;
+}
+
+.releaseCue strong {
+  color: var(--humanizer-ink);
+  font-size: 0.85rem;
+}
+
+.releaseCue span {
+  color: var(--humanizer-ink-muted);
+  font-size: 0.78rem;
+}
+
 .install {
   border-block: 1px solid var(--humanizer-rule);
   display: grid;
   gap: 0.4rem;
-  margin-top: clamp(2.5rem, 6vw, 4rem);
-  padding-block: 1rem;
+  margin-top: 1.25rem;
+  padding-block: 0.75rem;
 }
 
 .install span {
@@ -102,12 +119,10 @@
 }
 
 .proof {
-  align-self: center;
-  background: #172026;
+  background: var(--humanizer-panel);
   border-collapse: collapse;
-  color: #edf3f2;
+  color: var(--humanizer-panel-ink);
   min-width: 0;
-  padding: clamp(1rem, 3vw, 2rem);
   table-layout: fixed;
   width: 100%;
 }
@@ -127,19 +142,19 @@
   font-size: 0.72rem;
   font-weight: 750;
   letter-spacing: 0.06em;
-  padding: clamp(1rem, 3vw, 2rem) clamp(0.4rem, 1.5vw, 1rem) 0.8rem;
+  padding: 1rem clamp(0.4rem, 1.5vw, 0.85rem) 0.7rem;
   text-align: left;
   text-transform: uppercase;
 }
 
 .proof th:first-child,
 .proof td:first-child {
-  padding-left: clamp(1rem, 3vw, 2rem);
+  padding-left: clamp(0.85rem, 2vw, 1.5rem);
 }
 
 .proof th:last-child,
 .proof td:last-child {
-  padding-right: clamp(1rem, 3vw, 2rem);
+  padding-right: clamp(0.85rem, 2vw, 1.5rem);
   width: 38%;
 }
 
@@ -158,7 +173,7 @@
 }
 
 .proofRow td {
-  padding: clamp(1.2rem, 4vw, 2rem) clamp(0.4rem, 1.5vw, 1rem);
+  padding: clamp(0.8rem, 1.8vw, 1.15rem) clamp(0.4rem, 1.5vw, 0.85rem);
   vertical-align: top;
 }
 
@@ -177,14 +192,14 @@
 }
 
 .proofRow samp {
-  color: #91d9e8;
+  color: var(--humanizer-panel-accent);
 }
 
 .tasks {
   border-top: 1px solid var(--humanizer-rule);
   display: grid;
-  gap: clamp(2.5rem, 7vw, 6rem);
-  padding-block: clamp(5rem, 10vw, 9rem);
+  gap: clamp(2rem, 5vw, 4.5rem);
+  padding-block: clamp(3.5rem, 7vw, 6rem);
 }
 
 .sectionLead > p,
@@ -251,24 +266,24 @@
 }
 
 .languagePromise {
-  background: #045b6e;
-  color: #fff;
+  background: var(--humanizer-accent-deep);
+  color: var(--humanizer-panel-ink);
   display: grid;
   gap: 2rem;
   padding: clamp(2rem, 5vw, 4rem);
 }
 
 .languagePromise > p {
-  color: #d7f3f8;
+  color: var(--humanizer-panel-accent);
   margin: 0;
 }
 
 .languagePromise h2 {
-  color: #fff;
+  color: var(--humanizer-panel-ink);
 }
 
 .languagePromise div > p {
-  color: #e5f6f9;
+  color: var(--humanizer-panel-ink);
   font-size: 1.1rem;
   margin: 1rem 0 0;
   max-width: 44rem;
@@ -276,14 +291,14 @@
 
 .languagePromise .textLink {
   align-self: end;
-  color: #fff;
-  text-decoration-color: #fff;
+  color: var(--humanizer-panel-ink);
+  text-decoration-color: var(--humanizer-panel-accent);
 }
 
 .reference {
   display: grid;
   gap: 2rem;
-  padding-block: clamp(5rem, 10vw, 9rem);
+  padding-block: clamp(3.5rem, 7vw, 6rem);
 }
 
 .reference > p {
@@ -293,9 +308,39 @@
   max-width: 42rem;
 }
 
+@media (max-width: 996px) {
+  .proof td,
+  .proof td:last-child {
+    width: 100%;
+  }
+
+  .proof tbody td::before {
+    color: var(--humanizer-panel-accent);
+  }
+
+  .proof td[aria-hidden='true'] {
+    display: none;
+  }
+}
+
 @media (min-width: 48rem) {
+  .languagePromise {
+    grid-template-columns: 0.35fr minmax(0, 1.2fr) auto;
+  }
+
+  .reference {
+    align-items: end;
+    grid-template-columns: minmax(16rem, 0.9fr) minmax(18rem, 1.1fr);
+  }
+
+  .referenceLinks {
+    grid-column: 2;
+  }
+}
+
+@media (min-width: 64rem) {
   .hero {
-    grid-template-columns: minmax(0, 1.08fr) minmax(24rem, 0.92fr);
+    grid-template-columns: minmax(0, 1.02fr) minmax(25rem, 0.98fr);
   }
 
   .tasks {
@@ -309,18 +354,5 @@
 
   .task code {
     display: block;
-  }
-
-  .languagePromise {
-    grid-template-columns: 0.35fr minmax(0, 1.2fr) auto;
-  }
-
-  .reference {
-    align-items: end;
-    grid-template-columns: minmax(16rem, 0.9fr) minmax(18rem, 1.1fr);
-  }
-
-  .referenceLinks {
-    grid-column: 2;
   }
 }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -17,6 +17,7 @@ import {
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
 import {useEffect, useState} from 'react';
+import {ResponsiveTable} from '../theme/MDXComponents';
 import styles from './index.module.css';
 
 const transformations = [
@@ -99,11 +100,10 @@ export default function Home(): React.JSX.Element {
               />
               <span>Humanizer for .NET</span>
             </div>
-            <h1 id="home-title">Turn .NET values into words people understand.</h1>
+            <h1 id="home-title">Human-friendly text for .NET.</h1>
             <p className={styles.lede}>
-              Humanizer adds focused extension methods for readable strings,
-              dates, times, numbers, quantities, enums, and collections—across
-              every supported culture.
+              Humanize strings, dates, numbers, quantities, enums, and
+              collections with culture-aware .NET APIs.
             </p>
             <div className={styles.heroActions}>
               <Link className="button button--primary" to={docsPath('start/quick-start/')}>
@@ -113,13 +113,19 @@ export default function Home(): React.JSX.Element {
                 Find an API by task <span aria-hidden="true">→</span>
               </Link>
             </div>
+            <aside
+              aria-label="What’s new in Humanizer 4"
+              className={styles.releaseCue}>
+              <strong>What’s new in v4</strong>
+              <span>Guide coming soon</span>
+            </aside>
             <div className={styles.install}>
               <span>Install from NuGet</span>
               <code>dotnet add package Humanizer</code>
             </div>
           </div>
 
-          <table className={styles.proof}>
+          <ResponsiveTable className={styles.proof}>
             <caption className={styles.proofCaption}>
               Humanizer input and output examples
             </caption>
@@ -139,7 +145,7 @@ export default function Home(): React.JSX.Element {
                 </tr>
               ))}
             </tbody>
-          </table>
+          </ResponsiveTable>
         </section>
 
         <section className={styles.tasks} aria-labelledby="tasks-title">

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -113,12 +113,10 @@ export default function Home(): React.JSX.Element {
                 Find an API by task <span aria-hidden="true">→</span>
               </Link>
             </div>
-            <aside
-              aria-label="What’s new in Humanizer 4"
-              className={styles.releaseCue}>
+            <div className={styles.releaseCue}>
               <strong>What’s new in v4</strong>
               <span>Guide coming soon</span>
-            </aside>
+            </div>
             <div className={styles.install}>
               <span>Install from NuGet</span>
               <code>dotnet add package Humanizer</code>

--- a/website/src/theme/MDXComponents/index.tsx
+++ b/website/src/theme/MDXComponents/index.tsx
@@ -52,6 +52,8 @@ function enhanceTable(table: HTMLTableElement, tableId: string) {
       });
     });
   });
+
+  table.classList.add('humanizerResponsiveTable--enhanced');
 }
 
 export function ResponsiveTable({

--- a/website/src/theme/MDXComponents/index.tsx
+++ b/website/src/theme/MDXComponents/index.tsx
@@ -1,11 +1,101 @@
 import MDXComponents from '@theme-original/MDXComponents';
-import type {ComponentPropsWithoutRef} from 'react';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useId,
+  type ComponentPropsWithoutRef,
+  type PropsWithChildren,
+} from 'react';
 
-function FocusableTable(props: ComponentPropsWithoutRef<'table'>) {
-  return <table {...props} tabIndex={0} />;
+function enhanceTable(table: HTMLTableElement, tableId: string) {
+  table.classList.add('humanizerResponsiveTable');
+  table.tabIndex = 0;
+
+  const headers = Array.from(table.tHead?.rows[0]?.cells ?? []);
+  headers.forEach((header, index) => {
+    if (!header.scope) {
+      header.scope = 'col';
+    }
+    if (!header.id) {
+      header.id = `${tableId}-column-${index + 1}`;
+    }
+  });
+
+  Array.from(table.tBodies).forEach((body, bodyIndex) => {
+    Array.from(body.rows).forEach((row, rowIndex) => {
+      const rowHeader = Array.from(row.cells).find(
+        (cell) => cell.tagName === 'TH',
+      );
+      if (rowHeader) {
+        if (!rowHeader.scope) {
+          rowHeader.scope = 'row';
+        }
+        if (!rowHeader.id) {
+          rowHeader.id = `${tableId}-row-${bodyIndex + 1}-${rowIndex + 1}`;
+        }
+      }
+
+      Array.from(row.cells).forEach((cell, columnIndex) => {
+        if (cell.tagName !== 'TD') {
+          return;
+        }
+
+        const header = headers[columnIndex];
+        const label =
+          header?.getAttribute('aria-label') ?? header?.textContent?.trim() ?? '';
+        cell.dataset.label = label;
+
+        if (!cell.headers) {
+          cell.headers = [header?.id, rowHeader?.id].filter(Boolean).join(' ');
+        }
+      });
+    });
+  });
+}
+
+export function ResponsiveTable({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<'table'>) {
+  const id = useId().replaceAll(':', '');
+  const tableRef = useCallback(
+    (table: HTMLTableElement | null) => {
+      if (table) {
+        enhanceTable(table, `humanizer-table-${id}`);
+      }
+    },
+    [id],
+  );
+
+  return (
+    <div className="humanizerResponsiveTableFrame">
+      <table
+        {...props}
+        className={['humanizerResponsiveTable', className]
+          .filter(Boolean)
+          .join(' ')}
+        ref={tableRef}
+        tabIndex={0}
+      />
+    </div>
+  );
+}
+
+function ResponsiveTableScope({children}: PropsWithChildren) {
+  useEffect(() => {
+    document
+      .querySelectorAll<HTMLTableElement>('.theme-doc-markdown table')
+      .forEach((table, index) =>
+        enhanceTable(table, `humanizer-mdx-table-${index + 1}`),
+      );
+  }, [children]);
+
+  return <Fragment>{children}</Fragment>;
 }
 
 export default {
   ...MDXComponents,
-  table: FocusableTable,
+  table: ResponsiveTable,
+  wrapper: ResponsiveTableScope,
 };

--- a/website/tests/e2e/accessibility.spec.ts
+++ b/website/tests/e2e/accessibility.spec.ts
@@ -19,6 +19,21 @@ const routes = [
   {name: 'redirected legacy page', path: '/installation.html'},
 ];
 
+const responsiveTableRoutes = [
+  {name: 'homepage proof', path: '/'},
+  {name: 'ordinary Markdown', path: '/docs/next/scenarios/'},
+  {
+    name: 'historical wide table',
+    path: '/docs/3.0.8/start/troubleshooting/',
+  },
+  {
+    name: 'historical capability table',
+    path: '/docs/languages/supported-cultures/',
+  },
+];
+
+const responsiveTableViewports = [320, 375, 768, 1024, 1440];
+
 async function expectNoSeriousAccessibilityViolations(page: Page) {
   const results = await new AxeBuilder({page}).analyze();
   const violations = results.violations.filter(({impact}) =>
@@ -59,20 +74,117 @@ for (const colorScheme of ['light', 'dark'] as const) {
     });
   }
 
-  test(`ordinary Markdown tables are keyboard accessible at 320px in ${colorScheme} mode`, async ({
+  test(`responsive tables preserve width, labels, and focus in ${colorScheme} mode`, async ({
     page,
   }) => {
-    await page.setViewportSize({width: 320, height: 720});
-    await page.emulateMedia({colorScheme});
-    await page.goto('/docs/next/scenarios/');
+    for (const route of responsiveTableRoutes) {
+      for (const width of responsiveTableViewports) {
+        await page.setViewportSize({width, height: 900});
+        await page.emulateMedia({colorScheme});
+        await page.goto(route.path);
 
-    const table = page.locator('article table').first();
-    await expect(table).toBeVisible();
-    await expect(table).toHaveAttribute('tabindex', '0');
-    await table.focus();
-    await expect(table).toBeFocused();
+        const tables = page.locator('table');
+        await expect(tables.first()).toBeVisible();
+        expect(
+          await page.evaluate(
+            () =>
+              document.documentElement.scrollWidth <=
+              document.documentElement.clientWidth,
+          ),
+          `${route.name} document overflows at ${width}px`,
+        ).toBe(true);
 
-    await expectNoSeriousAccessibilityViolations(page);
+        for (let index = 0; index < (await tables.count()); index += 1) {
+          const table = tables.nth(index);
+          await expect(table).toHaveAttribute('tabindex', '0');
+          await table.focus();
+          await expect(table).toBeFocused();
+
+          const result = await table.evaluate((element, cardLayout) => {
+            const tableElement = element as HTMLTableElement;
+            const headers = Array.from(
+              tableElement.tHead?.rows[0]?.cells ?? [],
+            );
+            const labels = headers.map(
+              (header) =>
+                header.getAttribute('aria-label') ??
+                header.textContent?.trim() ??
+                '',
+            );
+            const failures: string[] = [];
+
+            if (tableElement.scrollWidth > tableElement.clientWidth) {
+              failures.push('table overflows');
+            }
+
+            let ancestor: HTMLElement | null = tableElement;
+            while (ancestor && ancestor !== document.body) {
+              const {overflowX} = getComputedStyle(ancestor);
+              if (overflowX === 'auto' || overflowX === 'scroll') {
+                failures.push(
+                  `${ancestor.tagName.toLowerCase()} is a horizontal scroller`,
+                );
+              }
+              ancestor = ancestor.parentElement;
+            }
+
+            headers.forEach((header, headerIndex) => {
+              if (header.scope !== 'col') {
+                failures.push(`header ${headerIndex + 1} has no column scope`);
+              }
+              if (!header.id) {
+                failures.push(`header ${headerIndex + 1} has no id`);
+              }
+            });
+
+            Array.from(tableElement.tBodies).forEach((body) => {
+              Array.from(body.rows).forEach((row) => {
+                Array.from(row.cells).forEach((cell, columnIndex) => {
+                  if (cell.tagName !== 'TD') {
+                    return;
+                  }
+
+                  if (cell.dataset.label !== labels[columnIndex]) {
+                    failures.push(`cell ${columnIndex + 1} has the wrong label`);
+                  }
+                  if (
+                    headers[columnIndex]?.id &&
+                    !cell.headers.split(' ').includes(headers[columnIndex].id)
+                  ) {
+                    failures.push(
+                      `cell ${columnIndex + 1} is not linked to its header`,
+                    );
+                  }
+                  if (
+                    cardLayout &&
+                    cell.dataset.label &&
+                    cell.getAttribute('aria-hidden') !== 'true' &&
+                    ['none', 'normal'].includes(
+                      getComputedStyle(cell, '::before').content,
+                    )
+                  ) {
+                    failures.push(
+                      `cell ${columnIndex + 1} has no visible card label`,
+                    );
+                  }
+                });
+              });
+            });
+
+            return failures;
+          }, width <= 996);
+
+          expect(
+            result,
+            `${route.name} table ${index + 1} failed at ${width}px`,
+          ).toEqual([]);
+        }
+      }
+
+      await page.setViewportSize({width: 320, height: 900});
+      await page.goto(route.path);
+      await expectNoSeriousAccessibilityViolations(page);
+    }
   });
 
   test(`all-version modal has no serious accessibility violations in ${colorScheme} mode`, async ({

--- a/website/tests/e2e/accessibility.spec.ts
+++ b/website/tests/e2e/accessibility.spec.ts
@@ -32,7 +32,7 @@ const responsiveTableRoutes = [
   },
 ];
 
-const responsiveTableViewports = [320, 375, 768, 1024, 1440];
+const responsiveTableViewports = [320, 996, 997, 1440];
 
 async function expectNoSeriousAccessibilityViolations(page: Page) {
   const results = await new AxeBuilder({page}).analyze();
@@ -77,14 +77,16 @@ for (const colorScheme of ['light', 'dark'] as const) {
   test(`responsive tables preserve width, labels, and focus in ${colorScheme} mode`, async ({
     page,
   }) => {
+    await page.emulateMedia({colorScheme});
+
     for (const route of responsiveTableRoutes) {
       for (const width of responsiveTableViewports) {
         await page.setViewportSize({width, height: 900});
-        await page.emulateMedia({colorScheme});
         await page.goto(route.path);
 
         const tables = page.locator('table');
         await expect(tables.first()).toBeVisible();
+        const tableCount = await tables.count();
         expect(
           await page.evaluate(
             () =>
@@ -94,7 +96,7 @@ for (const colorScheme of ['light', 'dark'] as const) {
           `${route.name} document overflows at ${width}px`,
         ).toBe(true);
 
-        for (let index = 0; index < (await tables.count()); index += 1) {
+        for (let index = 0; index < tableCount; index += 1) {
           const table = tables.nth(index);
           await expect(table).toHaveAttribute('tabindex', '0');
           await table.focus();

--- a/website/tests/e2e/accessibility.spec.ts
+++ b/website/tests/e2e/accessibility.spec.ts
@@ -43,6 +43,41 @@ async function expectNoSeriousAccessibilityViolations(page: Page) {
   expect(violations).toEqual([]);
 }
 
+test('responsive tables retain native headers without JavaScript', async ({
+  browser,
+}) => {
+  const context = await browser.newContext({
+    javaScriptEnabled: false,
+    viewport: {width: 320, height: 900},
+  });
+  const page = await context.newPage();
+
+  try {
+    await page.goto('/docs/next/scenarios/');
+
+    const table = page.locator('table').first();
+    await expect(table).toBeVisible();
+    await expect(table).not.toHaveClass(/humanizerResponsiveTable--enhanced/);
+    await expect(table.locator('thead th')).toHaveCount(3);
+    await expect(table.locator('thead')).toBeVisible();
+    expect(
+      await page.evaluate(() => {
+        const tableElement = document.querySelector('table');
+        return (
+          document.documentElement.scrollWidth <=
+            document.documentElement.clientWidth &&
+          Boolean(
+            tableElement &&
+              tableElement.scrollWidth <= tableElement.clientWidth,
+          )
+        );
+      }),
+    ).toBe(true);
+  } finally {
+    await context.close();
+  }
+});
+
 for (const colorScheme of ['light', 'dark'] as const) {
   for (const route of routes) {
     test(`${route.name} has no serious accessibility violations in ${colorScheme} mode`, async ({

--- a/website/tests/e2e/production.spec.ts
+++ b/website/tests/e2e/production.spec.ts
@@ -41,7 +41,7 @@ test('deployed site preserves reader, version, search, and legacy contracts', as
   await page.goto('/');
   await expect(
     page.getByRole('heading', {
-      name: 'Turn .NET values into words people understand.',
+      name: 'Human-friendly text for .NET.',
     }),
   ).toBeVisible();
   await expect(page.getByRole('button', {name: 'All versions'})).toBeVisible();

--- a/website/tests/e2e/reader-shell.spec.ts
+++ b/website/tests/e2e/reader-shell.spec.ts
@@ -35,22 +35,28 @@ test('navigation remains operable and unclipped at reader breakpoints', async ({
     const releaseCue = page.getByText('What’s new in v4', {exact: true});
     await expect(releaseCue).toBeVisible();
     expect(
-      await releaseCue.evaluate((element) => element.closest('a, button')),
-    ).toBeNull();
+      await releaseCue.evaluate((element) =>
+        Boolean(element.closest('a, button')),
+      ),
+    ).toBe(false);
   }
 
+  await page.setViewportSize({width: 1440, height: 900});
+  await page.goto('/');
   const install = page.getByText('dotnet add package Humanizer', {exact: true});
   const proof = page.getByRole('table', {
     name: 'Humanizer input and output examples',
   });
   expect(
     await install.evaluate(
-      (element) => element.getBoundingClientRect().bottom <= window.innerHeight,
+      (element) =>
+        element.getBoundingClientRect().bottom <= window.innerHeight + 1,
     ),
   ).toBe(true);
   expect(
     await proof.evaluate(
-      (element) => element.getBoundingClientRect().bottom <= window.innerHeight,
+      (element) =>
+        element.getBoundingClientRect().bottom <= window.innerHeight + 1,
     ),
   ).toBe(true);
 

--- a/website/tests/e2e/reader-shell.spec.ts
+++ b/website/tests/e2e/reader-shell.spec.ts
@@ -102,13 +102,9 @@ test('canonical branding renders in the shell and page metadata', async ({
     await page.emulateMedia({colorScheme});
     await page.goto('/');
 
-    const navbarLogo = page
-      .getByRole('img', {name: 'Humanizer home'})
-      .filter({visible: true});
+    const navbarLogo = page.locator('.navbar__logo img').first();
     const heroLogo = page.getByRole('img', {name: 'Humanizer logo'});
 
-    await expect(navbarLogo).toHaveAttribute('src', logoPath);
-    await expect(heroLogo).toHaveAttribute('src', logoPath);
     await expect(heroLogo).toBeVisible();
     await expect
       .poll(() =>
@@ -117,6 +113,7 @@ test('canonical branding renders in the shell and page metadata', async ({
       .toBe(115);
 
     for (const logo of [navbarLogo, heroLogo]) {
+      await expect(logo).toHaveAttribute('src', logoPath);
       expect(
         await logo.evaluate((image) => ({
           background: getComputedStyle(image).backgroundColor,

--- a/website/tests/e2e/reader-shell.spec.ts
+++ b/website/tests/e2e/reader-shell.spec.ts
@@ -96,7 +96,9 @@ test('canonical branding renders in the shell and page metadata', async ({
     await page.emulateMedia({colorScheme});
     await page.goto('/');
 
-    const navbarLogo = page.getByRole('img', {name: 'Humanizer home'});
+    const navbarLogo = page
+      .getByRole('img', {name: 'Humanizer home'})
+      .filter({visible: true});
     const heroLogo = page.getByRole('img', {name: 'Humanizer logo'});
 
     await expect(navbarLogo).toHaveAttribute('src', logoPath);

--- a/website/tests/e2e/reader-shell.spec.ts
+++ b/website/tests/e2e/reader-shell.spec.ts
@@ -26,13 +26,33 @@ test('navigation remains operable and unclipped at reader breakpoints', async ({
     expect(pageWidth).toBeLessThanOrEqual(width);
     await expect(
       page.getByRole('heading', {
-        name: 'Turn .NET values into words people understand.',
+        name: 'Human-friendly text for .NET.',
       }),
     ).toBeVisible();
     await expect(
       page.getByRole('table', {name: 'Humanizer input and output examples'}),
     ).toBeVisible();
+    const releaseCue = page.getByText('What’s new in v4', {exact: true});
+    await expect(releaseCue).toBeVisible();
+    expect(
+      await releaseCue.evaluate((element) => element.closest('a, button')),
+    ).toBeNull();
   }
+
+  const install = page.getByText('dotnet add package Humanizer', {exact: true});
+  const proof = page.getByRole('table', {
+    name: 'Humanizer input and output examples',
+  });
+  expect(
+    await install.evaluate(
+      (element) => element.getBoundingClientRect().bottom <= window.innerHeight,
+    ),
+  ).toBe(true);
+  expect(
+    await proof.evaluate(
+      (element) => element.getBoundingClientRect().bottom <= window.innerHeight,
+    ),
+  ).toBe(true);
 
   await page.setViewportSize({width: 320, height: 800});
   await page.goto('/');
@@ -70,18 +90,37 @@ test('navigation remains operable and unclipped at reader breakpoints', async ({
 test('canonical branding renders in the shell and page metadata', async ({
   page,
 }) => {
-  await page.goto('/');
-
   const logoPath = '/img/logo.png';
-  const navbarLogo = page.getByRole('img', {name: 'Humanizer home'});
-  const heroLogo = page.getByRole('img', {name: 'Humanizer logo'});
 
-  await expect(navbarLogo).toHaveAttribute('src', logoPath);
-  await expect(heroLogo).toHaveAttribute('src', logoPath);
-  await expect(heroLogo).toBeVisible();
-  await expect
-    .poll(() => heroLogo.evaluate((image: HTMLImageElement) => image.naturalWidth))
-    .toBe(115);
+  for (const colorScheme of ['light', 'dark'] as const) {
+    await page.emulateMedia({colorScheme});
+    await page.goto('/');
+
+    const navbarLogo = page.getByRole('img', {name: 'Humanizer home'});
+    const heroLogo = page.getByRole('img', {name: 'Humanizer logo'});
+
+    await expect(navbarLogo).toHaveAttribute('src', logoPath);
+    await expect(heroLogo).toHaveAttribute('src', logoPath);
+    await expect(heroLogo).toBeVisible();
+    await expect
+      .poll(() =>
+        heroLogo.evaluate((image: HTMLImageElement) => image.naturalWidth),
+      )
+      .toBe(115);
+
+    for (const logo of [navbarLogo, heroLogo]) {
+      expect(
+        await logo.evaluate((image) => ({
+          background: getComputedStyle(image).backgroundColor,
+          padding: getComputedStyle(image).padding,
+        })),
+      ).toEqual({
+        background: 'rgba(0, 0, 0, 0)',
+        padding: '0px',
+      });
+    }
+  }
+
   await expect(page.locator('link[rel="icon"]')).toHaveAttribute(
     'href',
     logoPath,


### PR DESCRIPTION
## Summary

The docs homepage is now compact and developer-first, with Humanizer's canonical blue/red palette and unchanged logo pixels. Tables no longer create horizontal scrollers: Markdown and JSX tables keep semantic table markup on desktop and present labeled row cards at narrow widths only after client enhancement is complete.

The shared renderer covers ordinary docs, historical tables, and homepage proof output without per-page table patches. Browser coverage asserts document and table fit, accessible header relationships, focus behavior, light/dark rendering from 320px through 1440px, and visible native headers before hydration or with JavaScript disabled.

## Validation

- `pnpm --dir website run typecheck` — passed.
- `pnpm --dir website run build` — production site and search index built.
- `pnpm --dir website run test:ci` — 40/40 responsive/accessibility browser tests passed.
- `pnpm --dir website run check:links` — passed.
- `pnpm --dir website run check:artifact` — passed.
- `git diff --check` — passed.

## Checklist

- [x] Implementation is clean.
- [x] Repository coding standards are followed.
- [x] No code-analysis warnings are introduced.
- [x] Responsive and accessibility behavior has browser coverage.
- [x] No copied code requires attribution.
- [x] Comments and XML documentation are not applicable.
- [x] Based on the latest `origin/main`.
- [x] No issue is closed by this focused visual-system change.
- [x] Documentation-facing behavior is covered in the site itself.
- [x] Applicable documentation gates were run.
