### PR TITLE
fix(generator): filter formatter grammar properties

### DIFF
--- a/src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs
+++ b/src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs
@@ -51,6 +51,17 @@ public sealed partial class HumanizerSourceGenerator
             "inflection"
         ];
 
+        static readonly string[] FormatterGrammarPropertyNames =
+        [
+            "pluralRule",
+            "casePluralRule",
+            "dataUnitPluralRule",
+            "dataUnitNonIntegralForm",
+            "prepositionMode",
+            "secondaryPlaceholderMode",
+            "timeUnitGenders"
+        ];
+
         internal static CanonicalLocaleDocument Parse(string localeCode, string fileText)
         {
             var root = SimpleYamlParser.Parse(fileText);
@@ -144,21 +155,9 @@ public sealed partial class HumanizerSourceGenerator
                     case "formatter":
                         features["formatter"] = surfaceMapping;
                         var grammar = ImmutableDictionary.CreateBuilder<string, SimpleYamlValue>(StringComparer.Ordinal);
-                        foreach (var propertyName in new[]
+                        foreach (var propertyName in FormatterGrammarPropertyNames.Where(surfaceMapping.Values.ContainsKey))
                         {
-                            "pluralRule",
-                            "casePluralRule",
-                            "dataUnitPluralRule",
-                            "dataUnitNonIntegralForm",
-                            "prepositionMode",
-                            "secondaryPlaceholderMode",
-                            "timeUnitGenders"
-                        })
-                        {
-                            if (surfaceMapping.TryGetValue(propertyName, out var propertyValue))
-                            {
-                                grammar[propertyName] = propertyValue;
-                            }
+                            grammar[propertyName] = surfaceMapping.Values[propertyName];
                         }
 
                         if (grammar.Count > 0)

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/CanonicalLocaleSchemaTests.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/CanonicalLocaleSchemaTests.cs
@@ -299,6 +299,10 @@ surfaces:
         Assert.Equal("conjunction", baseLocale.CollectionFormatter!.Kind);
         Assert.Equal("and", baseLocale.CollectionFormatter.Argument);
         Assert.Equal("russian", baseLocale.Grammar!.GetScalar("pluralRule"));
+        Assert.Equal("russian", baseLocale.Grammar.GetScalar("dataUnitPluralRule"));
+        var timeUnitGenders = Assert.IsType<HumanizerSourceGenerator.SimpleYamlMapping>(baseLocale.Grammar.Values["timeUnitGenders"]);
+        Assert.Equal("feminine", timeUnitGenders.GetScalar("hour"));
+        Assert.False(baseLocale.Grammar.Values.ContainsKey("engine"));
         Assert.Equal("russian", GetRequiredString(baseLocale.Formatter!, "pluralRule"));
         Assert.Equal("profiled", GetRequiredString(baseLocale.Formatter!, "engine"));
         Assert.Equal("conjunctional-scale", GetRequiredString(baseLocale.NumberToWords!, "engine"));

--- a/website/docs/contributing/locale-yaml-reference.mdx
+++ b/website/docs/contributing/locale-yaml-reference.mdx
@@ -167,7 +167,7 @@ These are the main files that turn locale YAML into runtime behavior:
    - shared runtime kernels
 
 <!-- humanizer-locale-reference-fingerprint:v1
-src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs c57968b32dd3b175cf0a90d3330781dce69af43d230090a708e4ee390331fee8
+src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs bac77a4d7a8f9199bc506b1d0e4689d4c6da3cc994dbcd21f18f9beaf7f30ef1
 src/Humanizer.SourceGenerators/Common/DurationCaseModels.cs ec2340b7af9e2353af43fb40de3eac0be7e00ae68ac927ea6ff8acaf3a4d35be
 src/Humanizer.SourceGenerators/Common/EngineContractCatalog.cs caf48277eaacf6409eec0a8541b49ec4974fcaaab53b561a5f8c7e67506658da
 src/Humanizer.SourceGenerators/Common/EngineContractModels.cs ed56aeb32417c9f8896f72ec5627422ca364e25386cef72fb69ac64123379feb


### PR DESCRIPTION
## Summary
- keep the fixed formatter-to-grammar property list in one reusable private array
- filter that list by formatter membership before copying values
- assert nested grammar properties survive while non-grammar formatter keys stay excluded
- update the reviewed generator-source fingerprint

Closes CodeQL alert #766.

Property order and values are unchanged. Generated contracts and incremental dependencies are unchanged.

## Validation
- targeted canonical surface test on net10.0 and net11.0 (1 passed each)
- full source-generator suite on net10.0 and net11.0 (159 passed each)
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
- `pwsh -NoLogo -NoProfile -File tools/docs/build.ps1 -Mode Validate`
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp>`
- `pwsh -NoLogo -NoProfile -File tests/verify-packages.ps1 ...`

## Coordination
PR #1902 has no production overlap with `CanonicalLocaleAuthoring.cs`; it has distinct test hunks in `CanonicalLocaleSchemaTests.cs` and shares the fingerprint document. Its owner must rebase and regenerate the complete fingerprint block.