### PR TITLE
fix(generator): filter invalid canonical entries

### DIFF
--- a/src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs
+++ b/src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs
@@ -55,14 +55,11 @@ public sealed partial class HumanizerSourceGenerator
         {
             var root = SimpleYamlParser.Parse(fileText);
 
-            foreach (var property in root.Values.Keys)
+            foreach (var property in root.Values.Keys.Where(static property => !SupportedTopLevelNames.Contains(property, StringComparer.Ordinal)))
             {
-                if (!SupportedTopLevelNames.Contains(property, StringComparer.Ordinal))
-                {
-                    throw new InvalidOperationException(
-                        $"Locale '{localeCode}' defines unsupported top-level property '{property}'. " +
-                        $"Supported properties: {string.Join(", ", SupportedTopLevelNames)}.");
-                }
+                throw new InvalidOperationException(
+                    $"Locale '{localeCode}' defines unsupported top-level property '{property}'. " +
+                    $"Supported properties: {string.Join(", ", SupportedTopLevelNames)}.");
             }
 
             var declaredLocale = root.GetScalar("locale")
@@ -213,13 +210,10 @@ public sealed partial class HumanizerSourceGenerator
             SimpleYamlMapping numberSurface,
             ImmutableDictionary<string, SimpleYamlValue>.Builder features)
         {
-            foreach (var property in numberSurface.Values.Keys)
+            foreach (var property in numberSurface.Values.Keys.Where(static property => property is not ("words" or "parse" or "formatting")))
             {
-                if (property is not ("words" or "parse" or "formatting"))
-                {
-                    throw new InvalidOperationException(
-                        $"Locale '{localeCode}.surfaces.number' defines unsupported property '{property}'. Supported properties: words, parse, formatting.");
-                }
+                throw new InvalidOperationException(
+                    $"Locale '{localeCode}.surfaces.number' defines unsupported property '{property}'. Supported properties: words, parse, formatting.");
             }
 
             if (numberSurface.TryGetValue("words", out var wordsValue))
@@ -259,13 +253,10 @@ public sealed partial class HumanizerSourceGenerator
 
         static void ValidateNumberFormattingBlock(string localeCode, SimpleYamlMapping formatting)
         {
-            foreach (var property in formatting.Values.Keys)
+            foreach (var property in formatting.Values.Keys.Where(static property => property is not ("decimalSeparator" or "negativeSign" or "groupSeparator")))
             {
-                if (property is not ("decimalSeparator" or "negativeSign" or "groupSeparator"))
-                {
-                    throw new InvalidOperationException(
-                        $"Locale '{localeCode}.surfaces.number.formatting' defines unsupported property '{property}'. Supported properties: decimalSeparator, negativeSign, groupSeparator.");
-                }
+                throw new InvalidOperationException(
+                    $"Locale '{localeCode}.surfaces.number.formatting' defines unsupported property '{property}'. Supported properties: decimalSeparator, negativeSign, groupSeparator.");
             }
 
             ValidateOptionalFormattingProperty(localeCode, formatting, "decimalSeparator");
@@ -304,13 +295,10 @@ public sealed partial class HumanizerSourceGenerator
             SimpleYamlMapping ordinalSurface,
             ImmutableDictionary<string, SimpleYamlValue>.Builder features)
         {
-            foreach (var property in ordinalSurface.Values.Keys)
+            foreach (var property in ordinalSurface.Values.Keys.Where(static property => property is not ("numeric" or "date" or "dateOnly")))
             {
-                if (property is not ("numeric" or "date" or "dateOnly"))
-                {
-                    throw new InvalidOperationException(
-                        $"Locale '{localeCode}.surfaces.ordinal' defines unsupported property '{property}'. Supported properties: numeric, date, dateOnly.");
-                }
+                throw new InvalidOperationException(
+                    $"Locale '{localeCode}.surfaces.ordinal' defines unsupported property '{property}'. Supported properties: numeric, date, dateOnly.");
             }
 
             if (ordinalSurface.TryGetValue("numeric", out var numericValue))
@@ -352,13 +340,10 @@ public sealed partial class HumanizerSourceGenerator
             SimpleYamlMapping calendarSurface,
             ImmutableDictionary<string, SimpleYamlValue>.Builder features)
         {
-            foreach (var property in calendarSurface.Values.Keys)
+            foreach (var property in calendarSurface.Values.Keys.Where(static property => property is not ("months" or "monthsGenitive" or "hijriMonths")))
             {
-                if (property is not ("months" or "monthsGenitive" or "hijriMonths"))
-                {
-                    throw new InvalidOperationException(
-                        $"Locale '{localeCode}.surfaces.calendar' defines unsupported property '{property}'. Supported properties: months, monthsGenitive, hijriMonths.");
-                }
+                throw new InvalidOperationException(
+                    $"Locale '{localeCode}.surfaces.calendar' defines unsupported property '{property}'. Supported properties: months, monthsGenitive, hijriMonths.");
             }
 
             var hasMonths = calendarSurface.TryGetValue("months", out var monthsValue);
@@ -370,13 +355,10 @@ public sealed partial class HumanizerSourceGenerator
                         $"Locale '{localeCode}.surfaces.calendar.months' must be a sequence of exactly 12 strings.");
                 }
 
