### PR TITLE
docs: refresh v4 reference and contributor guidance

### DIFF
--- a/website/docs/analyzer/index.mdx
+++ b/website/docs/analyzer/index.mdx
@@ -135,7 +135,6 @@ repair custom formatter implementations, or validate other behavior changes.
 
 ## Related guides and API
 
-- [Upgrade to Humanizer 4](../upgrading/main-preview.mdx)
 - [Configuration](../start/configuration.mdx)
 - [Troubleshooting](../start/troubleshooting.mdx)
 - [API reference](../api/index.md)

--- a/website/docs/analyzer/index.mdx
+++ b/website/docs/analyzer/index.mdx
@@ -44,7 +44,7 @@ Before the fix, a build reports `HUMANIZER001`:
 ```csharp
 using Humanizer.Bytes;
 
-var size = Humanizer.Bytes.ByteSize.FromKilobytes(10);
+var size = new Humanizer.Bytes.ByteSize(10 * 1024);
 ```
 
 ```text
@@ -56,7 +56,7 @@ After the fix:
 ```csharp
 using Humanizer;
 
-var size = Humanizer.ByteSize.FromKilobytes(10);
+var size = new Humanizer.ByteSize(10 * 1024);
 Console.WriteLine(size);
 ```
 

--- a/website/docs/analyzer/index.mdx
+++ b/website/docs/analyzer/index.mdx
@@ -26,10 +26,12 @@ dotnet add <app-project.csproj> package Humanizer --version 4.0.0
 dotnet restore <app-project.csproj>
 dotnet format <solution-or-project> analyzers --diagnostics HUMANIZER001 --severity info
 dotnet build <app-project.csproj> --no-restore
-dotnet test <app-project.csproj> --no-restore
+dotnet test <test-project-or-solution>
 ```
 
-Replace the placeholders with paths relative to the repository root.
+Replace the placeholders with paths relative to the repository root. The test
+path must identify the repository's test project or a solution that includes
+its tests.
 
 The code action is named **Update to Humanizer namespace** and supports Roslyn
 Fix All. Review the result: Fix All replaces each matching directive or

--- a/website/docs/analyzer/index.mdx
+++ b/website/docs/analyzer/index.mdx
@@ -3,42 +3,64 @@ id: analyzer
 title: Migrate namespaces with the analyzer
 sidebar_position: 1
 diataxis: how-to
-persona: developer migrating a Humanizer 2 codebase
+persona: developer updating Humanizer namespaces
 example: illustrative
 ---
 
 # Migrate namespaces with the analyzer
 
-## Orientation
+Humanizer 4 includes its analyzers in the `Humanizer` package; no separate
+analyzer package is required. `HUMANIZER001` finds old Humanizer sub-namespace
+using directives and qualified names that must move to the root `Humanizer`
+namespace.
 
-Humanizer 3 bundles analyzer assets in `Humanizer.Core`; a normal reference to
-the `Humanizer` package brings them in. Do not install a separate analyzer
-package. `HUMANIZER001` finds Humanizer 2 sub-namespace using directives and
-qualified names that must move to the root `Humanizer` namespace.
+The diagnostic is enabled by default with severity `error`, so it can fail a
+local or CI build even when `TreatWarningsAsErrors` is false.
 
-The shipped descriptor is enabled by default with severity `error`. It can fail
-local and CI builds even when `TreatWarningsAsErrors` is false. The analyzer
-release ledger and older prose call it a warning, but the source descriptor,
-tagged packages, tests, and package smoke builds establish the actual behavior.
+## Apply the automated migration
 
-### Apply the automated migration
-
-First update the package, then apply the fix:
+Update the package, restore, and apply the fix:
 
 ```console
-dotnet add package Humanizer --version 3.0.10
-dotnet restore
-dotnet format analyzers --diagnostics HUMANIZER001 --severity info
-dotnet build
-dotnet test
+dotnet add <app-project.csproj> package Humanizer --version 4.0.0
+dotnet restore <app-project.csproj>
+dotnet format <solution-or-project> analyzers --diagnostics HUMANIZER001 --severity info
+dotnet build <app-project.csproj> --no-restore
+dotnet test <app-project.csproj> --no-restore
 ```
+
+Replace the placeholders with paths relative to the repository root.
 
 The code action is named **Update to Humanizer namespace** and supports Roslyn
 Fix All. Review the result: Fix All replaces each matching directive or
-qualified prefix, but it does not promise to deduplicate identical
-`using Humanizer;` directives.
+qualified prefix, but it can leave duplicate `using Humanizer;` directives.
 
-### Configure or suppress the diagnostic
+## Example
+
+Before the fix, a build reports `HUMANIZER001`:
+
+```csharp
+using Humanizer.Bytes;
+
+var size = Humanizer.Bytes.ByteSize.FromKilobytes(10);
+```
+
+```text
+Build result: HUMANIZER001 reports both old namespace references.
+```
+
+After the fix:
+
+```csharp
+using Humanizer;
+
+var size = Humanizer.ByteSize.FromKilobytes(10);
+Console.WriteLine(size);
+```
+
+The namespace diagnostic is gone and the application prints `10 KB`.
+
+## Configure or suppress the diagnostic
 
 Use ordinary Roslyn configuration; Humanizer has no custom analyzer options.
 During a staged migration, lower the severity in the narrowest applicable
@@ -49,8 +71,7 @@ During a staged migration, lower the severity in the narrowest applicable
 dotnet_diagnostic.HUMANIZER001.severity = warning
 ```
 
-Use `none` only for code that must remain on Humanizer 2. For a narrow source
-exception:
+For a narrow source exception:
 
 ```csharp
 #pragma warning disable HUMANIZER001
@@ -59,10 +80,10 @@ using Humanizer.Bytes;
 ```
 
 MSBuild's project-wide equivalent is
-`<NoWarn>$(NoWarn);HUMANIZER001</NoWarn>`. Prefer `.editorconfig` because its
-file scope makes temporary exceptions visible.
+`<NoWarn>$(NoWarn);HUMANIZER001</NoWarn>`. Prefer `.editorconfig` or a pragma
+because its scope makes a temporary exception visible.
 
-### Run it in CI
+## Enforce the migration in CI
 
 Run restore and the normal build first. Because the diagnostic defaults to an
 error, the build is the enforcement gate. Add a no-change format check when CI
@@ -70,58 +91,51 @@ must also prove that the code fix has been applied:
 
 ```console
 dotnet build --no-restore
