### PR TITLE
fix(generator): simplify list template fallback

### DIFF
--- a/src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs
+++ b/src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs
@@ -491,18 +491,20 @@ public sealed partial class HumanizerSourceGenerator
             var engine = mapping.GetScalar("engine")
                 ?? throw new InvalidOperationException($"Locale '{localeCode}.surfaces.list' must define 'engine'.");
             var pairTemplate = mapping.GetScalar("pairTemplate");
-            var finalTemplate = mapping.GetScalar("finalTemplate") ?? pairTemplate;
+            var finalTemplate = mapping.GetScalar("finalTemplate");
             var serialTemplate = mapping.GetScalar("serialTemplate");
             if (engine == "oxford" && pairTemplate is null && finalTemplate is null)
             {
                 return mapping;
             }
 
-            if (pairTemplate is null || finalTemplate is null)
+            if (pairTemplate is null)
             {
                 throw new InvalidOperationException(
                     $"Locale '{localeCode}.surfaces.list' must define canonical list templates or legacy 'value'.");
             }
+
+            finalTemplate ??= pairTemplate;
 
             var values = ImmutableDictionary.CreateBuilder<string, SimpleYamlValue>(StringComparer.Ordinal);
             var oxfordComma = ReadBoolean(mapping, "oxfordComma");

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/CanonicalLocaleSchemaTests.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/CanonicalLocaleSchemaTests.cs
@@ -1290,6 +1290,15 @@ surfaces:
     finalTemplate: 'prefix {0}'
 """));
 
+        var missingPairTemplateCatalog = CreateCatalog(
+            ("zz", """
+locale: 'zz'
+surfaces:
+  list:
+    engine: 'conjunction'
+    finalTemplate: '{0} and {1}'
+"""));
+
         Assert.Contains(
             missingTemplatesCatalog.Diagnostics,
             static diagnostic => diagnostic.Id == "HSG003" &&
@@ -1298,6 +1307,10 @@ surfaces:
             malformedTemplatesCatalog.Diagnostics,
             static diagnostic => diagnostic.Id == "HSG003" &&
                 diagnostic.GetMessage().Contains("must use '{0}' and '{1}'", StringComparison.Ordinal));
+        Assert.Contains(
+            missingPairTemplateCatalog.Diagnostics,
+            static diagnostic => diagnostic.Id == "HSG003" &&
+                diagnostic.GetMessage().Contains("must define canonical list templates", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/website/docs/contributing/locale-yaml-reference.mdx
+++ b/website/docs/contributing/locale-yaml-reference.mdx
@@ -169,7 +169,7 @@ These are the main files that turn locale YAML into runtime behavior:
    - shared runtime kernels
 
 <!-- humanizer-locale-reference-fingerprint:v1
-src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs 1a97379e27bd7c68a65b540260c4c4e5c16de79197bc6ea11096260388b21864
+src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs c57968b32dd3b175cf0a90d3330781dce69af43d230090a708e4ee390331fee8
 src/Humanizer.SourceGenerators/Common/DurationCaseModels.cs f75edf57e2d25981d36ed313b760187f49d681bc749b9020e8131d9aaaf4c1d8
 src/Humanizer.SourceGenerators/Common/EngineContractCatalog.cs caf48277eaacf6409eec0a8541b49ec4974fcaaab53b561a5f8c7e67506658da
 src/Humanizer.SourceGenerators/Common/EngineContractModels.cs ed56aeb32417c9f8896f72ec5627422ca364e25386cef72fb69ac64123379feb


### PR DESCRIPTION
## Summary

Canonical list normalization now assigns the final-template fallback only after proving the required pair template exists. This removes CodeQL's constant-condition finding while preserving the Oxford empty-template exception, fallback behavior, diagnostics, and generated contracts.

The locale-reference source fingerprint is refreshed after reviewing the behavior-preserving generator change; no documentation prose changes.

Related: https://github.com/Humanizr/Humanizer/security/code-scanning/370

## Test plan

- `dotnet test tests/Humanizer.SourceGenerators.Tests/Humanizer.SourceGenerators.Tests.csproj --framework net10.0`
- `dotnet test tests/Humanizer.SourceGenerators.Tests/Humanizer.SourceGenerators.Tests.csproj --framework net11.0`
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity minimal`
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp>`
- `pwsh -NoLogo -NoProfile -File tools/docs/build.ps1 -Mode Validate`
- `pwsh -NoLogo -NoProfile -File tools/docs/test.ps1 -RequireNativeAot`

Independent review found no P0-P3 issues. PR #1902 overlaps the test and fingerprint files but no changed lines; its owner should regenerate the fingerprint block after rebasing.
