### PR TITLE
fix: require exact ByteRate types for equality

### DIFF
--- a/src/Humanizer/Bytes/ByteRate.cs
+++ b/src/Humanizer/Bytes/ByteRate.cs
@@ -128,10 +128,19 @@ public class ByteRate(ByteSize size, TimeSpan interval) :
 
     /// <summary>
     /// Compares this rate with another rate after normalizing both to bytes per second.
+    /// Rates with equal normalized values and different runtime types have distinct sort positions.
     /// </summary>
     /// <param name="other">The rate to compare with.</param>
-    public int CompareTo(ByteRate? other) =>
-        other is null ? 1 : BytesPerSecond.CompareTo(other.BytesPerSecond);
+    public int CompareTo(ByteRate? other)
+    {
+        if (other is null)
+            return 1;
+
+        var comparison = BytesPerSecond.CompareTo(other.BytesPerSecond);
+        return comparison != 0 || other.GetType() == GetType()
+            ? comparison
+            : string.CompareOrdinal(GetType().AssemblyQualifiedName, other.GetType().AssemblyQualifiedName);
+    }
 
     /// <inheritdoc />
     public bool Equals(ByteRate? other) =>

--- a/src/Humanizer/Bytes/ByteRate.cs
+++ b/src/Humanizer/Bytes/ByteRate.cs
@@ -128,7 +128,6 @@ public class ByteRate(ByteSize size, TimeSpan interval) :
 
     /// <summary>
     /// Compares this rate with another rate after normalizing both to bytes per second.
-    /// Rates with equal normalized values and different runtime types have distinct sort positions.
     /// </summary>
     /// <param name="other">The rate to compare with.</param>
     public int CompareTo(ByteRate? other)

--- a/src/Humanizer/Bytes/ByteRate.cs
+++ b/src/Humanizer/Bytes/ByteRate.cs
@@ -143,10 +143,16 @@ public class ByteRate(ByteSize size, TimeSpan interval) :
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Equality requires the other instance to have the same runtime type.
+    /// </remarks>
     public bool Equals(ByteRate? other) =>
         other?.GetType() == GetType() && BytesPerSecond.Equals(other.BytesPerSecond);
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Equality requires the other instance to have the same runtime type.
+    /// </remarks>
     public override bool Equals(object? obj) =>
         obj?.GetType() == GetType() && Equals((ByteRate)obj);
 

--- a/src/Humanizer/Bytes/ByteRate.cs
+++ b/src/Humanizer/Bytes/ByteRate.cs
@@ -135,11 +135,11 @@ public class ByteRate(ByteSize size, TimeSpan interval) :
 
     /// <inheritdoc />
     public bool Equals(ByteRate? other) =>
-        other is not null && BytesPerSecond.Equals(other.BytesPerSecond);
+        other?.GetType() == GetType() && BytesPerSecond.Equals(other.BytesPerSecond);
 
     /// <inheritdoc />
     public override bool Equals(object? obj) =>
-        obj is ByteRate other && Equals(other);
+        obj?.GetType() == GetType() && Equals((ByteRate)obj);
 
     /// <inheritdoc />
     public override int GetHashCode() =>

--- a/src/Humanizer/Bytes/ByteRate.cs
+++ b/src/Humanizer/Bytes/ByteRate.cs
@@ -137,9 +137,11 @@ public class ByteRate(ByteSize size, TimeSpan interval) :
             return 1;
 
         var comparison = BytesPerSecond.CompareTo(other.BytesPerSecond);
-        return comparison != 0 || other.GetType() == GetType()
+        var type = GetType();
+        var otherType = other.GetType();
+        return comparison != 0 || otherType == type
             ? comparison
-            : string.CompareOrdinal(GetType().AssemblyQualifiedName, other.GetType().AssemblyQualifiedName);
+            : type.TypeHandle.Value.ToInt64().CompareTo(otherType.TypeHandle.Value.ToInt64());
     }
 
     /// <inheritdoc />

--- a/tests/Humanizer.Tests/Bytes/ByteRateTests.cs
+++ b/tests/Humanizer.Tests/Bytes/ByteRateTests.cs
@@ -168,7 +168,7 @@ public class ByteRateTests
     }
 
     [Fact]