-dotnet format analyzers --no-restore --diagnostics HUMANIZER001 --severity info --verify-no-changes
+dotnet format <solution-or-project> analyzers --no-restore --diagnostics HUMANIZER001 --severity info --verify-no-changes
 ```
 
-Pin the SDK used locally and in CI. Humanizer `3.0.10` contains Roslyn 3.8, 4.8,
-and 4.14 analyzer variants plus a fallback target for hosts without versioned
-component selection.
+Pin the .NET SDK used locally and in CI. Humanizer selects a compatible
+analyzer build automatically.
 
-### Troubleshoot
+## Convert narrowed words-to-number results
+
+Humanizer 4's words-to-number APIs return `long`. When an assignment requires
+an `int`, compiler diagnostic `CS0029` or `CS0266` offers the separate
+**Wrap with checked int cast** action:
+
+```csharp
+using System.Globalization;
+using Humanizer;
+
+var culture = CultureInfo.GetCultureInfo("en");
+int number = "one hundred".ToNumber(culture);
+```
+
+The action produces:
+
+```csharp
+int number = checked((int)"one hundred".ToNumber(culture));
+Console.WriteLine(number);
+```
+
+The application prints `100`. This compiler-diagnostic fix is separate from
+`HUMANIZER001`.
+
+## Troubleshoot analyzer loading
 
 | Symptom | Consumer action |
 | --- | --- |
-| `HUMANIZER001` | The analyzer loaded. Apply the code fix or configure an intentional exception. |
-| No diagnostic for a listed old namespace | Confirm the resolved `Humanizer.Core` version in `project.assets.json`, remove stale `bin`/`obj`, restore, and rebuild. |
-| `CS8032` or `AD0001` on `3.0.1` | Upgrade to `3.0.10`; do not patch analyzer dependencies into the application. |
-| Duplicate analyzer/load behavior on `3.0.8` | Upgrade to `3.0.10` for the fallback-selection fix. |
-| IDE and CI disagree | Compare SDK/MSBuild versions and the resolved package lock file, then restart the IDE after a clean restore. |
+| `HUMANIZER001` | Apply the namespace code fix or configure an intentional exception. |
+| No diagnostic for an old namespace | Confirm the project references Humanizer 4, then clean, restore, and rebuild. |
+| `CS8032` or `AD0001` | Confirm the pinned SDK is supported, restore the current package, and rebuild before reporting the diagnostic. |
+| IDE and CI disagree | Compare SDK and MSBuild versions, then restart the IDE after a clean restore. |
 
-Humanizer 4 also offers a separate words-to-number code fix on compiler
-diagnostics `CS0029` and `CS0266`. It wraps recognized Humanizer calls in a
-checked `int` conversion. That feature is not part of `HUMANIZER001` and is not
-present in `3.0.1`, `3.0.8`, or `3.0.10`.
-
-## Example
-
-This example is illustrative of the migration performed by the code fix:
-
-```csharp
-// Before
-using Humanizer.Bytes;
-var size = Humanizer.Bytes.ByteSize.FromKilobytes(10);
-
-// After
-using Humanizer;
-var size = Humanizer.ByteSize.FromKilobytes(10);
-```
-
-## Pitfall
-
-The analyzer fixes namespaces only. It does not replace removed APIs, update
-enum generic constraints, repair formatter implementations, or validate
-behavior changes. Continue through the Humanizer 3 migration guide after the
-diagnostic is clean.
-
-## Version notes
-
-`HUMANIZER001` first appears in supported stable version `3.0.1` and retains
-default severity `error` through `3.0.10` and Humanizer 4. Analyzer loading
-is materially more robust at the `3.0.8` and `3.0.10` boundaries.
+The namespace fix changes syntax only. It does not replace removed APIs,
+repair custom formatter implementations, or validate other behavior changes.
 
 ## Related guides and API
 
-- [Humanizer 3 migration](../upgrading/version-3-migration.mdx)
-- [Humanizer 3 patch line](../upgrading/version-3-patch-line.mdx)
+- [Upgrade to Humanizer 4](../upgrading/main-preview.mdx)
 - [Configuration](../start/configuration.mdx)
-- [Selected-version API reference](../api/index.md)
+- [Troubleshooting](../start/troubleshooting.mdx)
+- [API reference](../api/index.md)

--- a/website/docs/concepts/culture-and-configuration.mdx
+++ b/website/docs/concepts/culture-and-configuration.mdx
@@ -4,59 +4,58 @@ title: Culture and global configuration
 sidebar_position: 1
 diataxis: explanation
 persona: application architect
+example: illustrative
 ---
-
-import CodeBlock from '@theme/CodeBlock';
-import localization from '!!raw-loader!../_examples/scenarios-localization/Program.cs';
 
 # Culture and global configuration
 
-## Orientation
+When an API accepts a `CultureInfo`, Humanizer uses it directly. Otherwise the
+API uses `CurrentCulture` or `CurrentUICulture`. A localiser registry then
+walks the selected culture's named parent chain and uses its default only when
+no registered parent matches.
 
-Humanizer chooses language and grammar from one of three places:
-
-1. A `CultureInfo` passed to the operation.
-2. `CultureInfo.CurrentCulture` or `CurrentUICulture`, depending on the API.
-3. A configured registry fallback for a culture that is not listed as supported.
-
-Per-call culture is the narrowest and safest choice. Ambient culture is useful when a request pipeline already establishes it. Global `Configurator` changes are process-wide policy.
+Per-call culture is the narrowest and safest choice. Ambient culture is useful
+when a request pipeline already establishes it. Global `Configurator` changes
+are process-wide policy.
 
 ## Example
 
-The example passes French directly to `ToWords`, establishes French ambient culture for APIs that need it, and keeps the custom transformer local:
+```csharp
+using System.Globalization;
+using Humanizer;
 
-<CodeBlock language="csharp" title="Program.cs">{localization}</CodeBlock>
+var french = CultureInfo.GetCultureInfo("fr-FR");
+Console.WriteLine(42.ToWords(french));
 
-That separation is intentional: select language close to the call, and reserve global configuration for behavior that truly applies to the entire application.
+CultureInfo.CurrentCulture = french;
+CultureInfo.CurrentUICulture = french;
+Console.WriteLine(42.ToWords());
+```
 
-## Why newer registries freeze
+Both calls print `quarante-deux`. The first makes its culture explicit; the
+second relies on the ambient culture established for the current operation.
 
-In Humanizer `3.x` and current builds, `LocaliserRegistry<TLocaliser>` resolves
-and caches components by culture. On first resolution it freezes the
-registration table, making subsequent reads predictable and safe. A later
-`Register` call therefore throws instead of silently changing behavior for
-only some cultures or requests.
+## Configure global behavior once
 
-Date humanization strategies are mutable properties rather than registries,
-but they should still be set once during startup. Enum description-property
-selection has the same startup boundary: in `3.x`, call
-`UseEnumDescriptionPropertyLocator` before any enum humanization; in `2.x`,
-assign `EnumDescriptionPropertyLocator` during startup.
+`LocaliserRegistry<TLocaliser>` resolves and caches components by culture. On
+first resolution it freezes the registration table, making subsequent reads
+predictable and safe. A later `Register` call throws instead of silently
+changing behavior for only some cultures or requests.
 
-## Pitfall
+Date and time humanization strategies are mutable properties rather than
+registries, but they should still be set once during startup. Call
+`UseEnumDescriptionPropertyLocator` before any enum humanization for the same
+reason.
 
-Setting only `CurrentCulture` is not always enough. Collection and enum localization can depend on `CurrentUICulture`, while numeric formatting commonly follows `CurrentCulture`. Set both at a well-defined boundary when you need consistent ambient behavior.
+## Keep ambient cultures aligned
 
-## Version notes
-
-Humanizer `2.x` keeps localization registries mutable and exposes an assignable
-`Configurator.EnumDescriptionPropertyLocator`. Humanizer `3.x` freezes
-registries after first use and replaces direct locator assignment with
-`UseEnumDescriptionPropertyLocator`. Treat the selected package and API
-reference as the authority for a specific release.
+Different Humanizer APIs use `CurrentCulture` or `CurrentUICulture`. Set both
+at a request, message, or job boundary when ambient output must be consistent.
+Prefer an explicit culture inside shared services when the API accepts one.
 
 ## Related guides and API
 
 - [Configuration basics](../start/configuration.mdx)
 - [Localization and extensibility](../scenarios/localization-and-extensibility.mdx)
-- [Selected-version API reference](../api/index.md)
+- [Configurator API](../api/Humanizer.Configurator.md)
+- [LocaliserRegistry API](../api/Humanizer.LocaliserRegistry_TLocaliser_.md)

--- a/website/docs/concepts/trimming-and-native-aot.mdx
+++ b/website/docs/concepts/trimming-and-native-aot.mdx
@@ -11,52 +11,30 @@ import aot from '!!raw-loader!../_examples/scenarios-aot/Program.cs';
 
 # Trimming and Native AOT
 
-## Orientation
-
-Humanizer `3.0.1` and later publish compatibility metadata for trimming and
-Native AOT on compatible target frameworks. Most extension methods are static
-and trim naturally. Enum humanization and dehumanization are the important
+Humanizer 4's .NET 8 and newer assets publish compatibility metadata for
+trimming and Native AOT. Enum humanization and dehumanization are the important
 choice points: use generic overloads when the enum type is known at compile
 time, and treat the runtime `Enum` and `Type` overloads as
 reflection-dependent.
 
 ## Example
 
-This tiny executable uses only generic enum APIs. Documentation validation runs it normally, publishes it as a self-contained trimmed application, and publishes it with Native AOT on supported host operating-system and architecture combinations:
+This executable uses generic enum APIs:
 
 <CodeBlock language="csharp" title="Program.cs">{aot}</CodeBlock>
 
-The repository verifier is:
+It prints:
 
-```console
-pwsh tools/docs/verify-aot.ps1
+```text
+Ready to ship
 ```
 