-                foreach (var item in monthsSeq.Items)
+                foreach (var item in monthsSeq.Items.Where(static item => item is not SimpleYamlScalar))
                 {
-                    if (item is not SimpleYamlScalar)
-                    {
-                        throw new InvalidOperationException(
-                            $"Locale '{localeCode}.surfaces.calendar.months' items must be scalar strings.");
-                    }
+                    throw new InvalidOperationException(
+                        $"Locale '{localeCode}.surfaces.calendar.months' items must be scalar strings.");
                 }
             }
 
@@ -394,13 +376,10 @@ public sealed partial class HumanizerSourceGenerator
                         $"Locale '{localeCode}.surfaces.calendar.monthsGenitive' must be a sequence of exactly 12 strings.");
                 }
 
-                foreach (var item in genitiveSeq.Items)
+                foreach (var item in genitiveSeq.Items.Where(static item => item is not SimpleYamlScalar))
                 {
-                    if (item is not SimpleYamlScalar)
-                    {
-                        throw new InvalidOperationException(
-                            $"Locale '{localeCode}.surfaces.calendar.monthsGenitive' items must be scalar strings.");
-                    }
+                    throw new InvalidOperationException(
+                        $"Locale '{localeCode}.surfaces.calendar.monthsGenitive' items must be scalar strings.");
                 }
             }
 
@@ -566,13 +545,10 @@ public sealed partial class HumanizerSourceGenerator
         public static string ConvertToCanonicalYaml(string localeCode, string fileText)
         {
             var root = SimpleYamlParser.Parse(fileText);
-            foreach (var property in root.Values.Keys)
+            foreach (var property in root.Values.Keys.Where(static property => !LegacyTopLevelNames.Contains(property, StringComparer.Ordinal)))
             {
-                if (!LegacyTopLevelNames.Contains(property, StringComparer.Ordinal))
-                {
-                    throw new InvalidOperationException(
-                        $"Legacy locale '{localeCode}' defines unsupported top-level property '{property}'.");
-                }
+                throw new InvalidOperationException(
+                    $"Legacy locale '{localeCode}' defines unsupported top-level property '{property}'.");
             }
 
             var builder = new StringBuilder();

--- a/website/docs/contributing/locale-yaml-reference.mdx
+++ b/website/docs/contributing/locale-yaml-reference.mdx
@@ -167,7 +167,7 @@ These are the main files that turn locale YAML into runtime behavior:
    - shared runtime kernels
 
 <!-- humanizer-locale-reference-fingerprint:v1
-src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs c57968b32dd3b175cf0a90d3330781dce69af43d230090a708e4ee390331fee8
+src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs 43a693a396ee247a9a54cab6c61372462b925c21088ec9ace38709406b476a43
 src/Humanizer.SourceGenerators/Common/DurationCaseModels.cs ec2340b7af9e2353af43fb40de3eac0be7e00ae68ac927ea6ff8acaf3a4d35be
 src/Humanizer.SourceGenerators/Common/EngineContractCatalog.cs caf48277eaacf6409eec0a8541b49ec4974fcaaab53b561a5f8c7e67506658da
 src/Humanizer.SourceGenerators/Common/EngineContractModels.cs ed56aeb32417c9f8896f72ec5627422ca364e25386cef72fb69ac64123379feb


### PR DESCRIPTION
## Summary
- filter unsupported canonical schema keys before reporting the first validation error
- filter non-scalar calendar items before reporting their unchanged diagnostics
- apply the same fail-fast filter to legacy top-level validation
- update the reviewed generator-source fingerprint

Closes CodeQL alerts #374, #386, #387, #416, #419, #420, #440, and #441.

All sequences retain source order, so the first invalid entry and exact exception message remain unchanged. Generated contracts and incremental dependencies are unchanged; existing canonical-schema tests cover these rejection paths.

## Validation
- `dotnet test tests/Humanizer.SourceGenerators.Tests/Humanizer.SourceGenerators.Tests.csproj --framework net10.0` (159 passed)
- `dotnet test tests/Humanizer.SourceGenerators.Tests/Humanizer.SourceGenerators.Tests.csproj --framework net11.0` (159 passed)
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
- `pwsh -NoLogo -NoProfile -File tools/docs/build.ps1 -Mode Validate`
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp>`
- `pwsh -NoLogo -NoProfile -File tests/verify-packages.ps1 ...`

## Coordination
PR #1902 has no production overlap with `CanonicalLocaleAuthoring.cs`. It changes distinct hunks in `CanonicalLocaleSchemaTests.cs` and shares the generated fingerprint document; its owner must regenerate the complete fingerprint block after rebasing.