-    public void ObjectEqualityRequiresMatchingRuntimeTypes()
+    public void EqualityAndComparisonDistinguishRuntimeTypes()
     {
         var rate = ByteSize.FromBytes(400).Per(TimeSpan.FromSeconds(10));
         var derivedRate = new DerivedByteRate(ByteSize.FromBytes(800), TimeSpan.FromSeconds(20));
@@ -180,8 +180,14 @@ public class ByteRateTests
         Assert.False(EqualityComparer<ByteRate>.Default.Equals(derivedRate, rate));
         Assert.False(rate.Equals((object)derivedRate));
         Assert.False(derivedRate.Equals((object)rate));
+        var comparison = rate.CompareTo(derivedRate);
+        Assert.NotEqual(0, comparison);
+        Assert.Equal(-Math.Sign(comparison), Math.Sign(derivedRate.CompareTo(rate)));
+        Assert.Equal(comparison, ((IComparable)rate).CompareTo(derivedRate));
+        Assert.Equal(2, new SortedSet<ByteRate> { rate, derivedRate }.Count);
         Assert.True(derivedRate.Equals(equivalentDerivedRate));
         Assert.True(derivedRate.Equals((object)equivalentDerivedRate));
+        Assert.Equal(0, derivedRate.CompareTo(equivalentDerivedRate));
     }
 
     [Fact]

--- a/tests/Humanizer.Tests/Bytes/ByteRateTests.cs
+++ b/tests/Humanizer.Tests/Bytes/ByteRateTests.cs
@@ -1,3 +1,10 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.Loader;
+#endif
+
 [UseCulture("en")]
 public class ByteRateTests
 {
@@ -190,6 +197,50 @@ public class ByteRateTests
         Assert.Equal(0, derivedRate.CompareTo(equivalentDerivedRate));
     }
 
+#if NET8_0_OR_GREATER
+    [Fact]
+    [RequiresDynamicCode("Builds derived fixture types in isolated load contexts.")]
+    [RequiresUnreferencedCode("Activates dynamically emitted fixture types.")]
+    public void ComparisonDistinguishesEqualNamedTypesAcrossLoadContexts()
+    {
+        var firstContext = new SharedHumanizerLoadContext();
+        var secondContext = new SharedHumanizerLoadContext();
+        var thirdContext = new SharedHumanizerLoadContext();
+        try
+        {
+            var first = CreateDerivedRate(firstContext);
+            var second = CreateDerivedRate(secondContext);
+            var third = CreateDerivedRate(thirdContext);
+
+            Assert.NotSame(first.GetType(), second.GetType());
+            Assert.NotSame(second.GetType(), third.GetType());
+            Assert.Equal(first.GetType().AssemblyQualifiedName, second.GetType().AssemblyQualifiedName);
+            Assert.Equal(first.GetType().AssemblyQualifiedName, third.GetType().AssemblyQualifiedName);
+            Assert.Same(firstContext, AssemblyLoadContext.GetLoadContext(first.GetType().Assembly));
+            Assert.Same(secondContext, AssemblyLoadContext.GetLoadContext(second.GetType().Assembly));
+            Assert.Same(thirdContext, AssemblyLoadContext.GetLoadContext(third.GetType().Assembly));
+            Assert.False(first.Equals(second));
+
+            var comparison = first.CompareTo(second);
+            Assert.NotEqual(0, comparison);
+            Assert.Equal(-Math.Sign(comparison), Math.Sign(second.CompareTo(first)));
+
+            var rates = new[] { first, second, third };
+            Array.Sort(rates);
+            Assert.True(rates[0].CompareTo(rates[1]) < 0);
+            Assert.True(rates[1].CompareTo(rates[2]) < 0);
+            Assert.True(rates[0].CompareTo(rates[2]) < 0);
+            Assert.Equal(3, new SortedSet<ByteRate>(rates).Count);
+        }
+        finally
+        {
+            firstContext.Unload();
+            secondContext.Unload();
+            thirdContext.Unload();
+        }
+    }
+#endif
+
     [Fact]
     public void DoesNotEqualDifferentOrNullRates()
     {
@@ -226,6 +277,50 @@ public class ByteRateTests
 
         Assert.Throws<NotSupportedException>(() => dummyRate.Humanize(units));
     }