-It tests the selected Humanizer NuGet package from an isolated package cache.
-The normal documentation test gate invokes it automatically. A supported host
-must complete both publish modes and run both binaries. An unsupported local
-OS/architecture is reported and skipped; CI can require a supported host with:
-
-```console
-pwsh tools/docs/test.ps1 -RequireNativeAot
-```
-
-### Prefer statically known enum types
-
-```csharp
-var state = "Ready to ship".DehumanizeTo<JobState>();
-var label = JobState.ReadyToShip.Humanize(
-    LetterCasing.Sentence,
-    EnumHumanizeSource.EnumName);
-```
-
-The generic parameter gives the trimmer and AOT compiler the enum’s public
+The generic parameter gives the trimmer and AOT compiler the enum's public
 fields. By contrast, `DehumanizeTo(string, Type, ...)` and the base-`Enum`
 `Humanize(...)` overloads construct generic methods through reflection and are
-annotated with both `RequiresUnreferencedCode` and `RequiresDynamicCode`. The
-source-selecting humanization overload is available on `Humanizer 4`.
+annotated with both `RequiresUnreferencedCode` and `RequiresDynamicCode`.
 
-### Read warnings as API feedback
+## Treat linker warnings as API feedback
 
 An `IL2026` warning on a runtime enum overload means the linker cannot prove
 the target enum members survive. `IL3050` means Native AOT cannot guarantee
@@ -64,20 +42,17 @@ creation of the required code. Replacing the overload with the generic form is
 the normal remediation; suppressing either warning does not make the dynamic
 path safe.
 
-## Pitfall
+## Validate the published application
 
-Assembly compatibility metadata is not proof that every consumer call, dependency, target framework, and runtime identifier is safe. Keep trim warnings enabled, publish the actual application in CI, and execute a smoke path through its Humanizer calls. Reflection-heavy application code around Humanizer can still require its own annotations.
-
-## Version notes
-
-This compatibility claim begins with Humanizer `3.0.1`; `2.x` snapshots must
-exclude this page. Humanizer 4 emits `IsTrimmable` and, on compatible TFMs,
-`IsAotCompatible` metadata. The publish verifier is the behavioral proof for
-`3.0.10` and Humanizer 4, rather than a promise about every historical target
-framework.
+Assembly compatibility metadata is not proof that every consumer call,
+dependency, target framework, and runtime identifier is safe. Keep trim
+warnings enabled, publish the actual application in CI, and execute a smoke
+path through its Humanizer calls. Reflection-heavy application code around
+Humanizer can still require its own annotations.
 
 ## Related guides and API
 
 - [Enums and flags](../scenarios/enums-and-flags.mdx)
 - [Troubleshooting](../start/troubleshooting.mdx)
-- [Selected-version API reference](../api/index.md)
+- [Enum humanization API](../api/Humanizer.EnumHumanizeExtensions.md)
+- [Enum dehumanization API](../api/Humanizer.EnumDehumanizeExtensions.md)

--- a/website/docs/contributing/adding-or-updating-a-locale.mdx
+++ b/website/docs/contributing/adding-or-updating-a-locale.mdx
@@ -19,7 +19,9 @@ file, one successful lookup, or one non-empty result is not completion.
 
 Before editing:
 
-1. Check out the branch that owns the affected Humanizer version.
+1. Check out `main` for Humanizer 4 work. For an approved correction to an
+   older release, use that release's maintenance branch and versioned
+   contributor docs instead.
 2. Install the SDK selected by `global.json`.
 3. Reproduce the behavior with the exact culture, API call, target framework,
    and platform from the report.

--- a/website/docs/contributing/adding-or-updating-a-locale.mdx
+++ b/website/docs/contributing/adding-or-updating-a-locale.mdx
@@ -9,8 +9,6 @@ example: illustrative
 
 # Add or update a locale
 
-## Orientation
-
 This tutorial takes a neutral locale from a reported gap to a reviewable
 change. The sample language is fictional so that the workflow is complete
 without presenting invented translations as real ones.
@@ -37,7 +35,7 @@ The files used in this tutorial are:
   changes
 - `artifacts/YYYY-MM-DD-<locale>-parity-map.md` for local, gitignored evidence
 
-## Example
+## Add the locale and prove its behavior
 
 Suppose neutral `xy` is missing and the parity map shows that its number-word
 and parsing rules fit existing structural engines.
@@ -169,7 +167,7 @@ gap set, native-reviewed wording where needed, exact-output and sweep proof,
 current generated coverage, and a warning-free package build. The pull request
 can name the exact ownership paths and assertions that establish parity.
 
-## Pitfall
+## Prove every supported surface
 
 Generic fallback, an inherited registration, non-empty output, or a compiling
 YAML file does not prove parity. Keep `formatter` and `phrases` separate, and
@@ -179,13 +177,6 @@ If existing engines cannot express the language, stop before adding flags or
 imperative hooks. Follow [Choose or extend a locale engine](./choosing-or-extending-a-locale-engine.mdx)
 and add a genuinely reusable structural kernel only when the rule family
 requires it.
-
-## Version notes
-
-This generated locale pipeline is the `main/preview` contributor model.
-Published versions through `3.0.10` use version-specific package and source
-shapes. Do not assume a current YAML field or engine exists on a historical
-branch.
 
 ## Related guides and API
 

--- a/website/docs/contributing/choosing-or-extending-a-locale-engine.mdx
+++ b/website/docs/contributing/choosing-or-extending-a-locale-engine.mdx
@@ -9,8 +9,6 @@ example: illustrative
 
 # Choose or extend a locale engine
 
-## Orientation
-
 Locale YAML owns words, phrases, lexical tables, switches, and structural
 engine choices. Shared runtime kernels own reusable algorithms. Generator C#
 maps a validated YAML structure to typed cached runtime objects. Runtime code
@@ -28,7 +26,7 @@ Use the first path that fits:
 The [engine catalogues](./locale-yaml-reference.mdx) list the existing
 contracts and fields.
 
-## Example
+## Reuse or extend an engine
 
 ### Reuse an existing engine
 
@@ -85,7 +83,7 @@ Keep a residual leaf when the morphology is still genuinely procedural,
 generalizing it would require imperative hooks, and no second locale supports
 a coherent abstraction. State that reason in the pull request.
 
-## Pitfall
+## Keep engines reusable and runtime dispatch static
 
 Do not create a generic-sounding engine that still switches on culture names.
 Do not add one flag per exceptional locale, expose generator-internal profile
@@ -96,13 +94,6 @@ Generated locale dispatch must remain direct and cached. Do not introduce
 runtime YAML/JSON parsing, reflection-based registry construction, or
 per-call profile creation. Benchmark shared-kernel changes against the path
 they replace.
-
-## Version notes
-
-The generated engine architecture and paths on this page describe
-`main/preview`. Historical branches can use handwritten converters and
-different generator contracts. Inspect the target branch before applying a
-current engine name or migration sequence.
 
 ## Related guides and API
 

