### PR TITLE
docs: make v4 scenarios runnable

### DIFF
--- a/tools/docs/verify-examples.ps1
+++ b/tools/docs/verify-examples.ps1
@@ -195,22 +195,30 @@ try {
                 "--artifacts-path", $projectArtifacts,
                 "--no-restore"
             ) + $inputArguments
-            $actualOutput = @(& dotnet @runArguments)
+            $standardErrorPath = Join-Path $projectArtifacts "stderr.txt"
+            $actualOutput = @(& dotnet @runArguments 2> $standardErrorPath)
             $runExitCode = $LASTEXITCODE
             if ($runExitCode -ne 0) {
+                $standardError = @(
+                    Get-Content $standardErrorPath -ErrorAction SilentlyContinue
+                ) -join "`n"
                 throw @"
 Example $($project.Name) failed for $($entry.version).
+Standard output:
 $($actualOutput -join "`n")
+Standard error:
+$standardError
 "@
             }
             $actualText = $actualOutput -join "`n"
             $expectedOutputPath = Join-Path (
                 $project.DirectoryName
             ) "expected-output.txt"
-            if ($entry.version -eq "current") {
-                if (-not (Test-Path $expectedOutputPath -PathType Leaf)) {
-                    throw "Example $($project.Name) has no expected-output.txt."
-                }
+            $hasExpectedOutput = Test-Path $expectedOutputPath -PathType Leaf
+            if ($entry.version -eq "current" -and -not $hasExpectedOutput) {
+                throw "Example $($project.Name) has no expected-output.txt."
+            }
+            if ($hasExpectedOutput) {
                 $expectedText = @(Get-Content $expectedOutputPath) -join "`n"
                 if (-not [string]::Equals(
                     $expectedText,

--- a/tools/docs/verify-examples.ps1
+++ b/tools/docs/verify-examples.ps1
@@ -50,8 +50,6 @@ try {
     foreach ($entry in $versions) {
         $entryExamplesRoot = if ($explicitExamplesRoot) {
             $ExamplesRoot
-        } elseif ($requestedAreas.Count -gt 0) {
-            Join-Path $repoRoot "website/docs/_examples"
         } elseif ($entry.published) {
             Join-Path $repoRoot "website/versioned_docs/version-$($entry.version)/_examples"
         } else {
@@ -197,10 +195,38 @@ try {
                 "--artifacts-path", $projectArtifacts,
                 "--no-restore"
             ) + $inputArguments
-            & dotnet @runArguments
-            if ($LASTEXITCODE -ne 0) {
-                throw "Example $($project.Name) failed for $($entry.version)."
+            $actualOutput = @(& dotnet @runArguments)
+            $runExitCode = $LASTEXITCODE
+            if ($runExitCode -ne 0) {
+                throw @"
+Example $($project.Name) failed for $($entry.version).
+$($actualOutput -join "`n")
+"@
             }
+            $actualText = $actualOutput -join "`n"
+            $expectedOutputPath = Join-Path (
+                $project.DirectoryName
+            ) "expected-output.txt"
+            if ($entry.version -eq "current") {
+                if (-not (Test-Path $expectedOutputPath -PathType Leaf)) {
+                    throw "Example $($project.Name) has no expected-output.txt."
+                }
+                $expectedText = @(Get-Content $expectedOutputPath) -join "`n"
+                if (-not [string]::Equals(
+                    $expectedText,
+                    $actualText,
+                    [System.StringComparison]::Ordinal
+                )) {
+                    throw @"
+Example $($project.Name) output differed for $($entry.version).
+Expected:
+$expectedText
+Actual:
+$actualText
+"@
+                }
+            }
+            Write-Host $actualText
         }
 
         Write-Host "Runnable examples passed: $($entry.version)"

--- a/website/docs/_examples/configuration/Configuration.csproj
+++ b/website/docs/_examples/configuration/Configuration.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <DocumentationArea>Start</DocumentationArea>
-    <DefineConstants Condition="$([System.String]::Copy('$(HumanizerPackageVersion)').StartsWith('2.'))">$(DefineConstants);HUMANIZER_V2</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/website/docs/_examples/configuration/Program.cs
+++ b/website/docs/_examples/configuration/Program.cs
@@ -1,9 +1,5 @@
 using System.Globalization;
 using Humanizer;
-#if HUMANIZER_V2
-using Humanizer.Configuration;
-using Humanizer.DateTimeHumanizeStrategy;
-#endif
 
 var culture = CultureInfo.GetCultureInfo("en-US");
 var comparison = new DateTime(2025, 1, 20, 12, 0, 0, DateTimeKind.Utc);
@@ -20,11 +16,6 @@ var result = comparison.AddMinutes(-45).Humanize(
 var duration = TimeSpan.FromMinutes(62).Humanize(
     precision: 2,
     culture: culture);
-
-if (result != "an hour ago")
-    throw new InvalidOperationException($"Unexpected result: {result}");
-if (duration != "1 hour")
-    throw new InvalidOperationException($"Unexpected duration: {duration}");
 
 Console.WriteLine($"{result}; {duration}");
 

--- a/website/docs/_examples/configuration/expected-output.txt
+++ b/website/docs/_examples/configuration/expected-output.txt
@@ -1,0 +1,1 @@
+an hour ago; 1 hour

--- a/website/docs/_examples/quick-start/Program.cs
+++ b/website/docs/_examples/quick-start/Program.cs
@@ -5,7 +5,5 @@ CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
 CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
 
 var result = TimeSpan.FromMinutes(2).Humanize();
-if (result != "2 minutes")
-    throw new InvalidOperationException($"Unexpected result: {result}");
 
 Console.WriteLine(result);

--- a/website/docs/_examples/quick-start/expected-output.txt
+++ b/website/docs/_examples/quick-start/expected-output.txt
@@ -1,0 +1,1 @@
+2 minutes

--- a/website/docs/_examples/scenarios-aot/Program.cs
+++ b/website/docs/_examples/scenarios-aot/Program.cs
@@ -7,10 +7,8 @@ CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
 var label = JobState.ReadyToShip.Humanize();
 var parsed = "READY TO SHIP".DehumanizeTo<JobState>();
 
-if (label != "Ready to ship" || parsed != JobState.ReadyToShip)
-    throw new InvalidOperationException($"Unexpected enum result: {label}; {parsed}");
-
-Console.WriteLine("Ready to ship");
+Console.WriteLine($"Label: {label}");
+Console.WriteLine($"Parsed: {parsed}");
 
 enum JobState
 {

--- a/website/docs/_examples/scenarios-aot/expected-output.txt
+++ b/website/docs/_examples/scenarios-aot/expected-output.txt
@@ -1,0 +1,2 @@
+Label: Ready to ship
+Parsed: ReadyToShip

--- a/website/docs/_examples/scenarios-bytes/Program.cs
+++ b/website/docs/_examples/scenarios-bytes/Program.cs
@@ -7,12 +7,12 @@ CultureInfo.CurrentUICulture = culture;
 
 var parsed = ByteSize.Parse("1.5 KB", culture);
 var combined = parsed + 512.Bytes();
-var rate = 3.Megabytes()
-    .Per(TimeSpan.FromSeconds(2))
-    .Humanize("0.0", TimeUnit.Second, culture);
 var composite = ByteSize.FromBits(81_937);
 var decimalSize = ByteSize.FromBytes(1_000_000);
 var binarySize = ByteSize.FromMebibytes(1);
+var rate = 3.Megabytes()
+    .Per(TimeSpan.FromSeconds(2))
+    .Humanize("0.0", TimeUnit.Second, culture);
 var decimalRate = ByteSize.FromDecimalMegabytes(1)
     .Per(TimeSpan.FromSeconds(1))
     .HumanizeWithUnitSystem(ByteSizeUnitSystem.DecimalSi, culture: culture);
@@ -20,61 +20,11 @@ var binaryRate = binarySize
     .Per(TimeSpan.FromSeconds(1))
     .HumanizeWithUnitSystem(ByteSizeUnitSystem.BinaryIec, culture: culture);
 
-AssertEqual(1536d, parsed.Bytes);
-AssertEqual("2 KB", combined.Humanize("0", culture));
-AssertEqual("1.5 MB/s", rate);
-AssertEqual(true, ByteSize.TryParse("12 b", culture, out var bits));
-AssertEqual(12L, bits.Bits);
-AssertEqual(
-    "10 KB 2 B",
-    composite.HumanizeComposite(precision: 2, formatProvider: culture));
-AssertEqual(
-    "10 KB 2 B 1 b",
-    composite.HumanizeComposite(precision: 3, formatProvider: culture));
-AssertEqual(
-    "10 kilobytes, 2 bytes",
-    10_242.Bytes().HumanizeComposite(
-        formatProvider: culture,
-        separator: ", ",
-        toWords: true));
-AssertEqual("-10 KB 2 B", (-10_242).Bytes().HumanizeComposite(formatProvider: culture));
-AssertEqual("0 b", 0.Bytes().HumanizeComposite(formatProvider: culture));
-AssertEqual(
-    "1 PB 1 TB 1 GB",
-    ByteSize.FromBytes(
-            ByteSize.BytesInPetabyte +
-            ByteSize.BytesInTerabyte +
-            ByteSize.BytesInGigabyte)
-        .HumanizeComposite(precision: 3, formatProvider: culture));
-AssertEqual("1 MB", decimalSize.Format(ByteSizeUnitSystem.DecimalSi, formatProvider: culture));
-AssertEqual("976.56 KiB", decimalSize.Format(ByteSizeUnitSystem.BinaryIec, formatProvider: culture));
-AssertEqual(
-    "1 MB 1 kB 1 B",
-    ByteSize.FromBytes(1_001_001)
-        .HumanizeCompositeWithUnitSystem(
-            ByteSizeUnitSystem.DecimalSi,
-            precision: 3,
-            formatProvider: culture));
-AssertEqual(
-    "1 MiB 1 KiB 1 B",
-    ByteSize.FromBytes(
-            ByteSize.BytesInMebibyte +
-            ByteSize.BytesInKibibyte +
-            1)
-        .HumanizeCompositeWithUnitSystem(
-            ByteSizeUnitSystem.BinaryIec,
-            precision: 3,
-            formatProvider: culture));
-AssertEqual(decimalSize, ByteSize.ParseWithUnitSystem("1 MB", ByteSizeUnitSystem.DecimalSi, culture));
-AssertEqual(binarySize, ByteSize.ParseWithUnitSystem("1 MiB", ByteSizeUnitSystem.BinaryIec, culture));
-AssertEqual(false, ByteSize.TryParseWithUnitSystem("1 MB", ByteSizeUnitSystem.BinaryIec, culture, out _));
-AssertEqual("1 MB/s", decimalRate);
-AssertEqual("1 MiB/s", binaryRate);
-
-Console.WriteLine("1.5 KB; 2 KB; 10 KB 2 B 1 b; 1.5 MB/s; 1 MB; 1 MB/s; 1 MiB/s");
-
-static void AssertEqual<T>(T expected, T actual)
-{
-    if (!EqualityComparer<T>.Default.Equals(expected, actual))
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
+Console.WriteLine($"Parsed: {parsed.Humanize("0.0", culture)}");
+Console.WriteLine($"Combined: {combined.Humanize("0", culture)}");
+Console.WriteLine($"Composite: {composite.HumanizeComposite(precision: 3, formatProvider: culture)}");
+Console.WriteLine($"Rate: {rate}");
+Console.WriteLine($"Decimal SI: {decimalSize.Format(ByteSizeUnitSystem.DecimalSi, formatProvider: culture)}");
+Console.WriteLine($"Binary IEC: {binarySize.Format(ByteSizeUnitSystem.BinaryIec, formatProvider: culture)}");
+Console.WriteLine($"Decimal rate: {decimalRate}");
+Console.WriteLine($"Binary rate: {binaryRate}");

--- a/website/docs/_examples/scenarios-bytes/expected-output.txt
+++ b/website/docs/_examples/scenarios-bytes/expected-output.txt
@@ -1,0 +1,8 @@
+Parsed: 1.5 KB
+Combined: 2 KB
+Composite: 10 KB 2 B 1 b
+Rate: 1.5 MB/s
+Decimal SI: 1 MB
+Binary IEC: 1 MiB
+Decimal rate: 1 MB/s
+Binary rate: 1 MiB/s

--- a/website/docs/_examples/scenarios-collections-tuples/Program.cs
+++ b/website/docs/_examples/scenarios-collections-tuples/Program.cs
@@ -12,18 +12,10 @@ var people = new[] { new Person("Ada"), new Person("Grace") }
 var cleaned = new string?[] { " tea ", null, " ", "coffee" }.Humanize();
 var tuple = 4.Tupleize();
 
-AssertEqual("tea, coffee, and water", list);
-AssertEqual("tea, coffee and water", britishList);
-AssertEqual("Ada and Grace", people);
-AssertEqual("tea and coffee", cleaned);
-AssertEqual("quadruple", tuple);
-
-Console.WriteLine($"{list}; {britishList}; {tuple}");
-
-static void AssertEqual(string expected, string actual)
-{
-    if (actual != expected)
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
+Console.WriteLine($"US: {list}");
+Console.WriteLine($"UK: {britishList}");
+Console.WriteLine($"People: {people}");
+Console.WriteLine($"Cleaned: {cleaned}");
+Console.WriteLine($"Tuple: {tuple}");
 
 record Person(string Name);

--- a/website/docs/_examples/scenarios-collections-tuples/expected-output.txt
+++ b/website/docs/_examples/scenarios-collections-tuples/expected-output.txt
@@ -1,0 +1,5 @@
+US: tea, coffee, and water
+UK: tea, coffee and water
+People: Ada and Grace
+Cleaned: tea and coffee
+Tuple: quadruple

--- a/website/docs/_examples/scenarios-dates/Program.cs
+++ b/website/docs/_examples/scenarios-dates/Program.cs
@@ -18,16 +18,8 @@ var timeOnlyComparison = new TimeOnly(12, 0);
 var timeOnlyRelative = timeOnlyComparison.AddMinutes(1).Humanize(timeOnlyComparison, culture: culture);
 var duration = TimeSpan.FromMinutes(125).Humanize(precision: 2, culture: culture);
 
-AssertEqual("yesterday", relative);
-AssertEqual("yesterday", offsetRelative);
-AssertEqual("yesterday", dateOnlyRelative);
-AssertEqual("a minute from now", timeOnlyRelative);
-AssertEqual("2 hours, 5 minutes", duration);
-
-Console.WriteLine($"{relative}; {offsetRelative}; {dateOnlyRelative}; {timeOnlyRelative}; {duration}");
-
-static void AssertEqual(string expected, string actual)
-{
-    if (actual != expected)
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
+Console.WriteLine($"DateTime: {relative}");
+Console.WriteLine($"DateTimeOffset: {offsetRelative}");
+Console.WriteLine($"DateOnly: {dateOnlyRelative}");
+Console.WriteLine($"TimeOnly: {timeOnlyRelative}");
+Console.WriteLine($"Duration: {duration}");

--- a/website/docs/_examples/scenarios-dates/expected-output.txt
+++ b/website/docs/_examples/scenarios-dates/expected-output.txt
@@ -1,0 +1,5 @@
+DateTime: yesterday
+DateTimeOffset: yesterday
+DateOnly: yesterday
+TimeOnly: a minute from now
+Duration: 2 hours, 5 minutes

--- a/website/docs/_examples/scenarios-durations/Program.cs
+++ b/website/docs/_examples/scenarios-durations/Program.cs
@@ -19,25 +19,12 @@ var fractionalSeconds = TimeSpan.FromMilliseconds(1500)
         culture: culture,
         maxUnit: TimeUnit.Second);
 var parsedCompact = "1h 30m 15.25s".DehumanizeTimeSpan();
-var parsedStandard = "1.02:03:04.0050060".DehumanizeTimeSpan();
-var parsedInvalid = "1,5h".TryDehumanizeTimeSpan(out var invalid);
 var age = TimeSpan.FromDays(750)
     .ToAge(culture, toWords: true);
 
-AssertEqual("2 hours, 5 minutes", elapsed);
-AssertEqual("1 minute and 2 seconds", compact);
-AssertEqual("1h, 3s, 1ms", symbols);
-AssertEqual("1.5 seconds", fractionalSeconds);
-AssertEqual(new TimeSpan(0, 1, 30, 15, 250), parsedCompact);
-AssertEqual(TimeSpan.FromTicks(937_840_050_060), parsedStandard);
-AssertEqual(false, parsedInvalid);
-AssertEqual(TimeSpan.Zero, invalid);
-AssertEqual("two years old", age);
-
-Console.WriteLine($"{elapsed}; {fractionalSeconds}; {symbols}; {age}");
-
-static void AssertEqual<T>(T expected, T actual)
-{
-    if (!EqualityComparer<T>.Default.Equals(expected, actual))
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
+Console.WriteLine($"Elapsed: {elapsed}");
+Console.WriteLine($"Natural list: {compact}");
+Console.WriteLine($"Symbols: {symbols}");
+Console.WriteLine($"Fractional: {fractionalSeconds}");
+Console.WriteLine($"Parsed: {parsedCompact}");
+Console.WriteLine($"Age: {age}");

--- a/website/docs/_examples/scenarios-durations/expected-output.txt
+++ b/website/docs/_examples/scenarios-durations/expected-output.txt
@@ -1,0 +1,6 @@
+Elapsed: 2 hours, 5 minutes
+Natural list: 1 minute and 2 seconds
+Symbols: 1h, 3s, 1ms
+Fractional: 1.5 seconds
+Parsed: 01:30:15.2500000
+Age: two years old

--- a/website/docs/_examples/scenarios-enums-collections/Program.cs
+++ b/website/docs/_examples/scenarios-enums-collections/Program.cs
@@ -6,22 +6,12 @@ CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
 CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
 string[] drinks = ["tea", "coffee", "water"];
 
-AssertEqual("Waiting for payment", OrderState.AwaitingPayment.Humanize());
-AssertEqual("Ready to ship", OrderState.ReadyToShip.Humanize());
-AssertEqual(OrderState.AwaitingPayment, "WAITING FOR PAYMENT".DehumanizeTo<OrderState>());
-AssertEqual("tea, coffee, and water", drinks.Humanize());
-AssertEqual(
-    "Ada and Grace",
-    new[] { new Person("Ada"), new Person("Grace") }
-        .Humanize(person => person.DisplayName));
+var people = new[] { new Person("Ada"), new Person("Grace") };
 
-Console.WriteLine("Waiting for payment; tea, coffee, and water");
-
-static void AssertEqual<T>(T expected, T actual)
-{
-    if (!EqualityComparer<T>.Default.Equals(actual, expected))
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
+Console.WriteLine($"State: {OrderState.AwaitingPayment.Humanize()}");
+Console.WriteLine($"Parsed: {"WAITING FOR PAYMENT".DehumanizeTo<OrderState>()}");
+Console.WriteLine($"Drinks: {drinks.Humanize()}");
+Console.WriteLine($"People: {people.Humanize(person => person.DisplayName)}");
 
 enum OrderState
 {

--- a/website/docs/_examples/scenarios-enums-collections/expected-output.txt
+++ b/website/docs/_examples/scenarios-enums-collections/expected-output.txt
@@ -1,0 +1,4 @@
+State: Waiting for payment
+Parsed: AwaitingPayment
+Drinks: tea, coffee, and water
+People: Ada and Grace

--- a/website/docs/_examples/scenarios-enums-flags/Program.cs
+++ b/website/docs/_examples/scenarios-enums-flags/Program.cs
@@ -7,62 +7,15 @@ CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
 
 var access = Access.Read | Access.Write;
 
-AssertEqual("Can view and Can edit", access.Humanize());
-AssertEqual(
-    "Read and Write",
-    access.Humanize(LetterCasing.Title, EnumHumanizeSource.EnumName));
-AssertEqual(Access.Read, "CAN VIEW".DehumanizeTo<Access>());
-AssertEqual(null, "missing".DehumanizeTo<Access>(OnNoMatch.ReturnsNull));
-AssertEqual("", ((Access)8).Humanize());
-AssertEqual("Awaiting reviewer", DeliveryState.NeedsReview.Humanize());
-AssertEqual(
-    "Awaiting reviewer",
-    DeliveryState.NeedsReview.Humanize(
-        LetterCasing.AllCaps,
-        EnumHumanizeSource.Default));
-AssertEqual(
-    "Needs review",
-    DeliveryState.NeedsReview.Humanize(
-        LetterCasing.Sentence,
-        EnumHumanizeSource.EnumName));
-AssertEqual(
-    "Review required",
-    DeliveryState.NeedsReview.Humanize(
-        LetterCasing.AllCaps,
-        EnumHumanizeSource.DisplayName));
-AssertEqual(
-    "Awaiting reviewer",
-    DeliveryState.NeedsReview.Humanize(
-        LetterCasing.AllCaps,
-        EnumHumanizeSource.DisplayDescription));
-AssertEqual(
-    "Review",
-    DeliveryState.NeedsReview.Humanize(
-        LetterCasing.AllCaps,
-        EnumHumanizeSource.DisplayShortName));
-AssertEqual(
-    "Waiting in queue",
-    DeliveryState.QueuedItem.Humanize(
-        LetterCasing.AllCaps,
-        EnumHumanizeSource.DisplayShortName));
-AssertEqual(
-    "Read",
-    Access.Read.Humanize(
-        LetterCasing.Sentence,
-        EnumHumanizeSource.DisplayName));
-AssertEqual(DeliveryState.NeedsReview, "NeedsReview".DehumanizeTo<DeliveryState>());
-AssertEqual(DeliveryState.NeedsReview, "Needs review".DehumanizeTo<DeliveryState>());
-AssertEqual(DeliveryState.NeedsReview, "Review required".DehumanizeTo<DeliveryState>());
-AssertEqual(DeliveryState.NeedsReview, "Awaiting reviewer".DehumanizeTo<DeliveryState>());
-AssertEqual(DeliveryState.NeedsReview, "REVIEW".DehumanizeTo<DeliveryState>());
-
-Console.WriteLine("Can view and Can edit; explicit sources; all aliases -> NeedsReview");
-
-static void AssertEqual<T>(T expected, T actual)
-{
-    if (!EqualityComparer<T>.Default.Equals(expected, actual))
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
+Console.WriteLine($"Flags: {access.Humanize()}");
+Console.WriteLine(
+    $"Enum names: {access.Humanize(LetterCasing.Title, EnumHumanizeSource.EnumName)}");
+Console.WriteLine($"Description: {DeliveryState.NeedsReview.Humanize()}");
+Console.WriteLine(
+    $"Display name: {DeliveryState.NeedsReview.Humanize(LetterCasing.Sentence, EnumHumanizeSource.DisplayName)}");
+Console.WriteLine($"Parsed alias: {"REVIEW".DehumanizeTo<DeliveryState>()}");
+Console.WriteLine(
+    $"Missing: {"missing".DehumanizeTo<Access>(OnNoMatch.ReturnsNull)?.ToString() ?? "(none)"}");
 
 [Flags]
 enum Access

--- a/website/docs/_examples/scenarios-enums-flags/expected-output.txt
+++ b/website/docs/_examples/scenarios-enums-flags/expected-output.txt
@@ -1,0 +1,6 @@
+Flags: Can view and Can edit
+Enum names: Read and Write
+Description: Awaiting reviewer
+Display name: Review required
+Parsed alias: NeedsReview
+Missing: (none)

--- a/website/docs/_examples/scenarios-fluent-dates/Program.cs
+++ b/website/docs/_examples/scenarios-fluent-dates/Program.cs
@@ -9,14 +9,6 @@ var startingPoint = new DateTime(2025, 1, 20, 9, 0, 0);
 var twoMonthsLater = In.Two.MonthsFrom(startingPoint);
 var appointment = In.AprilOf(2025).AddDays(2).At(14, 30);
 
-AssertEqual(TimeSpan.FromHours(36), duration);
-AssertEqual(new DateTime(2025, 3, 20, 9, 0, 0), twoMonthsLater);
-AssertEqual(new DateTime(2025, 4, 3, 14, 30, 0), appointment);
-
-Console.WriteLine("36 hours; 2025-03-20; 2025-04-03 14:30");
-
-static void AssertEqual<T>(T expected, T actual)
-{
-    if (!EqualityComparer<T>.Default.Equals(expected, actual))
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
+Console.WriteLine($"Duration: {duration.TotalHours} hours");
+Console.WriteLine($"Two months later: {twoMonthsLater:yyyy-MM-dd HH:mm}");
+Console.WriteLine($"Appointment: {appointment:yyyy-MM-dd HH:mm}");

--- a/website/docs/_examples/scenarios-fluent-dates/expected-output.txt
+++ b/website/docs/_examples/scenarios-fluent-dates/expected-output.txt
@@ -1,0 +1,3 @@
+Duration: 36 hours
+Two months later: 2025-03-20 09:00
+Appointment: 2025-04-03 14:30

--- a/website/docs/_examples/scenarios-inflection/Program.cs
+++ b/website/docs/_examples/scenarios-inflection/Program.cs
@@ -5,35 +5,8 @@ var culture = CultureInfo.GetCultureInfo("en-US");
 CultureInfo.CurrentCulture = culture;
 CultureInfo.CurrentUICulture = culture;
 
-AssertEqual("people", "person".Pluralize());
-AssertEqual("person", "people".Singularize());
-AssertEqual("two people", "person".ToQuantity(2, ShowQuantityAs.Words));
-
 Vocabularies.Default.AddIrregular("cactoid", "cactoidae", matchEnding: false);
-AssertEqual("cactoidae", "cactoid".Pluralize());
-AssertEqual("cactoid", "cactoidae".Singularize());
 
-var polishForms = new PluralizationForms(
-    singular: "plik",
-    other: "pliku",
-    one: "plik",
-    few: "pliki",
-    many: "plików");
-AssertTrue(polishForms.TryPluralize(5m, CultureInfo.GetCultureInfo("pl"), out var polish));
-AssertEqual("plików", polish);
-AssertTrue(polishForms.TrySingularize("pliki", out var singular));
-AssertEqual("plik", singular);
-
-Console.WriteLine("people; two people; cactoidae; plików; plik");
-
-static void AssertEqual(string expected, string? actual)
-{
-    if (actual != expected)
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
-
-static void AssertTrue(bool value)
-{
-    if (!value)
-        throw new InvalidOperationException("Expected success.");
-}
+Console.WriteLine($"Plural: {"person".Pluralize()}");
+Console.WriteLine($"Quantity: {"person".ToQuantity(2, ShowQuantityAs.Words)}");
+Console.WriteLine($"Custom plural: {"cactoid".Pluralize()}");

--- a/website/docs/_examples/scenarios-inflection/expected-output.txt
+++ b/website/docs/_examples/scenarios-inflection/expected-output.txt
@@ -1,0 +1,3 @@
+Plural: people
+Quantity: two people
+Custom plural: cactoidae

--- a/website/docs/_examples/scenarios-localization/Program.cs
+++ b/website/docs/_examples/scenarios-localization/Program.cs
@@ -5,16 +5,8 @@ var french = CultureInfo.GetCultureInfo("fr-FR");
 CultureInfo.CurrentCulture = french;
 CultureInfo.CurrentUICulture = french;
 
-AssertEqual("quarante-deux", 42.ToWords(french));
-AssertEqual("BONJOUR", "bonjour".Transform(french, new LoudTransformer()));
-
-Console.WriteLine("quarante-deux; BONJOUR");
-
-static void AssertEqual(string expected, string actual)
-{
-    if (actual != expected)
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
+Console.WriteLine($"Number: {42.ToWords(french)}");
+Console.WriteLine($"Transformed: {"bonjour".Transform(french, new LoudTransformer())}");
 
 sealed class LoudTransformer : ICulturedStringTransformer
 {

--- a/website/docs/_examples/scenarios-localization/expected-output.txt
+++ b/website/docs/_examples/scenarios-localization/expected-output.txt
@@ -1,0 +1,2 @@
+Number: quarante-deux
+Transformed: BONJOUR

--- a/website/docs/_examples/scenarios-metric/Program.cs
+++ b/website/docs/_examples/scenarios-metric/Program.cs
@@ -17,16 +17,8 @@ var scaleWord = 1.5E9.ToMetric(
     decimals: 2);
 var parsed = "1.5k".FromMetric();
 
-AssertEqual("123.5k", symbol);
-AssertEqual("1.00k", fixedWidth);
-AssertEqual("1 kilo", name);
-AssertEqual("1.50 Milliarden", scaleWord);
-AssertEqual(1500d, parsed);
-
-Console.WriteLine($"{symbol}; {fixedWidth}; {name}; {scaleWord}; {parsed}");
-
-static void AssertEqual<T>(T expected, T actual)
-{
-    if (!EqualityComparer<T>.Default.Equals(expected, actual))
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
+Console.WriteLine($"Symbol: {symbol}");
+Console.WriteLine($"Fixed width: {fixedWidth}");
+Console.WriteLine($"Prefix name: {name}");
+Console.WriteLine($"Scale word: {scaleWord}");
+Console.WriteLine($"Parsed: {parsed}");

--- a/website/docs/_examples/scenarios-metric/expected-output.txt
+++ b/website/docs/_examples/scenarios-metric/expected-output.txt
@@ -1,0 +1,5 @@
+Symbol: 123.5k
+Fixed width: 1.00k
+Prefix name: 1 kilo
+Scale word: 1.50 Milliarden
+Parsed: 1500

--- a/website/docs/_examples/scenarios-numbers/Program.cs
+++ b/website/docs/_examples/scenarios-numbers/Program.cs
@@ -14,4 +14,6 @@ Console.WriteLine($"Indian scale: {1_000_000_000L.ToIndianWords(IndianScaleStyle
 Console.WriteLine($"Fraction: {1.25m.Fractionalize(5, 0m)}");
 Console.WriteLine($"Financial: {10L.ToChineseFinancialCharacters(simplifiedChinese)}");
 Console.WriteLine($"Estonian scale: {1_000_000_000_000_000_000L.ToWords(estonian)}");
+Console.WriteLine($"Long max: {long.MaxValue.ToWords(estonian)}");
+Console.WriteLine($"Long min: {long.MinValue.ToWords(estonian)}");
 Console.WriteLine($"Roman: {14.ToRoman()}");

--- a/website/docs/_examples/scenarios-numbers/Program.cs
+++ b/website/docs/_examples/scenarios-numbers/Program.cs
@@ -3,66 +3,15 @@ using Humanizer;
 
 var culture = CultureInfo.GetCultureInfo("en-US");
 var estonian = CultureInfo.GetCultureInfo("et");
-var albanian = CultureInfo.GetCultureInfo("sq");
 var simplifiedChinese = CultureInfo.GetCultureInfo("zh-CN");
-var traditionalChinese = CultureInfo.GetCultureInfo("zh-TW");
 CultureInfo.CurrentCulture = culture;
 CultureInfo.CurrentUICulture = culture;
 
-AssertEqual("forty-two", 42.ToWords(culture));
-AssertEqual("twenty-first", 21.ToOrdinalWords(culture));
-AssertEqual("21st", 21.Ordinalize(culture));
-AssertEqual("2147483651st", 2_147_483_651L.Ordinalize(culture));
-AssertEqual("-9223372036854775808th", long.MinValue.Ordinalize(culture));
-AssertEqual("biljard", 1_000_000_000_000_000L.ToWords(estonian));
-AssertEqual("dy biliarë", 2_000_000_000_000_000L.ToWords(albanian));
-AssertEqual("triljon", 1_000_000_000_000_000_000L.ToWords(estonian));
-AssertNotEmpty(long.MaxValue.ToWords(estonian));
-AssertNotEmpty(long.MinValue.ToWords(estonian));
-AssertEqual("one arab", 1_000_000_000L.ToIndianWords());
-AssertEqual(
-    "one hundred crore",
-    1_000_000_000L.ToIndianWords(IndianScaleStyle.CroreBased));
-AssertEqual("1 1/4", 1.25m.Fractionalize(5, 0m));
-AssertEqual("1/3", 0.34m.Fractionalize(5, 0.01m));
-AssertEqual("¾", 0.75m.Fractionalize(4, 0m, useUnicode: true));
-AssertEqual("0.11", 0.11m.Fractionalize(10, 0m));
-AssertEqual("壹拾", 10L.ToChineseFinancialCharacters(simplifiedChinese));
-AssertEqual("壹拾", 10L.ToChineseFinancialCharacters(traditionalChinese));
-AssertEqual(
-    "负玖佰贰拾贰京叁仟叁佰柒拾贰兆零叁佰陆拾捌亿伍仟肆佰柒拾柒万伍仟捌佰零捌",
-    long.MinValue.ToChineseFinancialCharacters(simplifiedChinese));
-AssertThrows<NotSupportedException>(
-    () => 10L.ToChineseFinancialCharacters(CultureInfo.GetCultureInfo("zh")));
-AssertEqual("XIV", 14.ToRoman());
-AssertEqual("1.5 KB", 1536.Bytes().Humanize("0.0", culture));
-AssertEqual("two people", "person".ToQuantity(2, ShowQuantityAs.Words));
-
-Console.WriteLine("forty-two; 2147483651st; 1 1/4; 壹拾; XIV; 1.5 KB");
-
-static void AssertEqual<T>(T expected, T actual)
-{
-    if (!EqualityComparer<T>.Default.Equals(actual, expected))
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
-
-static void AssertNotEmpty(string actual)
-{
-    if (string.IsNullOrWhiteSpace(actual))
-        throw new InvalidOperationException("Expected localized number words.");
-}
-
-static void AssertThrows<TException>(Action action)
-    where TException : Exception
-{
-    try
-    {
-        action();
-    }
-    catch (TException)
-    {
-        return;
-    }
-
-    throw new InvalidOperationException($"Expected {typeof(TException).Name}.");
-}
+Console.WriteLine($"Words: {42.ToWords(culture)}");
+Console.WriteLine($"Ordinal words: {21.ToOrdinalWords(culture)}");
+Console.WriteLine($"Long ordinal: {2_147_483_651L.Ordinalize(culture)}");
+Console.WriteLine($"Indian scale: {1_000_000_000L.ToIndianWords(IndianScaleStyle.CroreBased)}");
+Console.WriteLine($"Fraction: {1.25m.Fractionalize(5, 0m)}");
+Console.WriteLine($"Financial: {10L.ToChineseFinancialCharacters(simplifiedChinese)}");
+Console.WriteLine($"Estonian scale: {1_000_000_000_000_000_000L.ToWords(estonian)}");
+Console.WriteLine($"Roman: {14.ToRoman()}");

--- a/website/docs/_examples/scenarios-numbers/expected-output.txt
+++ b/website/docs/_examples/scenarios-numbers/expected-output.txt
@@ -5,4 +5,6 @@ Indian scale: one hundred crore
 Fraction: 1 1/4
 Financial: 壹拾
 Estonian scale: triljon
+Long max: üheksa triljonit kakssada kakskümmend kolm biljardit kolmsada seitsekümmend kaks biljonit kolmkümmend kuus miljardit kaheksasada viiskümmend neli miljonit seitsesada seitsekümmend viis tuhat kaheksasada seitse
+Long min: miinus üheksa triljonit kakssada kakskümmend kolm biljardit kolmsada seitsekümmend kaks biljonit kolmkümmend kuus miljardit kaheksasada viiskümmend neli miljonit seitsesada seitsekümmend viis tuhat kaheksasada kaheksa
 Roman: XIV

--- a/website/docs/_examples/scenarios-numbers/expected-output.txt
+++ b/website/docs/_examples/scenarios-numbers/expected-output.txt
@@ -1,0 +1,8 @@
+Words: forty-two
+Ordinal words: twenty-first
+Long ordinal: 2147483651st
+Indian scale: one hundred crore
+Fraction: 1 1/4
+Financial: 壹拾
+Estonian scale: triljon
+Roman: XIV

--- a/website/docs/_examples/scenarios-parse-number-words/Program.cs
+++ b/website/docs/_examples/scenarios-parse-number-words/Program.cs
@@ -25,61 +25,13 @@ var frenchSucceeded = "un virgule deux".TryToDecimalNumber(
     out var frenchDecimal,
     frenchCulture,
     out var frenchUnrecognized);
-var unsupportedCulture = "aon point dhà".TryToDecimalNumber(
-    out var unsupportedDecimal,
-    CultureInfo.GetCultureInfo("gd"),
-    out var unsupportedPhrase);
-string nullWords = null!;
-var nullRejected = nullWords.TryToDecimalNumber(
-    out var nullDecimal,
-    culture,
-    out var nullUnrecognized);
 
-AssertEqual(205, Convert.ToInt64(parsed));
-AssertEqual(true, succeeded);
-AssertEqual(-42, Convert.ToInt64(negative));
-AssertEqual<string?>(null, unrecognized);
-AssertEqual(false, rejected);
-AssertEqual(0, Convert.ToInt64(invalid));
-AssertEqual("otters", invalidWord);
-AssertEqual(true, decimalSucceeded);
-AssertEqual("1.50", decimalValue.ToString(CultureInfo.InvariantCulture));
-AssertEqual<string?>(null, decimalUnrecognized);
-AssertEqual(false, decimalRejected);
-AssertEqual(0m, invalidDecimal);
-AssertEqual("ten", invalidDecimalWord);
-AssertEqual(true, frenchSucceeded);
-AssertEqual(1.2m, frenchDecimal);
-AssertEqual<string?>(null, frenchUnrecognized);
-AssertEqual(false, unsupportedCulture);
-AssertEqual(0m, unsupportedDecimal);
-AssertEqual("aon point dhà", unsupportedPhrase);
-AssertEqual(false, nullRejected);
-AssertEqual(0m, nullDecimal);
-AssertEqual(string.Empty, nullUnrecognized);
-AssertThrows<NotSupportedException>(
-    () => "aon point dhà".ToDecimalNumber(CultureInfo.GetCultureInfo("gd")));
-AssertThrows<ArgumentNullException>(() => nullWords.ToDecimalNumber(culture));
-
-Console.WriteLine("205; -42; 1.50; 1,2; rejected at otters and ten");
-
-static void AssertEqual<T>(T expected, T actual)
-{
-    if (!EqualityComparer<T>.Default.Equals(expected, actual))
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
-
-static void AssertThrows<TException>(Action action)
-    where TException : Exception
-{
-    try
-    {
-        action();
-    }
-    catch (TException)
-    {
-        return;
-    }
-
-    throw new InvalidOperationException($"Expected {typeof(TException).Name}.");
-}
+Console.WriteLine($"Integer: {parsed}");
+Console.WriteLine($"Negative: {(succeeded ? negative : unrecognized)}");
+Console.WriteLine($"Rejected: {(rejected ? invalid : invalidWord)}");
+Console.WriteLine(
+    $"Decimal: {(decimalSucceeded ? decimalValue.ToString(CultureInfo.InvariantCulture) : decimalUnrecognized)}");
+Console.WriteLine(
+    $"Invalid decimal: {(decimalRejected ? invalidDecimal : invalidDecimalWord)}");
+Console.WriteLine(
+    $"French decimal: {(frenchSucceeded ? frenchDecimal.ToString(frenchCulture) : frenchUnrecognized)}");

--- a/website/docs/_examples/scenarios-parse-number-words/expected-output.txt
+++ b/website/docs/_examples/scenarios-parse-number-words/expected-output.txt
@@ -1,0 +1,6 @@
+Integer: 205
+Negative: -42
+Rejected: otters
+Decimal: 1.50
+Invalid decimal: ten
+French decimal: 1,2

--- a/website/docs/_examples/scenarios-specialized/Program.cs
+++ b/website/docs/_examples/scenarios-specialized/Program.cs
@@ -5,22 +5,13 @@ var culture = CultureInfo.GetCultureInfo("en-US");
 CultureInfo.CurrentCulture = culture;
 CultureInfo.CurrentUICulture = culture;
 
-AssertEqual("southwest", 225d.ToHeading(HeadingStyle.Full, culture));
-AssertEqual('↙', 225d.ToHeadingArrow());
-AssertEqual("XIV", 14.ToRoman());
-AssertEqual(2_000_000, 2.Millions());
-AssertEqual("min", TimeUnit.Minute.ToSymbol(culture));
-AssertEqual("quadruple", 4.Tupleize());
-
 var titles = new[] { "The Theater", "An Apple", "Bear" };
 var sorted = EnglishArticle.PrependArticleSuffix(
     EnglishArticle.AppendArticlePrefix(titles));
-AssertEqual("An Apple, Bear, The Theater", string.Join(", ", sorted));
 
-Console.WriteLine("southwest; ↙; XIV; 2,000,000; min; quadruple");
-
-static void AssertEqual<T>(T expected, T actual)
-{
-    if (!EqualityComparer<T>.Default.Equals(expected, actual))
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
+Console.WriteLine($"Heading: {225d.ToHeading(HeadingStyle.Full, culture)} {225d.ToHeadingArrow()}");
+Console.WriteLine($"Roman: {14.ToRoman()}");
+Console.WriteLine($"Multiplier: {2.Millions():N0}");
+Console.WriteLine($"Unit: {TimeUnit.Minute.ToSymbol(culture)}");
+Console.WriteLine($"Tuple: {4.Tupleize()}");
+Console.WriteLine($"Titles: {string.Join(", ", sorted)}");

--- a/website/docs/_examples/scenarios-specialized/expected-output.txt
+++ b/website/docs/_examples/scenarios-specialized/expected-output.txt
@@ -1,0 +1,6 @@
+Heading: southwest ↙
+Roman: XIV
+Multiplier: 2,000,000
+Unit: min
+Tuple: quadruple
+Titles: An Apple, Bear, The Theater

--- a/website/docs/_examples/scenarios-spoken-dates/Program.cs
+++ b/website/docs/_examples/scenarios-spoken-dates/Program.cs
@@ -10,14 +10,6 @@ var dateInGenitive = new DateOnly(2022, 1, 25).ToOrdinalWords(GrammaticalCase.Ge
 var time = new TimeOnly(13, 23)
     .ToClockNotation(ClockNotationRounding.NearestFiveMinutes, culture);
 
-AssertEqual("January 25th, 2022", date);
-AssertEqual("January 25th, 2022", dateInGenitive);
-AssertEqual("twenty-five past one", time);
-
-Console.WriteLine($"{date}; {dateInGenitive}; {time}");
-
-static void AssertEqual(string expected, string actual)
-{
-    if (actual != expected)
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
+Console.WriteLine($"Date: {date}");
+Console.WriteLine($"Genitive date: {dateInGenitive}");
+Console.WriteLine($"Time: {time}");

--- a/website/docs/_examples/scenarios-spoken-dates/expected-output.txt
+++ b/website/docs/_examples/scenarios-spoken-dates/expected-output.txt
@@ -1,0 +1,3 @@
+Date: January 25th, 2022
+Genitive date: January 25th, 2022
+Time: twenty-five past one

--- a/website/docs/_examples/scenarios-strings/Program.cs
+++ b/website/docs/_examples/scenarios-strings/Program.cs
@@ -6,25 +6,11 @@ CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
 
 Vocabularies.Default.AddAcronym("iOS");
 
-AssertEqual("Customer order history", "CustomerOrderHistory".Humanize());
-AssertEqual("Customer Order History", "CustomerOrderHistory".Humanize(LetterCasing.Title));
-AssertEqual("iOS settings", "IOSSettings".Humanize());
-AssertEqual("Research & development", "Research&Development".Humanize());
-AssertEqual("CustomerOrderHistory", "customer order history".Dehumanize());
-AssertEqual("customer_order_history", "CustomerOrderHistory".Underscore());
-AssertEqual("HTML_Parser", "HTMLParser".Underscore(preserveCase: true));
-AssertEqual("customer-order-history", "CustomerOrderHistory".Kebaberize());
-AssertEqual("CustomerOrderHistory", "customer_order_history".Pascalize());
-AssertEqual("Customer…", "Customer order history".Truncate(9));
-AssertEqual(
-    "Text with more words…",
-    "Text with more words than the limit".Truncate(4, Truncator.FixedNumberOfWords));
-AssertEqual("Order History", "order history".Transform(To.TitleCase));
-
-Console.WriteLine("Customer order history; iOS settings; Research & development");
-
-static void AssertEqual(string expected, string? actual)
-{
-    if (actual != expected)
-        throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
-}
+Console.WriteLine($"Label: {"CustomerOrderHistory".Humanize()}");
+Console.WriteLine($"Acronym: {"IOSSettings".Humanize()}");
+Console.WriteLine($"Ampersand: {"Research&Development".Humanize()}");
+Console.WriteLine($"Snake case: {"CustomerOrderHistory".Underscore()}");
+Console.WriteLine($"Preserved case: {"HTMLParser".Underscore(preserveCase: true)}");
+Console.WriteLine($"Kebab case: {"CustomerOrderHistory".Kebaberize()}");
+Console.WriteLine($"Identifier: {"customer order history".Dehumanize()}");
+Console.WriteLine($"Truncated: {"Customer order history".Truncate(9)}");

--- a/website/docs/_examples/scenarios-strings/expected-output.txt
+++ b/website/docs/_examples/scenarios-strings/expected-output.txt
@@ -1,0 +1,8 @@
+Label: Customer order history
+Acronym: iOS settings
+Ampersand: Research & development
+Snake case: customer_order_history
+Preserved case: HTML_Parser
+Kebab case: customer-order-history
+Identifier: CustomerOrderHistory
+Truncated: Customer…

--- a/website/docs/scenarios/byte-sizes-and-rates.mdx
+++ b/website/docs/scenarios/byte-sizes-and-rates.mdx
@@ -8,10 +8,9 @@ persona: application developer
 
 import CodeBlock from '@theme/CodeBlock';
 import bytes from '!!raw-loader!../_examples/scenarios-bytes/Program.cs';
+import bytesOutput from '!!raw-loader!../_examples/scenarios-bytes/expected-output.txt';
 
 # Format byte sizes and transfer rates
-
-## Orientation
 
 `ByteSize` keeps a data quantity typed while the application parses, compares, adds, subtracts, and formats it. Numeric extensions create values without manual factors. `ByteRate` combines a size with a measurement interval for display as bytes, kilobytes, or larger units per second, minute, or hour.
 
@@ -23,10 +22,12 @@ transfer rate:
 
 <CodeBlock language="csharp" title="Program.cs">{bytes}</CodeBlock>
 
+<CodeBlock language="text" title="Output">{bytesOutput}</CodeBlock>
+
 ### Create and format sizes
 
 Use numeric extensions through `Terabytes`, or the corresponding
-`ByteSize.From...` factories. `Humanizer 4` also exposes decimal petabyte and
+`ByteSize.From...` factories. Humanizer also exposes decimal petabyte and
 exabyte values plus explicit binary `Kibibyte`, `Mebibyte`, `Gibibyte`,
 `Tebibyte`, and `Pebibyte` factories, properties, format tokens, parsing
 symbols, and `DataUnit` values. `Humanize` chooses the largest whole unit and
@@ -57,7 +58,7 @@ The choice is explicit and is not stored in `ByteSize`.
 
 ### Decompose exact quantities
 
-On `Humanizer 4`, `HumanizeComposite` walks the existing units from exabytes
+`HumanizeComposite` walks the existing units from exabytes
 through bits and returns up to `precision` nonzero parts. It preserves exact
 byte and bit residuals while parts remain available: for example, 81,937 bits
 becomes `10 KB 2 B 1 b` at precision 3. Once the precision is reached, the
@@ -84,10 +85,10 @@ ambiguous `KB`, `MB`, `GB`, `TB`, `PB`, and `EB` suffixes.
 Call `size.Per(interval).Humanize(format, TimeUnit.Second, culture)`. Rate display supports second, minute, and hour units.
 Use `HumanizeWithUnitSystem` on `ByteRate` for explicit SI or IEC rate output.
 
-## Pitfall
+## Choose a unit system before parsing or formatting
 
 Humanizer’s legacy `KB`, `MB`, `GB`, and `TB` values use binary multiples of
-1024, while `PB` and `EB` use decimal SI factors. On `Humanizer 4`, prefer the
+1024, while `PB` and `EB` use decimal SI factors. Prefer the
 explicit IEC symbols `KiB`, `MiB`, `GiB`, `TiB`, and `PiB` when the binary
 meaning must be unambiguous. The symbols `b` and `B` are intentionally
 case-sensitive: lowercase is bits, uppercase is bytes. Other recognized unit
@@ -105,14 +106,6 @@ humanizing a composite value, or displaying a rate; factory choice does not
 carry formatting provenance.
 
 Construct rates with a positive, nonzero interval. Keep `ByteSize` as the model value; formatted output is not a serialization contract.
-
-## Version notes
-
-Core `ByteSize` creation and formatting span the documented corpus. Petabyte,
-exabyte, explicit IEC unit support, and `HumanizeComposite` are `Humanizer 4`
-additions. Culture-aware `ByteRate.Humanize` appears in `2.13.14`; earlier
-snapshots need a reduced example or exclusion. The verified source runs
-against the selected package.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/collections-and-tuples.mdx
+++ b/website/docs/scenarios/collections-and-tuples.mdx
@@ -8,21 +8,22 @@ persona: application developer
 
 import CodeBlock from '@theme/CodeBlock';
 import collectionsTuples from '!!raw-loader!../_examples/scenarios-collections-tuples/Program.cs';
+import collectionsTuplesOutput from '!!raw-loader!../_examples/scenarios-collections-tuples/expected-output.txt';
 
 # Format collections and tuple names
-
-## Orientation
 
 Collection humanization turns a sequence into a localized natural-language list. Pass a display selector when items are domain objects. Tuple helpers produce words such as `double`, `triple`, or `quadruple` for multiplicity labels; they do not transform a collection itself.
 
 ## Example
 
 The executable formats strings, selects British English without changing
-ambient culture, projects a record to its display name, verifies the default
+ambient culture, projects a record to its display name, demonstrates the default
 formatter's null/blank filtering, and produces an invariant English tuple
 word:
 
 <CodeBlock language="csharp" title="Program.cs">{collectionsTuples}</CodeBlock>
+
+<CodeBlock language="text" title="Output">{collectionsTuplesOutput}</CodeBlock>
 
 ### Format a collection
 
@@ -32,7 +33,7 @@ The `separator` argument represents the desired conjunction token, such as `or`;
 
 ### Select a culture explicitly
 
-In Humanizer 4, pass a non-null `CultureInfo` to select the collection formatter
+Pass a non-null `CultureInfo` to select the collection formatter
 without changing `CurrentCulture`. For example, an `en-GB` formatter joins
 three items without the Oxford comma. The explicit-culture overload accepts the
 collection itself; when items need projection, select the display strings first
@@ -42,20 +43,13 @@ and then call `Humanize(culture)`.
 
 `Tupleize` returns fixed English names for common sizes and an `n-tuple` fallback. `ToTuple(culture)` uses the selected locale’s number-to-words converter where supported.
 
-## Pitfall
+## Set culture and validate required items
 
 Collection output follows `CurrentCulture`; set it at the request or job
 boundary. The default formatter silently removes null or blank display results,
 so validate required source data before formatting. A custom formatter can
 define a different contract. The `collectionSeparator` parameter on
 `TimeSpan.Humanize` has different literal-separator semantics.
-
-## Version notes
-
-Collection humanization and tuple helpers span the documented corpus, while
-punctuation and localized tuple coverage vary by release. The executable
-compiles and runs against the selected package. The explicit-culture
-collection overload is available in the Humanizer 4 NuGet package.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/dates-times-durations-and-age.mdx
+++ b/website/docs/scenarios/dates-times-durations-and-age.mdx
@@ -8,10 +8,11 @@ persona: returning developer
 
 import CodeBlock from '@theme/CodeBlock';
 import dates from '!!raw-loader!../_examples/scenarios-dates/Program.cs';
+import datesOutput from '!!raw-loader!../_examples/scenarios-dates/expected-output.txt';
 
 # Date, time, duration, and age scenarios
 
-## Orientation
+## Choose a focused guide
 
 Choose the guide by the meaning of the value and the sentence you need:
 
@@ -24,11 +25,13 @@ Choose the guide by the meaning of the value and the sentence you need:
 
 ## Example
 
-This verified source demonstrates the two most common display boundaries: a relative UTC date with an injected comparison instant and a two-unit elapsed duration:
+This source demonstrates common display boundaries with explicit comparison values and culture:
 
 <CodeBlock language="csharp" title="Program.cs">{dates}</CodeBlock>
 
-It prints `yesterday; 2 hours, 5 minutes`. Follow the focused guides for the full overload contracts.
+<CodeBlock language="text" title="Output">{datesOutput}</CodeBlock>
+
+Follow the focused guides for the full overload contracts.
 
 ### Pick a model before an API
 
@@ -37,13 +40,9 @@ It prints `yesterday; 2 hours, 5 minutes`. Follow the focused guides for the ful
 - Use `TimeOnly` for a wall-clock time without a date.
 - Use `TimeSpan` for elapsed duration, not calendar arithmetic.
 
-## Pitfall
+## Keep clocks and calendars explicit
 
 Reading `Now` inside formatting makes examples, tests, and cache behavior unstable. Inject comparison values and set culture explicitly. A `TimeSpan` has no calendar context, so months, years, and ages are approximations; use date arithmetic when leap years, month length, or birthdays must be exact.
-
-## Version notes
-
-`DateTime`, `DateTimeOffset`, and `TimeSpan` calls span the supported corpus. `DateOnly` and `TimeOnly` humanization begin in `2.11.10`; clock notation begins in `2.13.14`; `ToAge` begins in `3.0.1`. Historical sidebars must omit unavailable focused guides.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/durations-and-ages.mdx
+++ b/website/docs/scenarios/durations-and-ages.mdx
@@ -8,10 +8,9 @@ persona: application developer
 
 import CodeBlock from '@theme/CodeBlock';
 import durations from '!!raw-loader!../_examples/scenarios-durations/Program.cs';
+import durationsOutput from '!!raw-loader!../_examples/scenarios-durations/expected-output.txt';
 
 # Format durations and ages
-
-## Orientation
 
 Call `TimeSpan.Humanize` for elapsed time and `ToAge` for a human-readable age approximation. Precision controls how many units appear; minimum and maximum units define the allowed range. Keep calendar-sensitive calculations in date types and use this API only after the application has a duration.
 
@@ -23,6 +22,8 @@ with number words. It also shows fractional seconds without exposing a
 separate millisecond unit:
 
 <CodeBlock language="csharp" title="Program.cs">{durations}</CodeBlock>
+
+<CodeBlock language="text" title="Output">{durationsOutput}</CodeBlock>
 
 ### Control the decomposition
 
@@ -36,13 +37,13 @@ The default maximum unit is `Week`. Ask for `Month` or `Year` explicitly when th
 
 ### Use compact symbols
 
-In Humanizer 4, `HumanizeToSymbols` applies the same precision, empty-unit,
+`HumanizeToSymbols` applies the same precision, empty-unit,
 range, culture, and separator controls but emits localized `TimeUnit` symbols
 such as `1h, 3s, 1ms`.
 
 ### Keep sub-second precision in seconds
 
-In Humanizer 4, use `HumanizeWithFractionalSeconds` or
+Use `HumanizeWithFractionalSeconds` or
 `HumanizeToSymbolsWithFractionalSeconds` when milliseconds should appear as a
 fraction of the seconds unit. These APIs always use `Second` as the inclusive
 minimum unit. Supply the precision, maximum unit, maximum fractional digits,
@@ -61,7 +62,7 @@ from the configured formatter. A custom
 
 ### Apply grammatical case
 
-In Humanizer 4, `HumanizeWithCase` selects a locale-authored grammatical
+`HumanizeWithCase` selects a locale-authored grammatical
 case form for each duration unit. A singular form may include a localized word
 or article, and a locale may encode a count in the inflected unit form:
 
@@ -109,7 +110,7 @@ underlying locale-data model.
 
 ### Parse invariant durations
 
-In Humanizer 4, `DehumanizeTimeSpan` and `TryDehumanizeTimeSpan` accept
+`DehumanizeTimeSpan` and `TryDehumanizeTimeSpan` accept
 standard invariant `TimeSpan` text or compact tokens using `ms`, `s`, `m`, `h`,
 `d`, and `w`. Compact tokens may have one leading sign, optional whitespace,
 fractional values that resolve to whole ticks, repeated units, and units in any
@@ -124,21 +125,13 @@ Use `TryDehumanizeTimeSpan` at an input boundary. It returns `false` and
 
 `ToAge` adds the culture’s age phrase to a duration decomposition. It is convenient for an already computed elapsed span, but it is not a birthday calculator.
 
-## Pitfall
+## Keep calendar and parser boundaries explicit
 
 Months and years are approximated from a duration and do not know calendar month length or leap years. Negative `TimeSpan` values are rendered with positive unit counts, so preserve direction elsewhere when it matters. A precision of zero or less returns an empty string.
 
 Compact duration input is intentionally culture-invariant and is not a parser
 for localized humanized output. For example, `1.5h` is valid even under a
 comma-decimal culture, while `1,5h`, `one hour`, and `1 hour` are rejected.
-
-## Version notes
-
-`TimeSpan.Humanize` is available across the documented corpus. `ToAge` begins
-in `3.0.1`; `HumanizeWithCase`, `HumanizeToSymbols`, `DehumanizeTimeSpan`, and
-`TryDehumanizeTimeSpan` are `Humanizer 4` APIs. The verified executable runs
-against the selected package; older snapshots replace or exclude calls they
-do not support.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/enums-and-collections.mdx
+++ b/website/docs/scenarios/enums-and-collections.mdx
@@ -8,10 +8,9 @@ persona: returning developer
 
 import CodeBlock from '@theme/CodeBlock';
 import enumsCollections from '!!raw-loader!../_examples/scenarios-enums-collections/Program.cs';
+import enumsCollectionsOutput from '!!raw-loader!../_examples/scenarios-enums-collections/expected-output.txt';
 
 # Enum and collection scenarios
-
-## Orientation
 
 Enums and collections both become readable presentation text, but their contracts are different. Enum conversion maps between a typed member and a label, while collection humanization delegates conjunction and punctuation to a locale-aware formatter.
 
@@ -20,23 +19,19 @@ Enums and collections both become readable presentation text, but their contract
 
 ## Example
 
-This verified survey shows a description override, automatic enum casing, case-insensitive enum dehumanization, and an English collection:
+This program shows a description override, case-insensitive enum dehumanization, and an English collection:
 
 <CodeBlock language="csharp" title="Program.cs">{enumsCollections}</CodeBlock>
 
+<CodeBlock language="text" title="Output">{enumsCollectionsOutput}</CodeBlock>
+
 The source also projects `Person` records to display names. Follow the focused pages for flags, unknown values, localized punctuation, and custom formatters.
 
-## Pitfall
+## Make labels unambiguous and culture explicit
 
-Enum labels must be unambiguous even though matching is case-insensitive. The default no-match behavior throws. Collection output is culture-specific and can differ by selected release; scope `CurrentUICulture` before formatting in tests or background work.
+Enum labels must be unambiguous even though matching is case-insensitive. The default no-match behavior throws. Collection output is culture-specific; scope `CurrentUICulture` before formatting in tests or background work.
 
 For trimmed or Native AOT code, prefer generic enum APIs. The runtime `Type` dehumanization overload uses reflection and carries linker/AOT warnings.
-
-## Version notes
-
-The verified survey compiles and runs against the selected package. Enum
-generic constraints and metadata configuration change in Humanizer 3. Locale
-punctuation is versioned data even when the source call compiles unchanged.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/enums-and-flags.mdx
+++ b/website/docs/scenarios/enums-and-flags.mdx
@@ -8,27 +8,26 @@ persona: application developer
 
 import CodeBlock from '@theme/CodeBlock';
 import enumsFlags from '!!raw-loader!../_examples/scenarios-enums-flags/Program.cs';
+import enumsFlagsOutput from '!!raw-loader!../_examples/scenarios-enums-flags/expected-output.txt';
 
 # Humanize and parse enums and flags
 
-## Orientation
-
-Enum humanization resolves one display label for each member: supported description/display metadata when present, otherwise the humanized member name. On `Humanizer 4`, dehumanization also recognizes the raw name, its humanized form, and authored display aliases. Flags enums are decomposed and joined through the active collection formatter.
+Enum humanization resolves one display label for each member: supported description/display metadata when present, otherwise the humanized member name. Dehumanization also recognizes the raw name, its humanized form, and authored display aliases. Flags enums are decomposed and joined through the active collection formatter.
 
 ## Example
 
-The executable verifies a two-flag value, explicit enum-name and
-`DisplayAttribute` source selection, every dehumanization alias,
-case-insensitive generic dehumanization, no-match behavior, metadata fallback,
-and an unknown flag bit:
+The executable shows a two-flag value, explicit enum-name and
+`DisplayAttribute` source selection, alias dehumanization, and no-match behavior:
 
 <CodeBlock language="csharp" title="Program.cs">{enumsFlags}</CodeBlock>
+
+<CodeBlock language="text" title="Output">{enumsFlagsOutput}</CodeBlock>
 
 ### Choose metadata and casing
 
 Humanizer prefers supported description/display metadata before deriving words
 from the member name. That chosen value is also the member's dehumanization
-label. On `Humanizer 4`, `LetterCasing` changes only labels derived from the
+label. `LetterCasing` changes only labels derived from the
 member name; authored metadata preserves its exact casing.
 `Configurator.UseEnumDescriptionPropertyLocator` can select a custom
 description-like property globally and must run before enum metadata is
@@ -36,7 +35,7 @@ cached.
 
 ### Select the humanization source
 
-On `Humanizer 4`, pass both `LetterCasing` and `EnumHumanizeSource` when the
+Pass both `LetterCasing` and `EnumHumanizeSource` when the
 default metadata precedence is not the desired presentation:
 
 - `Default` preserves the existing precedence. A `DisplayAttribute` uses its
@@ -65,7 +64,7 @@ change dehumanization aliases or their collision rules.
 
 ### Parse accepted aliases
 
-On `Humanizer 4`, `DehumanizeTo<TEnum>` recognizes the raw member name, its
+`DehumanizeTo<TEnum>` recognizes the raw member name, its
 humanized form, and `DisplayAttribute` name, description, and short-name
 values. It also recognizes a configured description attribute value when that
 value becomes the member's authored description. Matching is
@@ -79,27 +78,16 @@ The default `DehumanizeTo<TEnum>` throws `NoMatchFoundException`. Pass `OnNoMatc
 
 Known nonzero flags are humanized and joined using the current UI culture. A defined zero member uses its label. A value containing only unknown bits humanizes to an empty string.
 
-## Pitfall
+## Prefer unambiguous aliases and generic overloads
 
-Aliases should be unambiguous even though matching is case-insensitive. On
-`Humanizer 4`, a current humanized representation takes precedence over a
+Aliases should be unambiguous even though matching is case-insensitive. A
+current humanized representation takes precedence over a
 supplemental alias when labels collide; collisions among supplemental aliases
 retain the later enum value in unsigned numeric order. Prefer the generic enum
 overloads. Runtime enum humanization and the runtime `Type` dehumanization
 overload use reflection and are annotated with `RequiresDynamicCode` and
 `RequiresUnreferencedCode`; they are not the safe default for trimmed or Native
 AOT applications.
-
-## Version notes
-
-Enum APIs span the documented corpus, but Humanizer 3 changes generic
-constraints and metadata configuration. The flags example runs against the
-selected package. Consult the selected API before migrating code that stores
-values as the base `Enum` type. Metadata casing preservation when a
-`LetterCasing` argument is supplied, and dehumanization through raw,
-humanized, and supplemental metadata aliases, are `Humanizer 4` behavior.
-`EnumHumanizeSource` and its two casing-plus-source overloads are also
-`Humanizer 4` APIs.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/fluent-dates-and-time-spans.mdx
+++ b/website/docs/scenarios/fluent-dates-and-time-spans.mdx
@@ -8,10 +8,9 @@ persona: application developer
 
 import CodeBlock from '@theme/CodeBlock';
 import fluentDates from '!!raw-loader!../_examples/scenarios-fluent-dates/Program.cs';
+import fluentDatesOutput from '!!raw-loader!../_examples/scenarios-fluent-dates/expected-output.txt';
 
 # Compose dates and time spans fluently
-
-## Orientation
 
 Humanizer’s numeric time-span extensions make duration constants readable, while `In`, `On`, and the date preposition extensions build calendar values. Use duration helpers for fixed elapsed time and calendar helpers for month/year arithmetic. Inject a starting date instead of relying on “now” when code or tests must be repeatable.
 
@@ -20,6 +19,8 @@ Humanizer’s numeric time-span extensions make duration constants readable, whi
 The executable composes a 36-hour duration, adds two calendar months to a fixed date, and constructs a dated appointment:
 
 <CodeBlock language="csharp" title="Program.cs">{fluentDates}</CodeBlock>
+
+<CodeBlock language="text" title="Output">{fluentDatesOutput}</CodeBlock>
 
 ### Fixed durations
 
@@ -31,16 +32,9 @@ Numeric values expose `Milliseconds`, `Seconds`, `Minutes`, `Hours`, `Days`, and
 
 `On.April.The3rd`, `In.AprilOf(2025)`, `At`, `AtNoon`, `AtMidnight`, and `In(year)` are readable constructors around `DateTime`. `InDate` and `OnDate` provide corresponding `DateOnly` values on compatible frameworks.
 
-## Pitfall
+## Keep calendar and duration arithmetic distinct
 
 Properties without `From` or `Of(year)` read `DateTime.Now` or `UtcNow`. Avoid them in deterministic code. `MonthsFrom` and `YearsFrom` inherit `AddMonths`/`AddYears` normalization, so moving February 29 into a non-leap year produces February 28. By contrast, `date.In(year)` reconstructs the same month and day in the requested year and throws when that date does not exist. Constructors for impossible month/day combinations also throw.
-
-## Version notes
-
-The `DateTime` fluent surface and time-span extensions are available across the
-documented corpus. `DateOnly` fluent helpers begin in `2.11.10` on compatible
-target frameworks. The example uses the shared `DateTime` surface and runs
-against the selected package.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/index.mdx
+++ b/website/docs/scenarios/index.mdx
@@ -8,12 +8,11 @@ persona: application developer
 
 import CodeBlock from '@theme/CodeBlock';
 import quickStart from '!!raw-loader!../_examples/quick-start/Program.cs';
+import quickStartOutput from '!!raw-loader!../_examples/quick-start/expected-output.txt';
 
 # Find a Humanizer scenario
 
-## Orientation
-
-Start with the value you already have and the text you need to produce. Humanizer keeps dates, durations, numbers, byte sizes, enums, and collections as typed values until the display boundary; each guide below shows the operation, deterministic culture or clock setup, failure behavior, and the versions where the API exists.
+Start with the value you already have and the text you need to produce. Humanizer keeps dates, durations, numbers, byte sizes, enums, and collections as typed values until the display boundary; each guide below shows the operation, deterministic culture or clock setup, and failure behavior.
 
 | You have | You want | Start here |
 | --- | --- | --- |
@@ -26,11 +25,12 @@ Start with the value you already have and the text you need to produce. Humanize
 
 ## Example
 
-Every substantive scenario imports source compiled and run against the selected
-package. This smallest example demonstrates the shared rule: set culture
-explicitly, call Humanizer at the presentation boundary, and assert the result.
+This smallest example demonstrates the shared rule: set culture explicitly
+and call Humanizer at the presentation boundary.
 
 <CodeBlock language="csharp" title="Program.cs">{quickStart}</CodeBlock>
+
+<CodeBlock language="text" title="Output">{quickStartOutput}</CodeBlock>
 
 ### Less common tasks
 
@@ -39,16 +39,12 @@ explicitly, call Humanizer at the presentation boundary, and assert the result.
 - [Specialized formatting utilities](./specialized-formatting-utilities.mdx)
 - [Trimming and Native AOT](../concepts/trimming-and-native-aot.mdx)
 
-## Pitfall
+## Keep the typed value
 
 Humanized output is presentation text, not a stable storage or wire format. Keep the original typed value and regenerate text for the active culture. A parser such as `TryToNumber` or `ByteSize.TryParse` has an explicit input contract; it does not make arbitrary humanized output round-trip safe.
-
-## Version notes
-
-The site covers selected releases from `2.10.1` through `3.0.10` plus `Humanizer 4`. Use the version selector before copying a call. Focused pages state important API boundaries, and unavailable pages are removed or replaced in historical snapshots.
 
 ## Related guides and API
 
 - [Install Humanizer](../start/installation.mdx)
 - [Troubleshooting](../start/troubleshooting.mdx)
-- [Selected-version API reference](../api/index.md)
+- [API reference](../api/index.md)

--- a/website/docs/scenarios/inflection-and-quantities.mdx
+++ b/website/docs/scenarios/inflection-and-quantities.mdx
@@ -8,20 +8,20 @@ persona: application developer
 
 import CodeBlock from '@theme/CodeBlock';
 import inflection from '!!raw-loader!../_examples/scenarios-inflection/Program.cs';
+import inflectionOutput from '!!raw-loader!../_examples/scenarios-inflection/expected-output.txt';
 
 # Pluralize and singularize nouns
-
-## Orientation
 
 Use `Pluralize` or `Singularize` when the application has an English noun but not a count. Use `ToQuantity` when the count and noun belong together. Humanizer’s vocabulary handles common irregular and uncountable English nouns; an application can add domain-specific rules before it begins formatting text.
 
 ## Example
 
 This isolated executable covers a built-in English irregular noun, a quantity
-written as words, one application-specific irregular pair, and caller-authored
-Polish plural forms:
+written as words, and one application-specific irregular pair:
 
 <CodeBlock language="csharp" title="Program.cs">{inflection}</CodeBlock>
+
+<CodeBlock language="text" title="Output">{inflectionOutput}</CodeBlock>
 
 ### Tell Humanizer what the input means
 
@@ -35,62 +35,31 @@ Polish plural forms:
 
 Numeric format strings and providers control the displayed number. They do not turn the English inflector into a localized noun engine.
 
-### Pluralize a localized noun for a count
-
-On `Humanizer 4`, `PluralizationForms.TryPluralize` selects a
-caller-supplied form using the explicit culture's Unicode CLDR decimal cardinal
-rule. Every supported culture supplies this rule. If the selected form was not
-supplied, the operation returns `false`; it does not guess morphology or fall
-back to English. Use `PluralizationForms.Invariant` for a word that never
-changes, or explicitly supply equal forms when categories share spelling. The
-encoded decimal scale is significant, so a culture can select different forms
-for `1m` and `1.0m`.
-
-CLDR categories are count-selection tags, not complete grammatical categories.
-`PluralizationForms` models one noun's singular and plural forms. Call
-`TrySingularize` on that form set to resolve any exact authored form back to
-its singular spelling. Matching is Unicode NFC-normalized, ordinal, and
-case-sensitive.
-
-The selector follows the
-[Unicode CLDR plural-rule contract](https://cldr.unicode.org/index/cldr-spec/plural-rules)
-and its [decimal operands](https://unicode.org/reports/tr35/tr35-numbers.html).
 ### Extend the vocabulary
 
 `Vocabularies.Default` supports `AddIrregular`, `AddUncountable`, `AddPlural`, and `AddSingular`. Prefer an irregular or uncountable entry over a broad regular expression. Set `matchEnding: false` when a rule must match the entire noun instead of every word ending with the same letters.
 
-In Humanizer 4, `AddAcronym` uses the same vocabulary to preserve the
+`AddAcronym` uses the same vocabulary to preserve the
 canonical casing of a domain acronym during string humanization. Registration
 is case-insensitive, but the registered spelling controls the output. Acronyms
 must contain letters only.
 
-## Pitfall
+## Configure vocabularies at startup
 
-Vocabulary changes, including acronym registrations in Humanizer 4, are
+Vocabulary changes, including acronym registrations, are
 process-global. Register domain words once during startup and test them in an
 isolated process; do not add rules per request. `ToQuantity` treats exactly `1`
 and `-1` as singular. Fractional values, `NaN`, and infinity use the plural
 form.
 
-The existing `Pluralize`, `Singularize`, vocabulary, and `ToQuantity` APIs
-continue to pluralize and singularize English nouns. Every supported culture
-supplies the cardinal rule used by `PluralizationForms`.
-
-## Version notes
-
-Core inflection is available across the documented release set. Individual
-vocabulary rules and overloads have changed, and early Humanizer `3.0.x`
-temporarily lacked quantity overloads restored by `3.0.8`. The verified source
-runs against the selected package. `AddAcronym` is available on
-`Humanizer 4`.
-Culture-explicit `PluralizationForms` are new in v4.
+`Pluralize`, `Singularize`, vocabulary, and `ToQuantity` pluralize and
+singularize English nouns.
 
 ## Related guides and API
 
 - [Numbers in words and ordinals](./numbers-in-words-and-ordinals.mdx)
 - [Localization and extensibility](./localization-and-extensibility.mdx)
 - [InflectorExtensions API](../api/Humanizer.InflectorExtensions.md)
-- [PluralizationForms API](../api/Humanizer.PluralizationForms.md)
 - [ToQuantityExtensions API](../api/Humanizer.ToQuantityExtensions.md)
 - [ShowQuantityAs API](../api/Humanizer.ShowQuantityAs.md)
 - [Vocabularies API](../api/Humanizer.Vocabularies.md)

--- a/website/docs/scenarios/localization-and-extensibility.mdx
+++ b/website/docs/scenarios/localization-and-extensibility.mdx
@@ -8,21 +8,23 @@ persona: application developer
 
 import CodeBlock from '@theme/CodeBlock';
 import localization from '!!raw-loader!../_examples/scenarios-localization/Program.cs';
+import localizationOutput from '!!raw-loader!../_examples/scenarios-localization/expected-output.txt';
 import configuration from '!!raw-loader!../_examples/configuration/Program.cs';
+import configurationOutput from '!!raw-loader!../_examples/configuration/expected-output.txt';
 
 # Localization and extensibility
-
-## Orientation
 
 Start with culture selection, then choose the narrowest extension point. Pass `CultureInfo` per call when possible. Establish `CurrentCulture` and `CurrentUICulture` at a request or job boundary for ambient APIs. Use a local interface implementation for one operation and reserve `Configurator` registries or strategies for process-wide application policy.
 
 ## Example
 
-This verified example produces French number words and supplies a per-call culture-aware transformer:
+This example produces French number words and supplies a per-call culture-aware transformer:
 
 <CodeBlock language="csharp" title="Program.cs">{localization}</CodeBlock>
 
-The result is `quarante-deux; BONJOUR`. A per-call transformer is isolated and easy to test.
+<CodeBlock language="text" title="Output">{localizationOutput}</CodeBlock>
+
+A per-call transformer is isolated and easy to test.
 
 ### Choose an extension point
 
@@ -39,7 +41,7 @@ Registries cover collection formatters, general formatters, number-word converte
 
 ### Set a global time-span policy
 
-On `Humanizer 4`, assign `Configurator.TimeSpanHumanizeStrategy` once during
+Assign `Configurator.TimeSpanHumanizeStrategy` once during
 application startup to route every `TimeSpan.Humanize` and
 `HumanizeToSymbols` call through an application-wide policy. Fractional-second
 calls use `IFractionalTimeSpanHumanizeStrategy` when the configured strategy
@@ -57,6 +59,8 @@ a custom time-span strategy that delegates all behavior to
 
 <CodeBlock language="csharp" title="Program.cs">{configuration}</CodeBlock>
 
+<CodeBlock language="text" title="Output">{configurationOutput}</CodeBlock>
+
 `HumanizeWithCase` uses a separate optional capability so existing custom
 components remain source- and binary-compatible. A configured strategy must
 implement `IGrammaticalCaseTimeSpanHumanizeStrategy`, and its selected
@@ -72,21 +76,11 @@ form may render the count explicitly or encode it in the unit form. It must
 not add a preposition. Install custom
 strategies and formatters during startup, before registry resolution freezes.
 
-## Pitfall
+## Register global behavior before first use
 
-In Humanizer `3.x` and current, localizer registries freeze on first resolution. Register components before any Humanizer call can resolve that registry. Humanizer `2.x` registries remain mutable, but startup registration still prevents request-to-request drift. Do not mutate global strategies per request; concurrent callers can observe the change.
+Localizer registries freeze on first resolution. Register components before any Humanizer call can resolve that registry. Do not mutate global strategies per request; concurrent callers can observe the change.
 
 Parent-culture fallback identifies where behavior was resolved. It does not prove that inherited wording is correct for every region.
-
-## Version notes
-
-The local transformer runs across the supported corpus. Registry immutability
-and enum metadata configuration change in Humanizer 3.
-`TimeSpanHumanizeStrategy`, `ITimeSpanHumanizeStrategy`, and
-`DefaultTimeSpanHumanizeStrategy` are Humanizer 4 APIs. Individual registries
-and supported-culture inventories are selected-version behavior; historical
-snapshots must not present current YAML/generator internals as old package
-behavior.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/metric-numerals.mdx
+++ b/website/docs/scenarios/metric-numerals.mdx
@@ -8,15 +8,14 @@ persona: application developer
 
 import CodeBlock from '@theme/CodeBlock';
 import metric from '!!raw-loader!../_examples/scenarios-metric/Program.cs';
+import metricOutput from '!!raw-loader!../_examples/scenarios-metric/expected-output.txt';
 
 # Format and parse metric numerals
-
-## Orientation
 
 Use `ToMetric` for compact decimal magnitudes such as `123.5k`, and
 `FromMetric` when an input follows Humanizer’s metric syntax.
 `MetricNumeralFormats` selects a symbol, SI prefix name, scale word, and
-optional spacing. Humanizer 4 can also preserve a fixed number of fractional
+optional spacing. Humanizer can also preserve a fixed number of fractional
 digits. Numeric text follows `CurrentCulture`; automatic scale-word selection
 follows `CurrentUICulture` and reuses that locale's number-word data.
 
@@ -27,6 +26,8 @@ decimals, preserves a fixed decimal width, automatically selects a scale word,
 emits an SI prefix name, and parses a symbol:
 
 <CodeBlock language="csharp" title="Program.cs">{metric}</CodeBlock>
+
+<CodeBlock language="text" title="Output">{metricOutput}</CodeBlock>
 
 ### Select the representation
 
@@ -67,7 +68,7 @@ zero.
 
 `FromMetric` accepts a numeric value followed by a supported SI symbol or prefix name, with optional whitespace. It returns `double` and throws `ArgumentException` for invalid syntax. Short- and long-scale words produced by `ToMetric` are display forms and do not round-trip through `FromMetric`.
 
-## Pitfall
+## Keep metric and byte units distinct
 
 Metric prefixes are powers of 1000. `ByteSize` uses a mixed unit contract:
 legacy `KB` through `TB` are binary multiples, `PB` and `EB` are decimal SI,
@@ -76,14 +77,6 @@ metric exponent range stops before `10^27` and below `10^-27`; out-of-range
 values throw. Because there is no culture parameter, scope `CurrentCulture`
 when parsing or exact numeric output matters, and scope `CurrentUICulture`
 when `UseScaleWord` must be deterministic.
-
-## Version notes
-
-Metric conversion spans the documented corpus, but Humanizer 3 removed older
-boolean formatting overloads in favor of `MetricNumeralFormats`.
-`UseScaleWord` and `KeepTrailingZeros` are available in Humanizer 4. The
-executable uses the selected version's formatting API and runs against that
-package.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/numbers-in-words-and-ordinals.mdx
+++ b/website/docs/scenarios/numbers-in-words-and-ordinals.mdx
@@ -8,10 +8,9 @@ persona: application developer
 
 import CodeBlock from '@theme/CodeBlock';
 import numbers from '!!raw-loader!../_examples/scenarios-numbers/Program.cs';
+import numbersOutput from '!!raw-loader!../_examples/scenarios-numbers/expected-output.txt';
 
 # Write numbers and ordinals in words
-
-## Orientation
 
 Use `ToWords` for cardinal words, `ToOrdinalWords` for word ordinals, and
 `Ordinalize` when the number should remain numeric with a localized ordinal
@@ -23,11 +22,13 @@ English output needs an explicit named-scale or crore-based vocabulary.
 
 ## Example
 
-The shared number example verifies cardinal words, locale-specific magnitude
-names, 64-bit ordinals, common fractions, simplified and traditional Chinese
-financial characters, and the established number-formatting helpers:
+The shared number example shows cardinal and ordinal words, a 64-bit ordinal,
+Indian and Estonian scale names, a common fraction, Chinese financial
+characters, and a Roman numeral:
 
 <CodeBlock language="csharp" title="Program.cs">{numbers}</CodeBlock>
+
+<CodeBlock language="text" title="Output">{numbersOutput}</CodeBlock>
 
 ### Choose the output
 
@@ -56,7 +57,7 @@ not change `ToWords`, configured converters, or other locales.
 
 ### Format 64-bit ordinals
 
-In Humanizer 4, numeric `Ordinalize` overloads accept the full `long` range and
+Numeric `Ordinalize` overloads accept the full `long` range and
 retain the selected culture, gender, and `WordForm` rules. String `Ordinalize`
 remains `int`-bounded; parse to `long` first when the input can exceed that
 range.
@@ -93,7 +94,7 @@ domain policy separately.
 
 ### Use the full `long` range
 
-In Humanizer 4, every built-in number-word locale supports the full signed
+Every built-in number-word locale supports the full signed
 `long` range. Estonian follows its authored scale names through `triljon`;
 Albanian uses `miliar`, `bilion`, `biliar`, and `trilion`, with their plural
 forms. The executable above calls `ToWords` for both `long.MaxValue` and
@@ -102,21 +103,12 @@ or `NotImplementedException` as a partial-coverage boundary. Custom converters
 can retain narrower ranges when their profiles do not define the required
 scale words.
 
-## Pitfall
+## Check locale capabilities and numeric limits
 
 Grammar features differ by locale. Do not infer gender, abbreviation, Eifeler,
 or ordinal-word support from cardinal support. String `Ordinalize` parses the
 input using culture and can throw for malformed or out-of-range text; prefer
 the numeric overload when the application already has a number.
-
-## Version notes
-
-The basic number-word and ordinal APIs span the documented corpus, but overloads
-and locale grammar have changed. `Fractionalize`, Chinese financial numerals,
-64-bit numeric ordinals, Indian scale vocabulary selection, and the Estonian
-and Albanian scale corrections described above are available in the Humanizer
-4 NuGet package. The verified source runs against the selected package.
-Historical snapshots link to their own capability data and signatures.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/numbers-words-ordinals-roman-bytes-and-quantities.mdx
+++ b/website/docs/scenarios/numbers-words-ordinals-roman-bytes-and-quantities.mdx
@@ -8,10 +8,11 @@ persona: returning developer
 
 import CodeBlock from '@theme/CodeBlock';
 import numbers from '!!raw-loader!../_examples/scenarios-numbers/Program.cs';
+import numbersOutput from '!!raw-loader!../_examples/scenarios-numbers/expected-output.txt';
 
 # Number and data formatting scenarios
 
-## Orientation
+## Choose a focused guide
 
 Choose one operation instead of treating every formatted number as the same kind of string:
 
@@ -26,22 +27,17 @@ Choose one operation instead of treating every formatted number as the same kind
 
 ## Example
 
-This verified survey sets English culture and exercises one representative call from several families:
+This program sets English culture and exercises representative formatting calls:
 
 <CodeBlock language="csharp" title="Program.cs">{numbers}</CodeBlock>
 
+<CodeBlock language="text" title="Output">{numbersOutput}</CodeBlock>
+
 Focused guides separate the typed model, parsing contract, localization behavior, and failure modes. Pass `CultureInfo` directly where an overload permits it; scope both ambient cultures for APIs without a culture argument.
 
-## Pitfall
+## Keep the typed number
 
 Do not persist humanized number text as the numeric source of truth. `ByteSize` uses binary multiples, metric numerals use decimal powers, number-word parsing has locale-specific grammar, and Roman numerals have a strict range. Keep the typed value and choose a parser only for an input format the application explicitly accepts.
-
-## Version notes
-
-The survey’s available calls compile and run against the selected package.
-Number-word parsing begins in `3.0.1` and changes from `int` to `long` on
-`Humanizer 4`. Culture-aware byte-rate formatting begins in `2.13.14`.
-Historical snapshots remove or replace unavailable focused pages.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/parse-number-words.mdx
+++ b/website/docs/scenarios/parse-number-words.mdx
@@ -8,26 +8,26 @@ persona: application developer
 
 import CodeBlock from '@theme/CodeBlock';
 import parseNumberWords from '!!raw-loader!../_examples/scenarios-parse-number-words/Program.cs';
+import parseNumberWordsOutput from '!!raw-loader!../_examples/scenarios-parse-number-words/expected-output.txt';
 
 # Parse localized number words
 
-## Orientation
-
 Use `TryToNumber` at an input boundary where invalid integer words are expected.
 Use `ToNumber` when invalid text is exceptional and should throw.
-Humanizer 4 adds the corresponding decimal APIs `TryToDecimalNumber` and
+The corresponding decimal APIs are `TryToDecimalNumber` and
 `ToDecimalNumber`. All four require an explicit `CultureInfo`, because the
 same words, magnitude system, and token rules do not mean the same thing in
 every culture.
 
 ## Example
 
-This executable parses positive and negative integers, parses English and
-French decimal words, preserves an authored decimal scale, and verifies the
-unsupported-culture contract. `Convert.ToInt64` keeps the integer assertions
-compatible with the stable `int` result and current `long` result:
+This executable parses positive and negative integers, handles an unrecognized
+word, parses English and French decimal words, and preserves an authored
+decimal scale:
 
 <CodeBlock language="csharp" title="Program.cs">{parseNumberWords}</CodeBlock>
+
+<CodeBlock language="text" title="Output">{parseNumberWordsOutput}</CodeBlock>
 
 ### Handle expected failure
 
@@ -77,24 +77,17 @@ For `null` or empty input, that reported value is an empty string.
 
 ### Convert to a narrower type
 
-Current builds return `long`. If the application requires `int`, use a checked conversion after successful parsing:
+`ToNumber` returns `long`. If the application requires `int`, use a checked conversion after successful parsing:
 
 ```csharp
 var value = checked((int)parsedLong);
 ```
 
-## Pitfall
+## Treat number words as a defined input format
 
-The parsers support only the locales and word forms represented by the selected
-version's generated profiles. They are not general natural-language parsers.
+The parsers support only the locales and word forms represented by Humanizer's
+generated profiles. They are not general natural-language parsers.
 Preserve the explicit culture from the user-input boundary.
-
-## Version notes
-
-Words-to-number begins in Humanizer `3.0.1`; this page is unavailable in `2.x`.
-Releases through `3.0.10` return `int`. Humanizer 4 returns `long`, and its
-analyzer can offer a checked conversion for existing assignments that now fail
-with `CS0029` or `CS0266`. Decimal word parsing is available in Humanizer 4.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/relative-dates-and-times.mdx
+++ b/website/docs/scenarios/relative-dates-and-times.mdx
@@ -8,10 +8,9 @@ persona: application developer
 
 import CodeBlock from '@theme/CodeBlock';
 import dates from '!!raw-loader!../_examples/scenarios-dates/Program.cs';
+import datesOutput from '!!raw-loader!../_examples/scenarios-dates/expected-output.txt';
 
 # Humanize relative dates and times
-
-## Orientation
 
 Relative humanization compares a temporal value with a known base and returns text such as `yesterday`, `3 hours ago`, or `a month from now`. Pass both the comparison base and culture when output must be deterministic. Choose the overload that preserves the semantics of `DateTime`, `DateTimeOffset`, `DateOnly`, or `TimeOnly`.
 
@@ -22,6 +21,8 @@ The same explicit `CultureInfo` argument is available on the `DateTimeOffset`,
 `DateOnly`, and `TimeOnly` overloads:
 
 <CodeBlock language="csharp" title="Program.cs">{dates}</CodeBlock>
+
+<CodeBlock language="text" title="Output">{datesOutput}</CodeBlock>
 
 ### Choose the temporal type
 
@@ -38,13 +39,9 @@ Nullable overloads return the locale’s “never” phrase for `null`. That is 
 
 The default strategies choose familiar boundaries such as “yesterday.” `PrecisionDateTimeHumanizeStrategy` and its sibling strategies use a precision factor when applications need more gradual thresholds. Assign a strategy through `Configurator` once during startup.
 
-## Pitfall
+## Keep local and UTC values separate
 
 Do not compare a local `DateTime` with a UTC base accidentally. Humanizer converts the injected comparison according to `utcDate`; mixed `Kind` values can move the boundary. `TimeOnly` has no date context, so a comparison around midnight cannot know whether the intended event was yesterday or tomorrow.
-
-## Version notes
-
-`DateTime` and `DateTimeOffset` support span the documented corpus. `DateOnly` and `TimeOnly` humanization begin in `2.11.10` on compatible target frameworks. Strategy types and thresholds are selected-version behavior.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/specialized-formatting-utilities.mdx
+++ b/website/docs/scenarios/specialized-formatting-utilities.mdx
@@ -8,10 +8,9 @@ persona: returning developer
 
 import CodeBlock from '@theme/CodeBlock';
 import specialized from '!!raw-loader!../_examples/scenarios-specialized/Program.cs';
+import specializedOutput from '!!raw-loader!../_examples/scenarios-specialized/expected-output.txt';
 
 # Use specialized formatting utilities
-
-## Orientation
 
 Humanizer includes a few focused helpers that do not justify forcing a broader string or number abstraction: compass headings and arrows, Roman numerals, readable numeric multipliers, tuple names, localized time-unit symbols, and English article-aware sorting. Use each only when its narrow input contract matches the task.
 
@@ -20,6 +19,8 @@ Humanizer includes a few focused helpers that do not justify forcing a broader s
 This executable exercises every utility on fixed input:
 
 <CodeBlock language="csharp" title="Program.cs">{specialized}</CodeBlock>
+
+<CodeBlock language="text" title="Output">{specializedOutput}</CodeBlock>
 
 ### Headings and arrows
 
@@ -37,13 +38,9 @@ This executable exercises every utility on fixed input:
 
 `EnglishArticle.AppendArticlePrefix` moves leading `A`, `An`, or `The` to a suffix and returns the transformed array already sorted. Pass that result directly to `PrependArticleSuffix` to restore display titles. This advanced helper is deliberately English-only and throws for an empty array.
 
-## Pitfall
+## Respect each utility's input range
 
 These APIs are not general parsers. Compass quantization loses the original degree and does not validate or normalize negative, `NaN`, or infinite input. Roman conversion has a strict range, multiplier methods can overflow their numeric type, and article sorting recognizes only its exact English pattern. Preserve the original value whenever later logic needs it.
-
-## Version notes
-
-Most utilities span the documented corpus. Localized time-unit symbols appear in `2.13.14`; earlier snapshots need that section removed. Exact locale output is release data, while Roman and invariant tuple examples are stable.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/spoken-dates-and-clock-times.mdx
+++ b/website/docs/scenarios/spoken-dates-and-clock-times.mdx
@@ -8,20 +8,21 @@ persona: application developer
 
 import CodeBlock from '@theme/CodeBlock';
 import spokenDates from '!!raw-loader!../_examples/scenarios-spoken-dates/Program.cs';
+import spokenDatesOutput from '!!raw-loader!../_examples/scenarios-spoken-dates/expected-output.txt';
 
 # Produce spoken dates and clock times
-
-## Orientation
 
 Use date ordinal words when a calendar date should read naturally, and clock notation when a `TimeOnly` value should become a phrase such as “twenty-five past one.” These are localized presentation operations, distinct from relative time and numeric ordinal suffixes.
 
 ## Example
 
-Date ordinal words use ambient culture. Humanizer 4 can pass a culture directly
-to clock notation; this executable demonstrates that overload while also
+Date ordinal words use ambient culture. Clock notation can take a culture
+directly; this executable demonstrates that overload while also
 scoping both ambient cultures for the date API:
 
 <CodeBlock language="csharp" title="Program.cs">{spokenDates}</CodeBlock>
+
+<CodeBlock language="text" title="Output">{spokenDatesOutput}</CodeBlock>
 
 ### Date ordinal words
 
@@ -36,10 +37,10 @@ together at the boundary.
 `TimeOnly.ToClockNotation()` renders the exact minute.
 `ClockNotationRounding.NearestFiveMinutes` first rounds to the nearest
 five-minute boundary, then selects the phrase. Rounding can cross an hour or
-day-period boundary. The Humanizer 4 overload that also accepts a `CultureInfo`
+day-period boundary. The overload that also accepts a `CultureInfo`
 avoids changing ambient culture.
 
-## Pitfall
+## Check culture support
 
 Every culture listed by `Configurator.IsCultureSupported` supplies date ordinal
 words, the grammatical-case overload, and clock notation. A locale whose date
@@ -48,12 +49,6 @@ Supported same-language descendants inherit their parent locale's behavior;
 no supported non-English culture reaches the English default. Unsupported
 cultures can use a configured registry default, so the completeness guarantee
 applies only when `Configurator.IsCultureSupported` returns `true`.
-
-## Version notes
-
-`DateTime.ToOrdinalWords` predates the documented corpus. `DateOnly` date words
-begin with its framework support in `2.11.10`. Clock notation appears in
-`2.13.14`; the explicit-culture clock overload is available in Humanizer 4.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/strings-and-casing.mdx
+++ b/website/docs/scenarios/strings-and-casing.mdx
@@ -8,31 +8,33 @@ persona: returning developer
 
 import CodeBlock from '@theme/CodeBlock';
 import strings from '!!raw-loader!../_examples/scenarios-strings/Program.cs';
+import stringsOutput from '!!raw-loader!../_examples/scenarios-strings/expected-output.txt';
 
 # Transform strings, identifiers, and casing
-
-## Orientation
 
 Use `Humanize` to turn program-shaped identifiers into display text. Use the identifier transformations when code, file, or route naming is the destination. Apply `LetterCasing` or a cultured transformer only after deciding the word boundaries; casing and identifier conversion solve different problems.
 
 ## Example
 
-This verified source covers readable labels, custom acronym casing, ampersands, explicit casing, Pascal/snake/kebab conversion, dehumanization, truncation, and a cultured transformer:
+This source covers readable labels, custom acronym casing, ampersands,
+snake/kebab conversion, dehumanization, and truncation:
 
 <CodeBlock language="csharp" title="Program.cs">{strings}</CodeBlock>
+
+<CodeBlock language="text" title="Output">{stringsOutput}</CodeBlock>
 
 ### Turn an identifier into a label
 
 `Humanize` recognizes PascalCase, camelCase, underscores, dashes, numbers, and common acronym boundaries. Pass `LetterCasing.Sentence`, `Title`, `LowerCase`, or `AllCaps` when the label needs a known presentation case. All-capital input is treated as an acronym and can remain unchanged until a casing operation is requested.
 
-On `Humanizer 4`, `Humanize` preserves ampersands as separate tokens instead
+`Humanize` preserves ampersands as separate tokens instead
 of discarding them with other punctuation. For example,
 `"Research&Development".Humanize()` returns `"Research & development"`.
 Other punctuation such as `+` and `/` is still removed.
 
 ### Preserve domain acronym casing
 
-On `Humanizer 4`, call `Vocabularies.Default.AddAcronym` once during startup
+Call `Vocabularies.Default.AddAcronym` once during startup
 when an acronym has required output casing. Registration matches
 case-insensitively, while the registered spelling supplies the output:
 registering `iOS` makes `"IOSSettings".Humanize()` return `"iOS settings"`.
@@ -55,7 +57,7 @@ tests that change it isolated.
 
 `Dehumanize` is the direct readable-text-to-PascalCase operation. Use the named inflector transformations when the destination convention matters.
 
-`Underscore()` lowercases its output. On `Humanizer 4`, pass
+`Underscore()` lowercases its output. Pass
 `preserveCase: true` to retain the input casing while inserting boundaries:
 `"HTMLParser".Underscore(preserveCase: true)` returns `"HTML_Parser"`.
 
@@ -63,20 +65,11 @@ tests that change it isolated.
 
 `Transform(To.TitleCase)` and its sentence, upper, and lower siblings use cultured string transformers. Pass a `CultureInfo` to the cultured overload. Implement `IStringTransformer` or `ICulturedStringTransformer` for a local reusable rule without changing process-global configuration.
 
-## Pitfall
+## Treat identifier transformations as lossy
 
 Identifier conversions are intentionally lossy. Acronym boundaries, punctuation, whitespace, and Unicode can prevent a round trip. `Dasherize` and `Hyphenate` primarily replace underscores; use `Kebaberize` when the input needs complete word-boundary normalization.
 
 Title and sentence casing use culture-sensitive text operations. Scope culture when output must be deterministic, especially for Turkish and Azerbaijani casing, and do not assume title casing implements a particular editorial style guide.
-
-## Version notes
-
-The verified executable compiles and runs against the selected package. Core
-transformations also exist in `2.x`, but custom acronym registration,
-ampersand preservation, and the case-preserving `Underscore` overload are
-`Humanizer 4` behavior. Humanizer 3 also changes several delimiter and
-no-letter edge cases. Use the selected snapshot when exact legacy behavior
-matters.
 
 ## Related guides and API
 

--- a/website/docs/scenarios/truncation-and-dehumanization.mdx
+++ b/website/docs/scenarios/truncation-and-dehumanization.mdx
@@ -8,18 +8,20 @@ persona: returning developer
 
 import CodeBlock from '@theme/CodeBlock';
 import strings from '!!raw-loader!../_examples/scenarios-strings/Program.cs';
+import stringsOutput from '!!raw-loader!../_examples/scenarios-strings/expected-output.txt';
 
 # Truncation and dehumanization
-
-## Orientation
 
 Use `Truncate` to fit display text into a character or word budget without hand-written substring rules. Select a built-in `ITruncator` according to what the length means. Use string `Dehumanize` separately when readable words must become a PascalCase-shaped identifier.
 
 ## Example
 
-The truncation and dehumanization calls in this verified source produce `Customer…`, preserve four complete words, and produce `CustomerOrderHistory`:
+The truncation and dehumanization calls in this source produce `Customer…`
+and `CustomerOrderHistory`:
 
 <CodeBlock language="csharp" title="Program.cs">{strings}</CodeBlock>
+
+<CodeBlock language="text" title="Output">{stringsOutput}</CodeBlock>
 
 ### Choose the truncator
 
@@ -37,17 +39,11 @@ The default marker is the single-character ellipsis `…`. Pass a custom marker 
 
 `Dehumanize` removes word separators and produces PascalCase. It is suitable for application-controlled labels and scaffolding, not for reconstructing an original identifier.
 
-## Pitfall
+## Account for truncation markers and lost information
 
 The marker consumes budget for fixed-length strategies. When the marker itself fills the available length, preserve-word strategies can return only the marker or an empty result. Truncation preserves null input, but an application still needs to decide whether null and empty text mean the same thing.
 
 `Dehumanize` is not a lossless inverse: punctuation, casing, acronym, and word-boundary information can be discarded.
-
-## Version notes
-
-The verified source compiles and runs against the selected package. Truncator
-strategies exist across the documented corpus, but overload order and Unicode
-behavior vary; consult the selected-version API before editing an old call.
 
 ## Related guides and API
 

--- a/website/scenario-api-contract.json
+++ b/website/scenario-api-contract.json
@@ -13,7 +13,6 @@
       "Humanizer.StringDehumanizeExtensions.md"
     ],
     "scenarios/inflection-and-quantities.mdx": [
-      "Humanizer.PluralizationForms.md",
       "Humanizer.InflectorExtensions.md",
       "Humanizer.ToQuantityExtensions.md",
       "Humanizer.ShowQuantityAs.md",
@@ -159,10 +158,6 @@
     }
   ],
   "unavailable": [
-    {
-      "versions": ["2.10.1", "2.11.10", "2.13.14", "2.14.1", "3.0.1", "3.0.8", "3.0.10"],
-      "target": "Humanizer.PluralizationForms.md"
-    },
     {
       "versions": ["2.10.1", "2.11.10", "2.13.14", "2.14.1", "3.0.1", "3.0.8", "3.0.10"],
       "target": "Humanizer.ByteSizeUnitSystem.md"


### PR DESCRIPTION
## Summary

Current scenario examples now read like consumer programs: inputs and Humanizer calls produce visible output, while one shared verifier compares stdout with checked-in expected results. Scenario prose displays that same verified output and drops assertion-style demonstrations and forced template sections.

The localized arbitrary-string inflection slice was intentionally excluded because it is not part of the final v4 contract. The scenario API contract was mechanically synchronized with that owner-approved correction. This builds on the content contract merged in #1895.

## Validation

- `pwsh ./tools/docs/verify-examples.ps1 -Version current -Area Scenarios` — all current scenario projects and expected outputs passed.
- `pwsh ./tools/docs/verify-examples.ps1 -Version 3.0.10 -Area Scenarios` — all published 3.0.10 scenario projects passed.
- `pwsh ./tools/docs/snapshot.ps1 -Version current -Check` — deterministic current API and scenario contract passed.
- `pnpm --dir website run check:content` — all seven areas passed.
- `pnpm --dir website run test:unit` — 50/50 passed.
- `pnpm --dir website run typecheck` — passed.
- Rebase patch identity — `fc1bb37109837d3f964700ecd949c82b2b0a811f2033e54925eaf45766197649` before and after retargeting to `main`.
- `git diff --check` — passed.

## Checklist

- [x] Implementation is clean.
- [x] Repository coding standards are followed.
- [x] No code-analysis warnings are introduced.
- [x] Every runnable scenario has checked output verification.
- [x] No copied code requires attribution.
- [x] Comments and XML documentation are not applicable.
- [x] Rebased onto `main` after #1895 merged.
- [x] No issue is closed by this focused documentation unit.
- [x] Scenario documentation and examples are updated together.
- [x] Applicable documentation gates were run.