+
+#if NET8_0_OR_GREATER
+    [RequiresDynamicCode("Builds a derived fixture type in an isolated load context.")]
+    [RequiresUnreferencedCode("Activates a dynamically emitted fixture type.")]
+    static ByteRate CreateDerivedRate(AssemblyLoadContext context)
+    {
+        using var _ = context.EnterContextualReflection();
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new("Humanizer.ByteRate.LoadContextFixture"),
+            AssemblyBuilderAccess.RunAndCollect);
+        var type = assembly
+            .DefineDynamicModule("Main")
+            .DefineType(
+                "Humanizer.Tests.LoadContextByteRate",
+                TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed,
+                typeof(ByteRate));
+        var constructor = type.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.Standard,
+            [typeof(ByteSize), typeof(TimeSpan)]);
+        var generator = constructor.GetILGenerator();
+        generator.Emit(OpCodes.Ldarg_0);
+        generator.Emit(OpCodes.Ldarg_1);
+        generator.Emit(OpCodes.Ldarg_2);
+        generator.Emit(
+            OpCodes.Call,
+            typeof(ByteRate).GetConstructor([typeof(ByteSize), typeof(TimeSpan)])!);
+        generator.Emit(OpCodes.Ret);
+
+        var runtimeType = type.CreateType()!;
+        return (ByteRate)Activator.CreateInstance(
+            runtimeType,
+            ByteSize.FromBytes(400),
+            TimeSpan.FromSeconds(10))!;
+    }
+
+    sealed class SharedHumanizerLoadContext() : AssemblyLoadContext(isCollectible: true)
+    {
+        protected override Assembly? Load(AssemblyName assemblyName) =>
+            assemblyName.Name == typeof(ByteRate).Assembly.GetName().Name
+                ? typeof(ByteRate).Assembly
+                : null;
+    }
+#endif
 
     sealed class DerivedByteRate(ByteSize size, TimeSpan interval) : ByteRate(size, interval);
 }

--- a/tests/Humanizer.Tests/Bytes/ByteRateTests.cs
+++ b/tests/Humanizer.Tests/Bytes/ByteRateTests.cs
@@ -168,6 +168,23 @@ public class ByteRateTests
     }
 
     [Fact]
+    public void ObjectEqualityRequiresMatchingRuntimeTypes()
+    {
+        var rate = ByteSize.FromBytes(400).Per(TimeSpan.FromSeconds(10));
+        var derivedRate = new DerivedByteRate(ByteSize.FromBytes(800), TimeSpan.FromSeconds(20));
+        var equivalentDerivedRate = new DerivedByteRate(ByteSize.FromBytes(400), TimeSpan.FromSeconds(10));
+
+        Assert.False(rate.Equals(derivedRate));
+        Assert.False(derivedRate.Equals(rate));
+        Assert.False(EqualityComparer<ByteRate>.Default.Equals(rate, derivedRate));
+        Assert.False(EqualityComparer<ByteRate>.Default.Equals(derivedRate, rate));
+        Assert.False(rate.Equals((object)derivedRate));
+        Assert.False(derivedRate.Equals((object)rate));
+        Assert.True(derivedRate.Equals(equivalentDerivedRate));
+        Assert.True(derivedRate.Equals((object)equivalentDerivedRate));
+    }
+
+    [Fact]
     public void DoesNotEqualDifferentOrNullRates()
     {
         var rate = ByteSize.FromBytes(400).Per(TimeSpan.FromSeconds(10));
@@ -203,4 +220,6 @@ public class ByteRateTests
 
         Assert.Throws<NotSupportedException>(() => dummyRate.Humanize(units));
     }
+
+    sealed class DerivedByteRate(ByteSize size, TimeSpan interval) : ByteRate(size, interval);
 }


### PR DESCRIPTION
## Summary

`ByteRate` equality now requires matching runtime types across typed, generic, and object equality paths. This preserves the public class's inheritance surface while removing asymmetric base/derived equality.

Related: https://github.com/Humanizr/Humanizer/security/code-scanning/563

## Validation

- Equality regression proven failing against the prior implementation and passing after the fix
- Equal-name, three-`AssemblyLoadContext` comparison regression proven failing on the name-only tie-break and passing on the runtime-type identity fix
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 61,011 passed
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 61,011 passed
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 61,011 passed
- `dotnet build src/Humanizer/Humanizer.csproj --framework net48 -c Release --no-restore` — succeeded without warnings or errors
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — 0 of 2,821 files changed
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp>` — succeeded without warnings or errors
- `tests/verify-packages.ps1` — analyzer package entries and .NET 8 consumer load passed
- Independent exact-diff review — approved with no findings after all comparison, load-context, and documentation feedback was resolved

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] Copied-code disclosure is not applicable; no external code was copied
- [x] There are very few or no comments
- [x] XML documentation changes are not applicable; no public API surface was added or changed
- [x] This PR is based on the latest `main`
- [x] The related CodeQL alert is linked above
- [x] Readme changes are not applicable; documented feature behavior is unchanged
- [x] Applicable validation from `AGENTS.md` was run