--- a/website/docs/contributing/documentation.mdx
+++ b/website/docs/contributing/documentation.mdx
@@ -9,8 +9,6 @@ example: illustrative
 
 # Contribute documentation
 
-## Orientation
-
 Change the canonical page under `website/docs`; do not hand-edit immutable
 version snapshots. Keep the page focused on one reader task and preserve its
 selected-version context. C# is the canonical example language.
@@ -20,7 +18,7 @@ pitfall, state version boundaries, and link to related guidance plus the
 same-version API root. Contributor-only detail belongs in this cluster rather
 than in the primary user path.
 
-## Example
+## Structure the page for its reader
 
 Use front matter that identifies the page role and primary reader:
 
@@ -38,18 +36,12 @@ If an example is executable, add it to the documentation example harness and
 import the tested source. Mark non-executable fragments as illustrative and
 keep them syntactically honest.
 
-## Pitfall
+## Keep current and historical documentation separate
 
 Do not copy current behavior into a historical page without package or tagged
 source evidence. Do not link a historical guide to a current API route. Avoid
 hand-maintained language counts and lists; update locale YAML and rerun the one
 coverage generator.
-
-## Version notes
-
-The canonical corpus includes `main/preview` as a first-class public preview.
-Published snapshots remain version-honest and immutable except for reviewed,
-targeted factual corrections through the snapshot workflow.
 
 ## Validate a documentation change
 
@@ -88,7 +80,7 @@ dispatch the release workflow from `main`:
 
 ```console
 gh workflow run docs-release.yml --ref main \
-  -f version=3.1.0 \
+  -f version=4.0.0 \
   -f promote_latest=true
 ```
 

--- a/website/docs/contributing/index.mdx
+++ b/website/docs/contributing/index.mdx
@@ -9,7 +9,7 @@ example: illustrative
 
 # Contribute to Humanizer documentation and languages
 
-## Orientation
+These pages describe the contributor workflow for v4 development on `main`.
 
 Start with the smallest path that matches the problem:
 
@@ -23,13 +23,13 @@ Start with the smallest path that matches the problem:
 Language contribution is visible here without being a prerequisite for using
 Humanizer. User guidance stays under [Languages and cultures](../languages/index.mdx).
 
-## Example
+## Report enough detail to reproduce the issue
 
 A useful issue report is a compact, reproducible record:
 
 ```text
 Culture: fr-CA
-Humanizer version: 3.0.10
+Humanizer version: <version>
 API call: 2.ToWords(culture)
 Expected: ...
 Actual: ...
@@ -39,19 +39,12 @@ Platform/TFM: macOS, net8.0
 That is enough to route the problem before anyone changes locale ownership or
 grammar.
 
-## Pitfall
+## Reproduce before changing locale ownership
 
 Do not start by copying a parent locale or adding a culture code to a registry.
 A successful lookup is not proof of natural output, and package presence is
 not capability coverage. Trace the owning YAML surface and reproduce the
 behavior first.
-
-## Version notes
-
-The YAML and generator workflow in this contributor cluster describes
-`main/preview`. Published releases through `3.0.10` have version-specific
-package and localization implementations. Report the exact version, and make
-changes against the branch that owns that version.
 
 ## Related guides and API
 

--- a/website/docs/contributing/locale-yaml-how-to.mdx
+++ b/website/docs/contributing/locale-yaml-how-to.mdx
@@ -9,8 +9,6 @@ example: illustrative
 
 # Locale YAML how-to
 
-## Orientation
-
 Each file under `src/Humanizer/Locales` owns one locale. YAML holds words,
 phrases, lexical tables, formatting overrides, and structural engine choices.
 Reusable algorithms stay in runtime C#; the source generator compiles YAML
@@ -20,7 +18,7 @@ Valid top-level keys are `locale`, optional `variantOf`, and `surfaces`.
 Canonical surfaces are `list`, `formatter`, `phrases`, `inflection`, `number`,
 `ordinal`, `clock`, `compass`, and `calendar`.
 
-## Example
+## Define locale-owned behavior
 
 ```yaml
 locale: 'en-US'
@@ -62,7 +60,7 @@ Follow the complete [platform globalization override recipe](./platform-globaliz
 to capture the cross-target probe, author the narrowest override, and test
 every affected API.
 
-## Pitfall
+## Preserve inheritance and surface boundaries
 
 Omission is the inheritance signal; do not use empty mappings. Do not add a
 block merely to say “default.” The narrow exception is
@@ -74,14 +72,9 @@ grammar metadata). Keep render-side `number.words` aligned with parse-side
 
 If no existing engine fits, use the
 [engine-choice workflow](./choosing-or-extending-a-locale-engine.mdx) before
-adding schema or runtime code.
-
-## Version notes
-
-This authoring contract is for `main/preview`. The exhaustive
-[YAML reference](./locale-yaml-reference.mdx) lists the currently accepted
-engines and fields. Historical branches can have different schema and runtime
-ownership; use their source rather than copying a current block backward.
+adding schema or runtime code. The exhaustive
+[YAML reference](./locale-yaml-reference.mdx) lists the fields and engines
+accepted on `main`.
 
 ## Related guides and API
 

--- a/website/docs/contributing/locale-yaml-reference.mdx
+++ b/website/docs/contributing/locale-yaml-reference.mdx
@@ -9,9 +9,7 @@ example: illustrative
 
 # Locale YAML reference
 
-## Orientation
-
-This is the index for the canonical `main/preview` authoring contract under
+This is the index for the v4 authoring contract on `main` under
 `src/Humanizer/Locales/*.yml`. Use the smallest reference that answers the
 question:
 
@@ -25,7 +23,7 @@ Together with [Locale YAML how-to](./locale-yaml-how-to.mdx) and
 describe the checked-in locale contract without requiring contributors to
 reverse-engineer generator source.
 
-## Example
+## Start with a minimal variant
 
 A regional variant declares its parent and overrides only real differences:
 
@@ -243,7 +241,7 @@ Examples in the current repo:
 - `ru-RU.yml` does not need to exist when `ru` already covers the generated behavior.
 - `en-IN.yml` declares `variantOf: 'en'` and overrides only the `number.words` fields that genuinely differ.
 
-## Pitfall
+## Use only documented schema
 
 Do not invent fields, use empty mappings as inheritance sentinels, copy a
 parent file into every variant, or reference generator-internal profile keys.
@@ -251,12 +249,6 @@ Changing `engine` replaces that mapped block instead of merging it.
 
 The reference describes accepted structure; it does not prove that authored
 words or inherited behavior are natural for a culture.
-
-## Version notes
-
-This schema documents the canonical `main/preview` locale YAML compiler.
-Published releases through `3.0.10` use their own checked-in localization and
-package shapes. Do not backport a field merely because it appears here.
 
 ## Related guides and API
 

--- a/website/docs/contributing/locale-yaml-schema-reference.mdx
+++ b/website/docs/contributing/locale-yaml-schema-reference.mdx
@@ -9,13 +9,11 @@ example: illustrative
 
 # Locale YAML schema and inheritance
 
-## Orientation
-
 Use this reference for file-level rules, merge behavior, lexical table shapes,
 and common authoring patterns. Surface fields and engine-specific values are
 in the linked companion references.
 
