### PR TITLE
fix: make decimal marker boundaries explicit

### DIFF
--- a/src/Humanizer/Localisation/WordsToNumber/LocalizedWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/LocalizedWordsToDecimalNumberConverter.cs
@@ -269,11 +269,19 @@ internal sealed class LocalizedWordsToDecimalNumberConverter : IWordsToDecimalNu
             }
 
             var markerEnd = markerIndex + decimalMarker.Length;
-            if (allowsJoinedTokens ||
-                ((markerIndex == 0 || char.IsWhiteSpace(words[markerIndex - 1])) &&
-                 (markerEnd == words.Length || char.IsWhiteSpace(words[markerEnd]))))
+            if (allowsJoinedTokens)
             {
                 return markerIndex;
+            }
+
+            var startsAtTokenBoundary = markerIndex == 0 || char.IsWhiteSpace(words[markerIndex - 1]);
+            if (startsAtTokenBoundary)
+            {
+                var endsAtTokenBoundary = markerEnd == words.Length || char.IsWhiteSpace(words[markerEnd]);
+                if (endsAtTokenBoundary)
+                {
+                    return markerIndex;
+                }
             }
 
             startIndex = markerIndex + decimalMarker.Length;

--- a/src/Humanizer/Localisation/WordsToNumber/LocalizedWordsToDecimalNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/LocalizedWordsToDecimalNumberConverter.cs
@@ -268,6 +268,9 @@ internal sealed class LocalizedWordsToDecimalNumberConverter : IWordsToDecimalNu
                 return -1;
             }
 
+            if (markerIndex > words.Length - decimalMarker.Length)
+                return -1;
+
             var markerEnd = markerIndex + decimalMarker.Length;
             if (allowsJoinedTokens)
             {

--- a/tests/Humanizer.Tests/Localisation/en/WordsToDecimalNumberTests.cs
+++ b/tests/Humanizer.Tests/Localisation/en/WordsToDecimalNumberTests.cs
@@ -46,6 +46,8 @@ public class WordsToDecimalNumberTests
     [InlineData("one point 2", "2")]
     [InlineData("one dot two", "one dot two")]
     [InlineData("onepointtwo", "onepointtwo")]
+    [InlineData("onepoint two", "onepoint two")]
+    [InlineData("one pointtwo", "one pointtwo")]
     [InlineData("one point twothree", "twothree")]
     [InlineData("minusone point two", "minusone")]
     public void RejectsMalformedDecimalPhrases(string words, string expectedUnrecognizedWord)
@@ -106,6 +108,26 @@ public class WordsToDecimalNumberTests
             " \t ",
             [],
             []));
+
+    [Fact]
+    public void EmbeddedIgnorableMarkerPreservesBoundaryShortCircuit()
+    {
+        const string words = "xm";
+        const string marker = "m\u00AD";
+        Assert.Equal(1, CultureInfo.CurrentCulture.CompareInfo.IndexOf(
+            words,
+            marker,
+            CompareOptions.IgnoreCase));
+        var converter = new LocalizedWordsToDecimalNumberConverter(
+            CultureInfo.CurrentCulture,
+            marker,
+            [],
+            []);
+
+        Assert.False(converter.TryConvert(words, out var parsed, out var unrecognizedNumber));
+        Assert.Equal(0m, parsed);
+        Assert.Equal(words, unrecognizedNumber);
+    }
 
     [Fact]
     public void RejectsFractionBeyondDecimalScale()

--- a/tests/Humanizer.Tests/Localisation/en/WordsToDecimalNumberTests.cs
+++ b/tests/Humanizer.Tests/Localisation/en/WordsToDecimalNumberTests.cs
@@ -109,17 +109,20 @@ public class WordsToDecimalNumberTests
             [],
             []));
 
-    [Fact]
-    public void EmbeddedIgnorableMarkerPreservesBoundaryShortCircuit()
+    [Theory]
+    [InlineData("en-US", "xm", 1)]
+    [InlineData("en-US", "x m", 2)]
+    [InlineData("zh-CN", "xm", 1)]
+    public void EmbeddedIgnorableMarkerDoesNotReadPastInput(string cultureName, string words, int expectedIndex)
     {
-        const string words = "xm";
+        var culture = CultureInfo.GetCultureInfo(cultureName);
         const string marker = "m\u00AD";
-        Assert.Equal(1, CultureInfo.CurrentCulture.CompareInfo.IndexOf(
+        Assert.Equal(expectedIndex, culture.CompareInfo.IndexOf(
             words,
             marker,
             CompareOptions.IgnoreCase));
         var converter = new LocalizedWordsToDecimalNumberConverter(
-            CultureInfo.CurrentCulture,
+            culture,
             marker,
             [],
             []);


### PR DESCRIPTION
## Summary

Decimal-marker parsing now makes joined-token and token-boundary decisions explicit, clearing CodeQL #769 without changing accepted phrases or adding allocations. The ordered checks preserve culture-sensitive `CompareInfo` short-circuiting, including ignorable-character matches whose nominal marker extends past the source. Focused regressions cover each boundary independently and the soft-hyphen case that caught an eager-evaluation bug during review.

Related: [CodeQL alert #769](https://github.com/Humanizr/Humanizer/security/code-scanning/769)

## Validation

- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 61,014 passed
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 61,014 passed
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 61,014 passed
- `dotnet build src/Humanizer/Humanizer.csproj --framework net48 --configuration Release` — 0 warnings, 0 errors
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — 0 of 2,821 files changed
- Release pack and `tests/verify-packages.ps1` — passed
- Independent exact-diff review — approved after resolving the short-circuit finding

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. No copied code is used.
- [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
- [x] Xml documentation is added/updated for the addition/change. Not applicable: no public API changed.
- [ ] Your PR is (re)based on top of the latest commits from the `main` branch. Main advanced after exact-head review via unrelated source-generator PR #1907; this reviewed head is intentionally preserved unless branch protection requires an update.
- [x] Link to the issue(s) you're fixing from your PR description. The related CodeQL alert is linked above; there is no GitHub issue.
- [x] Readme is updated if you change an existing feature or add a new one. Not applicable: behavior and public APIs are unchanged.
- [x] Run the applicable validation from `AGENTS.md`; documentation changes include the documentation gates