-## Example
+## Start with a minimal variant
 
 ```yaml
 locale: 'fr-CA'
@@ -166,17 +164,12 @@ These field-name patterns repeat across engines.
 | `negative*` | Fields used only for negative number rendering or parsing. |
 | `useCulture` | Instructs the generated runtime path to pass the current culture into the shared kernel. |
 
-## Pitfall
+## Preserve merge semantics
 
 Omission is the inheritance signal. Do not use empty mappings, cross-language
 parents, or child sequences that contain only the changed element. Do not use
 numeric-slot mappings merely to avoid writing a dense sequence whose every
 slot is meaningful.
-
-## Version notes
-
-This file schema is for `main/preview`. Historical branches may not contain
-the locale YAML compiler or may accept a different shape.
 
 ## Related guides and API
 

--- a/website/docs/contributing/locale-yaml-surface-reference.mdx
+++ b/website/docs/contributing/locale-yaml-surface-reference.mdx
@@ -9,13 +9,11 @@ example: illustrative
 
 # Locale YAML surface reference
 
-## Orientation
-
 This reference lists the canonical surface fields, shared strategy values,
 date and ordinal blocks, formatter data, and clock notation data. Use the
 engine catalogues for number parsing and rendering contracts.
 
-## Example
+## Author only owned values
 
 ```yaml
 surfaces:
@@ -915,16 +913,11 @@ Notes:
 - Non-bucketed minutes fall to range-based defaults or `defaultTemplate`.
 - Day-period hour resolution is template-aware: templates that reference `{nextHour}` or `{nextArticle}` base the day period on hour+1 (since the phrasing is relative to the next hour), while templates using `{hour}` base the period on the current hour.
 
-## Pitfall
+## Keep surfaces separate
 
 Keep `formatter` separate from `phrases`, and keep `number.words`
 separate from `number.parse`. Calendar and number-formatting overrides are
 optional compatibility contracts, not placeholders for platform defaults.
-
-## Version notes
-
-These fields and strategy values describe `main/preview`. Verify the schema
-on a historical branch before applying them there.
 
 ## Related guides and API
 

--- a/website/docs/contributing/number-to-words-engine-reference.mdx
+++ b/website/docs/contributing/number-to-words-engine-reference.mdx
@@ -9,13 +9,11 @@ example: illustrative
 
 # Number-to-words engine reference
 
-## Orientation
-
 Choose a rendering engine by the language's composition, scale, gender, and
 ordinal rules. Locale-owned lexicons and switches belong in YAML; reusable
 composition stays in the shared runtime kernel.
 
-## Example
+## Configure a rendering engine
 
 ```yaml
 surfaces:
@@ -946,16 +944,11 @@ Fields:
 - `billions`
 - `useCulture`
 
-## Pitfall
+## Test rule boundaries
 
 Do not select an engine by name resemblance alone or add locale-specific
 branches to a shared kernel. Exact-output tests must cover the rule boundaries,
 not only single-digit examples.
-
-## Version notes
-
-These rendering engines are the accepted `main/preview` contracts.
-Historical branches may use different engines or handwritten converters.
 
 ## Related guides and API
 

--- a/website/docs/contributing/parity-and-preflight.mdx
+++ b/website/docs/contributing/parity-and-preflight.mdx
@@ -9,8 +9,6 @@ example: illustrative
 
 # Locale parity and preflight
 
-## Orientation
-
 Before editing, create `artifacts/YYYY-MM-DD-<locale>-parity-map.md`. The
 artifact is local, gitignored working evidence. Cover these canonical surfaces:
 
@@ -33,7 +31,7 @@ At the top of the artifact, keep three summaries:
 
 The final effective gap set must be empty.
 
-## Example
+## Record ownership and proof
 
 Use only explicit states:
 
@@ -62,7 +60,7 @@ verification result. Include separate lines for nested required blocks such as
 `number.words`, `number.parse`, each `phrases` family, ordinal variants, and
 authored calendar arrays.
 
-## Pitfall
+## Do not substitute broad test results for proof
 
 Do not mark a row proved because the full suite passed. Name the exact
 assertion. Registry presence, non-empty output, a culture-aware platform
@@ -75,12 +73,6 @@ confidence, limitations, rejected alternatives, and the accepted outputs.
 If any row remains `unknown`, `missing`, `english-fallback`, or otherwise lacks
 proof, report `parity not complete`; do not smooth it into a general statement
 that tests pass.
-
-## Version notes
-
-This parity contract applies to `main/preview` locale work. A historical
-correction should use the tests and ownership model of its branch, but it still
-must not claim correctness from generic or English fallback.
 
 ## Related guides and API
 

--- a/website/docs/contributing/platform-globalization-overrides.mdx
+++ b/website/docs/contributing/platform-globalization-overrides.mdx
@@ -9,8 +9,6 @@ example: illustrative
 
 # Override platform globalization data
 
-## Orientation
-
 .NET Framework commonly reads Windows NLS data while modern .NET normally
 uses ICU. Month names and numeric punctuation can therefore differ by
 platform, target framework, or globalization-data version.
@@ -19,7 +17,7 @@ Add an override only when a probe demonstrates that platform data is wrong or
 inconsistent for the locale. Locale YAML does not mutate `CultureInfo`; it
 supplies narrow values at documented Humanizer call sites.
 
-### Probe before editing
+## Probe before editing
 
 Run the same culture and values on the affected targets, including Windows
 `net48` and a modern .NET target when the report concerns NLS/ICU drift.
@@ -33,7 +31,7 @@ Record:
 
 Keep the probe with the parity artifact and add exact-output regression tests.
 
-## Example
+## Add the narrowest override
 
 ### Override month names
 
@@ -111,7 +109,7 @@ After authoring an override:
 3. Run the full [locale validation matrix](./validation-and-testing.mdx).
 4. Regenerate supported-culture coverage and review the ownership change.
 
-## Pitfall
+## Override only proven platform drift
 
 Do not copy platform data into YAML merely to make ownership explicit. Absence
 means Humanizer should use platform globalization data. An override becomes a
@@ -120,13 +118,6 @@ maintained compatibility contract and must have a proving regression test.
 Caller-supplied custom format providers remain authoritative. String
 `Ordinalize` overloads parse through the culture's native
 `NumberFormatInfo`; locale overrides do not rewrite arbitrary provider input.
-
-## Version notes
-
-The YAML-backed `calendar` and `number.formatting` surfaces describe
-`main/preview`. Historical versions can rely directly on platform data or have
-different call-site behavior. Probe the package and targets you actually
-ship before backporting an override.
 
 ## Related guides and API
 

--- a/website/docs/contributing/report-language-issue.mdx
+++ b/website/docs/contributing/report-language-issue.mdx
@@ -9,8 +9,6 @@ example: illustrative
 
 # Report or correct a language issue
 
-## Orientation
-
 Capture the culture, Humanizer version, exact API call, expected natural
 output, actual output, and platform/target framework. Include grammatical
 context: gender, case, count, tense, or the noun being modified can change the
@@ -18,7 +16,7 @@ correct answer.
 
 [Open a prefilled locale issue](https://github.com/Humanizr/Humanizer/issues/new?title=Locale%3A%20describe%20the%20language%20issue&body=Culture%3A%20%0AHumanizer%20version%3A%20%0AAPI%20call%3A%20%0AExpected%3A%20%0AActual%3A%20%0APlatform%2FTFM%3A%20).
 
-## Example
+## Provide a minimal reproduction
 
 Paste a minimal program or test-shaped snippet:
 
@@ -34,7 +32,7 @@ Then state what a native speaker expects in that exact context. If the issue
 appears only on one platform, include both outputs and whether the target uses
 ICU or Windows NLS.
 
-## Pitfall
+## Diagnose the exact locale behavior
 
 Do not report only “French is wrong” or assume the nearest English phrase has
 the same grammar. Also do not infer a fix from the generated coverage table:
@@ -44,13 +42,6 @@ for Canada.
 For a pull request, update the owning surface once and add exact-output tests.
 Follow the full [locale workflow](./adding-or-updating-a-locale.mdx) when the
 change affects parity or inheritance.
-
-## Version notes
-
-Locale output and package IDs are versioned. The generated coverage table is
-for `main/preview`; it is not evidence for `3.0.10` or an older line. Reproduce
-against the reported version before deciding whether the correction belongs
-on the current branch or in historical documentation.
 
 ## Related guides and API
 

--- a/website/docs/contributing/validation-and-testing.mdx
+++ b/website/docs/contributing/validation-and-testing.mdx
@@ -9,8 +9,6 @@ example: illustrative
 
 # Validate locale changes
 
-## Orientation
-
 Locale changes need exact-output proof and broad sweep proof. Put
 culture-specific xUnit tests under
 `tests/Humanizer.Tests/Localisation/<culture>`. Update source-generator tests
@@ -30,7 +28,7 @@ The minimum proof set is:
   changes
 - package and formatting validation
 
-## Example
+## Run the validation matrix
 
 Run the complete locale validation from the repository root:
 
@@ -68,7 +66,7 @@ affected path:
 Record OS, target framework, globalization mode, and result in the parity
 artifact.
 
-## Pitfall
+## Keep generated coverage and platform claims honest
 
 Do not commit a regenerated coverage file without its YAML change, or a YAML
 change without regenerated coverage. `-Check` intentionally fails when those
@@ -80,13 +78,6 @@ concrete assertion for every canonical surface and required subrow.
 Do not run `net48` on non-Windows hosts, and do not claim a cross-platform
 formatting fix from a single ICU or NLS result. Preserve a failing probe and
 the exact regression assertion that replaces it.
-
-## Version notes
-
-These commands target the current repository and therefore `main/preview`.
-Historical maintenance branches can target different frameworks. Use the
-branch's toolchain while preserving exact-output, sweep, and warning-free pack
-gates.
 
 ## Related guides and API
 

--- a/website/docs/contributing/words-to-number-engine-reference.mdx
+++ b/website/docs/contributing/words-to-number-engine-reference.mdx
@@ -9,13 +9,11 @@ example: illustrative
 
 # Words-to-number engine reference
 
-## Orientation
-
 Choose a parser engine only after mapping the language's token normalization,
 cardinal composition, scales, and ordinal behavior. Render-side number words
 use a separate engine catalogue.
 
-## Example
+## Configure a parser engine
 
 ```yaml
 surfaces:
@@ -238,15 +236,10 @@ Fields:
 - `teenLeaderToken`
 - `teenLeaderBases`
 
-## Pitfall
+## Prove parsing separately
 
 A number-to-words engine does not imply a matching parser. Prove cardinal and
 ordinal parsing independently, including normalization and ambiguous tokens.
-
-## Version notes
-
-These parser engines are the accepted `main/preview` contracts. Historical
-branches may expose fewer engines or handwritten converters.
 
 ## Related guides and API
 

--- a/website/docs/languages/custom-localization.mdx
+++ b/website/docs/languages/custom-localization.mdx
@@ -9,8 +9,6 @@ example: illustrative
 
 # Customize localization
 
-## Orientation
-
 Prefer a per-call culture or transformer first. Use a custom localiser only
 when an application needs process-wide behavior that the selected locale does
 not provide.
@@ -22,7 +20,7 @@ humanization strategies are separate process-wide properties.
 
 ## Example
 
-In `Humanizer 4`, register before any code resolves the formatter registry:
+Register before any code resolves the formatter registry:
 
 ```csharp
 using System.Globalization;
@@ -43,22 +41,23 @@ sealed class ProductFormatter(CultureInfo culture)
 }
 ```
 
-The result is `just now`. Register the narrowest component that owns the
+The output is `just now`. Register the narrowest component that owns the
 behavior; do not replace a formatter merely to change number words.
 
-In Humanizer 4, a custom formatter used by `HumanizeWithCase` must also
-implement `IGrammaticalCaseTimeSpanFormatter`. A custom global time-span
-strategy must implement `IGrammaticalCaseTimeSpanHumanizeStrategy`. Existing
-`IFormatter` and `ITimeSpanHumanizeStrategy` implementations continue to work
-for the existing duration APIs, but case-aware calls fail with
-`NotSupportedException` instead of silently using another locale.
+## Support case-aware durations
 
-## Pitfall
+A custom formatter used by `HumanizeWithCase` must also implement
+`IGrammaticalCaseTimeSpanFormatter`. A custom global time-span strategy must
+implement `IGrammaticalCaseTimeSpanHumanizeStrategy`. Existing `IFormatter`
+and `ITimeSpanHumanizeStrategy` implementations continue to work for the
+existing duration APIs, but case-aware calls fail with `NotSupportedException`
+instead of silently using another locale.
 
-In Humanizer `3.x` and `Humanizer 4`, a `LocaliserRegistry` freezes on first
-resolution. A later `Register` call throws. Configure registries once during
-startup, before hosted services, request handlers, or static initializers can
-call Humanizer.
+## Configure before first use
+
+A `LocaliserRegistry` freezes on first resolution. A later `Register` call
+throws. Configure registries once during startup, before hosted services,
+request handlers, or static initializers can call Humanizer.
 
 Custom global components affect every caller that resolves that culture.
 For request-specific text transformation, implement `IStringTransformer` or
@@ -68,18 +67,10 @@ If the built-in locale is wrong rather than product-specific, follow the
 [language correction guide](../contributing/report-language-issue.mdx) or
 [open a prefilled locale issue](https://github.com/Humanizr/Humanizer/issues/new?title=Locale%3A%20describe%20the%20language%20issue&body=Culture%3A%20%0AHumanizer%20version%3A%20%0AAPI%20call%3A%20%0AExpected%3A%20%0AActual%3A%20%0APlatform%2FTFM%3A%20).
 
-## Version notes
-
-Humanizer `2.x` registries remain mutable; `3.x` and `Humanizer 4` freeze them
-after first use. Constructor shapes and available registries are
-version-specific public API. Compile against the selected package and follow
-that snapshot's API reference rather than copying a `Humanizer 4` extension
-into a historical application.
-
 ## Related guides and API
 
 - [Culture and global configuration](../concepts/culture-and-configuration.mdx)
 - [Localization and extensibility](../scenarios/localization-and-extensibility.mdx)
 - [Format durations and ages](../scenarios/durations-and-ages.mdx)
 - [Grammar and platform formatting](./grammar-and-platform-formatting.mdx)
-- [Selected-version API reference](../api/index.md)
+- [API reference](../api/index.md)

--- a/website/docs/languages/grammar-and-platform-formatting.mdx
+++ b/website/docs/languages/grammar-and-platform-formatting.mdx
@@ -9,8 +9,6 @@ example: illustrative
 
 # Grammar and platform formatting
 
-## Orientation
-
 Humanizer APIs expose grammatical gender, word form, and grammatical case
 where the result needs information that a number or date cannot carry by
 itself. These arguments affect language rules; they are not presentation-only
@@ -18,9 +16,9 @@ labels.
 
 Calendar names and numeric punctuation are a separate layer. .NET Framework
 uses Windows NLS, while modern .NET normally uses ICU. When those sources
-disagree, consult the selected-version language inventory for package-specific
-behavior or overrides, and test the target frameworks and platforms the
-application ships.
+disagree, Humanizer uses an explicit locale-profile override where one is
+defined. Otherwise the runtime globalization data is authoritative. Test the
+target frameworks and platforms the application ships.
 
 ## Example
 
@@ -36,46 +34,45 @@ Console.WriteLine(1.ToWords(
     GrammaticalGender.Masculine,
     spanish));
 
-CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("cs");
-CultureInfo.CurrentUICulture = CultureInfo.CurrentCulture;
-Console.WriteLine(new DateTime(2026, 7, 27)
-    .ToOrdinalWords(GrammaticalCase.Genitive));
+var czech = CultureInfo.GetCultureInfo("cs");
+Console.WriteLine(TimeSpan.FromDays(1)
+    .HumanizeWithCase(GrammaticalCase.Nominative, culture: czech));
+```
+
+The output is:
+
+```text
+una
+un
+jeden den
 ```
 
 Pass grammar explicitly when the surrounding noun or sentence determines it.
 The default gender or case is a locale convention, not a guess about your
 domain text.
 
-In Humanizer 4, `TimeSpan.HumanizeWithCase` applies case only to a bare
-duration phrase. It does not add a preposition and does not alter the separate
-relative-date or date-ordinal grammar paths. Singular duration forms may be
-complete locale-authored one-word or article phrases; counted forms may write
-the number explicitly or encode it in the unit form.
+`TimeSpan.HumanizeWithCase` applies case only to a bare duration phrase. It
+does not add a preposition and does not alter the separate relative-date or
+date-ordinal grammar paths.
 
-## Pitfall
+## Keep language rules and presentation separate
 
 Not every grammatical option has a distinct natural form in every locale.
 Do not manufacture a gender or case by post-processing Humanizer output.
 Choose a supported overload and test the complete phrase native speakers will
 see.
 
-Caller-supplied custom format providers remain authoritative. Consult the
-selected-version language inventory for any Humanizer-specific calendar or
-number-formatting overrides. When none are documented, calendar names and
-numeric punctuation follow the runtime globalization data for the target
-framework and platform.
+Caller-supplied custom format providers remain authoritative. Without a custom
+provider or a Humanizer locale-profile override, calendar names and numeric
+punctuation follow the runtime globalization data for the target framework and
+platform.
 
 For incorrect grammar or platform-specific output, use the
 [language correction guide](../contributing/report-language-issue.mdx) or
 [open a prefilled locale issue](https://github.com/Humanizr/Humanizer/issues/new?title=Locale%3A%20describe%20the%20language%20issue&body=Culture%3A%20%0AHumanizer%20version%3A%20%0AAPI%20call%3A%20%0AExpected%3A%20%0AActual%3A%20%0APlatform%2FTFM%3A%20).
 
-## Version notes
-
-The selected-version language inventory records package-specific calendar or
-number-formatting behavior available in that release. Runtime globalization
-data can still differ by target framework and platform, so test the selected
-package on the targets you ship. `DateOnly` and `TimeOnly` APIs require a target
-framework on which those types exist.
+`DateOnly` and `TimeOnly` APIs require a target framework on which those types
+exist.
 
 ## Related guides and API
 
@@ -83,4 +80,4 @@ framework on which those types exist.
 - [Supported cultures](./supported-cultures.mdx)
 - [Format durations and ages](../scenarios/durations-and-ages.mdx)
 - [Localization scenarios](../scenarios/localization-and-extensibility.mdx)
-- [Selected-version API reference](../api/index.md)
+- [API reference](../api/index.md)

--- a/website/docs/languages/index.mdx
+++ b/website/docs/languages/index.mdx
@@ -9,19 +9,15 @@ example: illustrative
 
 # Languages and cultures
 
-## Orientation
-
 Humanizer localizes behavior by culture, not by translating one final string.
-Choose a culture for the operation, then confirm that it is listed for the
-selected documentation version. Every listed culture supports every applicable
-localized feature.
+Choose a culture for the operation, then confirm that it or one of its named
+parents has a generated [Humanizer 4 locale profile](./supported-cultures.mdx).
+`Configurator.IsCultureSupported` performs the same parent-chain check in
+application code.
 
-The package and the culture are separate choices. Published releases through
-`3.0.10` use the `Humanizer` metapackage to bring in `Humanizer.Core` and its
-locale packages. Humanizer 4 is consolidated: one
-`Humanizer` reference contains the runtime, generated locale data, and
-analyzers. Installing a culture-specific package does not select that culture,
-and selecting a culture does not install a missing historical package.
+Humanizer 4 ships its runtime, generated locale data, and analyzers in the
+single `Humanizer` package. Installing the package does not select a culture;
+the application still chooses one with `CultureInfo`.
 
 ## Example
 
@@ -35,29 +31,28 @@ var french = CultureInfo.GetCultureInfo("fr-FR");
 Console.WriteLine(42.ToWords(french));
 ```
 
+The output is:
+
+```text
+quarante-deux
+```
+
 Use [culture selection](./using-cultures.mdx) for per-call and ambient-culture
-patterns. Use [supported cultures](./supported-cultures.mdx)
-for the selected-version inventory.
-Use the [scenario finder](../scenarios/index.mdx) to reach the focused guide for
-number words, dates, clock notation, collections, or another localized task.
+patterns. Use [supported cultures](./supported-cultures.mdx) for the current
+inventory. Use the [scenario finder](../scenarios/index.mdx) to reach the
+focused guide for number words, dates, clock notation, collections, or another
+localized task.
 
-Found a wrong translation, inflection, parser result, or platform-specific
-format? Follow the [language correction guide](../contributing/report-language-issue.mdx)
-or [open a prefilled locale issue](https://github.com/Humanizr/Humanizer/issues/new?title=Locale%3A%20describe%20the%20language%20issue&body=Culture%3A%20%0AHumanizer%20version%3A%20%0AAPI%20call%3A%20%0AExpected%3A%20%0AActual%3A%20%0APlatform%2FTFM%3A%20).
-
-## Pitfall
+## How culture fallback works
 
 Do not infer support from a package name or English fallback. A regional
 culture can reuse a same-language parent such as `fr`; that is an
 implementation detail, not partial support. Report incorrect inherited
 behavior just as you would incorrect directly authored behavior.
 
-## Version notes
-
-The generated coverage page is scoped to the selected documentation version.
-Stable snapshots use their own package and documentation evidence. Package
-consolidation is Humanizer 4 behavior, while published versions through
-`3.0.10` retain the metapackage and locale-package model.
+Found a wrong translation, parser result, or platform-specific format? Follow
+the [language correction guide](../contributing/report-language-issue.mdx) or
+[open a prefilled locale issue](https://github.com/Humanizr/Humanizer/issues/new?title=Locale%3A%20describe%20the%20language%20issue&body=Culture%3A%20%0AHumanizer%20version%3A%20%0AAPI%20call%3A%20%0AExpected%3A%20%0AActual%3A%20%0APlatform%2FTFM%3A%20).
 
 ## Related guides and API
 
@@ -65,4 +60,4 @@ consolidation is Humanizer 4 behavior, while published versions through
 - [Grammar and platform formatting](./grammar-and-platform-formatting.mdx)
 - [Scenario finder](../scenarios/index.mdx)
 - [Package selection](../start/package-selection.md)
-- [Selected-version API reference](../api/index.md)
+- [API reference](../api/index.md)

--- a/website/docs/languages/supported-cultures.mdx
+++ b/website/docs/languages/supported-cultures.mdx
@@ -14,13 +14,11 @@ export const supportedCultures =
 
 # Supported cultures
 
-## Orientation
-
-Humanizer 4 treats locale support as all-or-nothing. Every culture listed below
-supports every applicable localized feature. Regional cultures may reuse a
-same-language parent, and calendar or numeric formatting may use .NET
-globalization data when no Humanizer override is needed; neither represents
-partial support.
+Humanizer 4 ships a complete generated locale profile for every code listed
+here. A regional culture can be supported through a listed same-language
+parent, so use `Configurator.IsCultureSupported` to check a requested
+`CultureInfo`. Calendar or numeric formatting uses .NET globalization data
+when a profile does not need a Humanizer override.
 
 ## Example
 
@@ -34,7 +32,13 @@ var culture = CultureInfo.GetCultureInfo("pt-BR");
 Console.WriteLine(123.ToWords(culture));
 ```
 
-<p>This version supports {supportedCultures.length} cultures:</p>
+The output is:
+
+```text
+cento e vinte e três
+```
+
+<p>Humanizer 4 ships {supportedCultures.length} generated locale profiles:</p>
 
 <ul className="supportedCultureList" aria-label="Supported cultures">
   {supportedCultures.map((locale) => (
@@ -42,24 +46,17 @@ Console.WriteLine(123.ToWords(culture));
   ))}
 </ul>
 
-## Pitfall
+## When output is wrong
 
-A listed culture is supported. Missing behavior, English fallback, or
-incorrect language in that culture is a bug. If output is wrong, use the
-correction path.
+Incorrect output from a localized Humanizer surface backed by one of these
+profiles is a bug. If output is wrong, use the correction path.
 
 [Open the correction guide](../contributing/report-language-issue.mdx) or
 [open a prefilled locale issue](https://github.com/Humanizr/Humanizer/issues/new?title=Locale%3A%20describe%20the%20language%20issue&body=Culture%3A%20%0AHumanizer%20version%3A%20%0AAPI%20call%3A%20%0AExpected%3A%20%0AActual%3A%20%0APlatform%2FTFM%3A%20).
-
-## Version notes
-
-The sibling `language-coverage.json` is generated separately for each docs
-version. Published snapshots use their own verified NuGet packages and culture
-lists; they never inherit another version's inventory.
 
 ## Related guides and API
 
 - [Choose a culture](./using-cultures.mdx)
 - [Grammar and platform formatting](./grammar-and-platform-formatting.mdx)
 - [Report or correct a language issue](../contributing/report-language-issue.mdx)
-- [Selected-version API reference](../api/index.md)
+- [API reference](../api/index.md)

--- a/website/docs/languages/using-cultures.mdx
+++ b/website/docs/languages/using-cultures.mdx
@@ -9,8 +9,6 @@ example: illustrative
 
 # Choose explicit and ambient cultures
 
-## Orientation
-
 Pass a `CultureInfo` directly when an overload accepts one. It makes the
 language choice visible, keeps concurrent requests isolated, and is easy to
 test. Set `CurrentCulture` and `CurrentUICulture` together at a request,
@@ -28,39 +26,44 @@ using System.Globalization;
 using Humanizer;
 
 var french = CultureInfo.GetCultureInfo("fr-FR");
-
 Console.WriteLine(42.ToWords(french));
-Console.WriteLine(DateTime.UtcNow.AddDays(-1).Humanize(culture: french));
-Console.WriteLine(new[] { "un", "deux", "trois" }.Humanize(french));
+```
 
+The output is `quarante-deux`.
+
+Keep using explicit overloads inside shared services where possible; this
+prevents one concurrent operation from changing another operation's output.
+
+## Establish ambient culture at a boundary
+
+Some APIs use the ambient culture:
+
+```csharp
 CultureInfo.CurrentCulture = french;
 CultureInfo.CurrentUICulture = french;
+
 Console.WriteLine(42.ToWords());
 ```
 
-The first three calls are explicit. The final call uses the ambient culture.
+The output is again `quarante-deux`.
 
-For application code, establish ambient culture once at the request, message,
-or background-job boundary. Keep using explicit overloads inside shared
-services where possible; this prevents one concurrent operation from changing
-another operation's output.
+## Keep both ambient cultures consistent
 
-## Pitfall
-
-`CurrentCulture` and `CurrentUICulture` serve different .NET concerns.
-Humanizer's ambient localizer registries, including collection formatting,
-follow `CurrentCulture`; application resources can follow `CurrentUICulture`.
-Setting only one can produce mixed-language output. Also avoid changing
-ambient culture in a shared request path when an explicit overload exists.
+`CurrentCulture` and `CurrentUICulture` serve different .NET concerns, and
+Humanizer APIs can use either one. Setting only one can produce mixed-language
+output. Avoid changing ambient culture in a shared request path when an
+explicit overload exists.
 
 Parent fallback is resolution, not parity proof. If `fr-CA` reaches `fr`, that
 only identifies where the data came from. It does not establish that French
 Canadian wording matches every neutral-French choice.
 
-In Humanizer 4, use `Configurator.IsCultureSupported(culture)` before choosing
-an application fallback. It checks generated Humanizer locale data through the
-named parent chain and does not return `true` merely because the default English
-localizers could produce output:
+## Choose an application fallback
+
+Use `Configurator.IsCultureSupported(culture)` before choosing an application
+fallback. It checks generated Humanizer locale data through the named parent
+chain and does not return `true` merely because the default English localizers
+could produce output:
 
 ```csharp
 var requested = CultureInfo.GetCultureInfo("fr-FR");
@@ -73,18 +76,10 @@ If inherited or direct output is wrong, follow the
 [language correction guide](../contributing/report-language-issue.mdx) or
 [open a prefilled locale issue](https://github.com/Humanizr/Humanizer/issues/new?title=Locale%3A%20describe%20the%20language%20issue&body=Culture%3A%20%0AHumanizer%20version%3A%20%0AAPI%20call%3A%20%0AExpected%3A%20%0AActual%3A%20%0APlatform%2FTFM%3A%20).
 
-## Version notes
-
-Explicit and ambient `CultureInfo` selection applies across the supported
-documentation corpus. Humanizer 4 ships generated locale data and
-`Configurator.IsCultureSupported` in the consolidated `Humanizer` NuGet
-package. Releases through `3.0.10` use the metapackage and locale-package graph
-documented in their snapshot.
-
 ## Related guides and API
 
 - [Supported cultures](./supported-cultures.mdx)
 - [Culture and global configuration](../concepts/culture-and-configuration.mdx)
 - [Localization and extensibility](../scenarios/localization-and-extensibility.mdx)
 - [Package selection](../start/package-selection.md)
-- [Selected-version API reference](../api/index.md)
+- [API reference](../api/index.md)

--- a/website/docs/languages/using-cultures.mdx
+++ b/website/docs/languages/using-cultures.mdx
@@ -39,6 +39,9 @@ prevents one concurrent operation from changing another operation's output.
 Some APIs use the ambient culture:
 
 ```csharp
+using System.Globalization;
+
+var french = CultureInfo.GetCultureInfo("fr-FR");
 CultureInfo.CurrentCulture = french;
 CultureInfo.CurrentUICulture = french;
 

--- a/website/docs/languages/using-cultures.mdx
+++ b/website/docs/languages/using-cultures.mdx
@@ -40,6 +40,7 @@ Some APIs use the ambient culture:
 
 ```csharp
 using System.Globalization;
+using Humanizer;
 
 var french = CultureInfo.GetCultureInfo("fr-FR");
 CultureInfo.CurrentCulture = french;


### PR DESCRIPTION
## Summary

Current language, culture, analyzer, Native AOT, and contributor guidance now describes the Humanizer 4 source and package model directly. Historical-version boilerplate and forced template sections are removed while operational details, YAML surfaces, platform behavior, and contribution commands remain intact.

This builds on the content contract merged in #1895. The two source ownership units remain separate commits inside this focused current-reference PR.

## Validation

- `pnpm --dir website run check:content` — all seven areas passed.
- `pnpm --dir website run typecheck` — passed.
- Namespace analyzer and code-fix tests — 20/20 passed on Roslyn 4.14.
- Shipped analyzer/Fix All proof — both old namespace references were updated, the corrected consumer built, and output was `10 KB`.
- Original rebase patch identity — `153159aa8dbfaca7cb7084ceaf7e8378ea56a385df8b4124d12d736917c1c760` before and after retargeting to `main`; later review fixes are isolated follow-up commits.
- `git diff --check` — passed.

## Checklist

- [x] Implementation is clean.
- [x] Repository coding standards are followed.
- [x] No code-analysis warnings are introduced.
- [x] Analyzer and runnable-example corrections have focused executable coverage.
- [x] No copied code requires attribution.
- [x] Comments and XML documentation are not applicable.
- [x] Rebased onto `main` after #1895 merged.
- [x] No issue is closed by this focused documentation unit.
- [x] Current reference and contributor documentation is updated.
- [x] Applicable documentation gates were run.
