### PR TITLE
fix(generator): filter invalid canonical entries

### DIFF
--- a/src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs
+++ b/src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs
@@ -51,18 +51,26 @@ public sealed partial class HumanizerSourceGenerator
             "inflection"
         ];
 
+        static readonly string[] FormatterGrammarPropertyNames =
+        [
+            "pluralRule",
+            "casePluralRule",
+            "dataUnitPluralRule",
+            "dataUnitNonIntegralForm",
+            "prepositionMode",
+            "secondaryPlaceholderMode",
+            "timeUnitGenders"
+        ];
+
         internal static CanonicalLocaleDocument Parse(string localeCode, string fileText)
         {
             var root = SimpleYamlParser.Parse(fileText);
 
-            foreach (var property in root.Values.Keys)
+            foreach (var property in root.Values.Keys.Where(static property => !SupportedTopLevelNames.Contains(property, StringComparer.Ordinal)))
             {
-                if (!SupportedTopLevelNames.Contains(property, StringComparer.Ordinal))
-                {
-                    throw new InvalidOperationException(
-                        $"Locale '{localeCode}' defines unsupported top-level property '{property}'. " +
-                        $"Supported properties: {string.Join(", ", SupportedTopLevelNames)}.");
-                }
+                throw new InvalidOperationException(
+                    $"Locale '{localeCode}' defines unsupported top-level property '{property}'. " +
+                    $"Supported properties: {string.Join(", ", SupportedTopLevelNames)}.");
             }
 
             var declaredLocale = root.GetScalar("locale")
@@ -144,21 +152,9 @@ public sealed partial class HumanizerSourceGenerator
                     case "formatter":
                         features["formatter"] = surfaceMapping;
                         var grammar = ImmutableDictionary.CreateBuilder<string, SimpleYamlValue>(StringComparer.Ordinal);
-                        foreach (var propertyName in new[]
+                        foreach (var propertyName in FormatterGrammarPropertyNames.Where(surfaceMapping.Values.ContainsKey))
                         {
-                            "pluralRule",
-                            "casePluralRule",
-                            "dataUnitPluralRule",
-                            "dataUnitNonIntegralForm",
-                            "prepositionMode",
-                            "secondaryPlaceholderMode",
-                            "timeUnitGenders"
-                        })
-                        {
-                            if (surfaceMapping.TryGetValue(propertyName, out var propertyValue))
-                            {
-                                grammar[propertyName] = propertyValue;
-                            }
+                            grammar[propertyName] = surfaceMapping.Values[propertyName];
                         }
 
                         if (grammar.Count > 0)
@@ -213,13 +209,10 @@ public sealed partial class HumanizerSourceGenerator
             SimpleYamlMapping numberSurface,
             ImmutableDictionary<string, SimpleYamlValue>.Builder features)
         {
-            foreach (var property in numberSurface.Values.Keys)
+            foreach (var property in numberSurface.Values.Keys.Where(static property => property is not ("words" or "parse" or "formatting")))
             {
-                if (property is not ("words" or "parse" or "formatting"))
-                {
-                    throw new InvalidOperationException(
-                        $"Locale '{localeCode}.surfaces.number' defines unsupported property '{property}'. Supported properties: words, parse, formatting.");
-                }
+                throw new InvalidOperationException(
+                    $"Locale '{localeCode}.surfaces.number' defines unsupported property '{property}'. Supported properties: words, parse, formatting.");
             }
 
             if (numberSurface.TryGetValue("words", out var wordsValue))
@@ -259,13 +252,10 @@ public sealed partial class HumanizerSourceGenerator
 
         static void ValidateNumberFormattingBlock(string localeCode, SimpleYamlMapping formatting)
         {
-            foreach (var property in formatting.Values.Keys)
+            foreach (var property in formatting.Values.Keys.Where(static property => property is not ("decimalSeparator" or "negativeSign" or "groupSeparator")))
             {
-                if (property is not ("decimalSeparator" or "negativeSign" or "groupSeparator"))
-                {
-                    throw new InvalidOperationException(
-                        $"Locale '{localeCode}.surfaces.number.formatting' defines unsupported property '{property}'. Supported properties: decimalSeparator, negativeSign, groupSeparator.");
-                }
+                throw new InvalidOperationException(
+                    $"Locale '{localeCode}.surfaces.number.formatting' defines unsupported property '{property}'. Supported properties: decimalSeparator, negativeSign, groupSeparator.");
             }
 
             ValidateOptionalFormattingProperty(localeCode, formatting, "decimalSeparator");
@@ -304,13 +294,10 @@ public sealed partial class HumanizerSourceGenerator
             SimpleYamlMapping ordinalSurface,
             ImmutableDictionary<string, SimpleYamlValue>.Builder features)
         {
-            foreach (var property in ordinalSurface.Values.Keys)
+            foreach (var property in ordinalSurface.Values.Keys.Where(static property => property is not ("numeric" or "date" or "dateOnly")))
             {
-                if (property is not ("numeric" or "date" or "dateOnly"))
-                {
-                    throw new InvalidOperationException(
-                        $"Locale '{localeCode}.surfaces.ordinal' defines unsupported property '{property}'. Supported properties: numeric, date, dateOnly.");
-                }
+                throw new InvalidOperationException(
+                    $"Locale '{localeCode}.surfaces.ordinal' defines unsupported property '{property}'. Supported properties: numeric, date, dateOnly.");
             }
 
             if (ordinalSurface.TryGetValue("numeric", out var numericValue))
@@ -352,13 +339,10 @@ public sealed partial class HumanizerSourceGenerator
             SimpleYamlMapping calendarSurface,
             ImmutableDictionary<string, SimpleYamlValue>.Builder features)
         {
-            foreach (var property in calendarSurface.Values.Keys)
+            foreach (var property in calendarSurface.Values.Keys.Where(static property => property is not ("months" or "monthsGenitive" or "hijriMonths")))
             {
-                if (property is not ("months" or "monthsGenitive" or "hijriMonths"))
-                {
-                    throw new InvalidOperationException(
-                        $"Locale '{localeCode}.surfaces.calendar' defines unsupported property '{property}'. Supported properties: months, monthsGenitive, hijriMonths.");
-                }
+                throw new InvalidOperationException(
+                    $"Locale '{localeCode}.surfaces.calendar' defines unsupported property '{property}'. Supported properties: months, monthsGenitive, hijriMonths.");
             }
 
             var hasMonths = calendarSurface.TryGetValue("months", out var monthsValue);
@@ -370,13 +354,10 @@ public sealed partial class HumanizerSourceGenerator
                         $"Locale '{localeCode}.surfaces.calendar.months' must be a sequence of exactly 12 strings.");
                 }
 
-                foreach (var item in monthsSeq.Items)
+                if (monthsSeq.Items.Any(static item => item is not SimpleYamlScalar))
                 {
-                    if (item is not SimpleYamlScalar)
-                    {
-                        throw new InvalidOperationException(
-                            $"Locale '{localeCode}.surfaces.calendar.months' items must be scalar strings.");
-                    }
+                    throw new InvalidOperationException(
+                        $"Locale '{localeCode}.surfaces.calendar.months' items must be scalar strings.");
                 }
             }
 
@@ -394,13 +375,10 @@ public sealed partial class HumanizerSourceGenerator
                         $"Locale '{localeCode}.surfaces.calendar.monthsGenitive' must be a sequence of exactly 12 strings.");
                 }
 
-                foreach (var item in genitiveSeq.Items)
+                if (genitiveSeq.Items.Any(static item => item is not SimpleYamlScalar))
                 {
-                    if (item is not SimpleYamlScalar)
-                    {
-                        throw new InvalidOperationException(
-                            $"Locale '{localeCode}.surfaces.calendar.monthsGenitive' items must be scalar strings.");
-                    }
+                    throw new InvalidOperationException(
+                        $"Locale '{localeCode}.surfaces.calendar.monthsGenitive' items must be scalar strings.");
                 }
             }
 
@@ -566,13 +544,10 @@ public sealed partial class HumanizerSourceGenerator
         public static string ConvertToCanonicalYaml(string localeCode, string fileText)
         {
             var root = SimpleYamlParser.Parse(fileText);
-            foreach (var property in root.Values.Keys)
+            foreach (var property in root.Values.Keys.Where(static property => !LegacyTopLevelNames.Contains(property, StringComparer.Ordinal)))
             {
-                if (!LegacyTopLevelNames.Contains(property, StringComparer.Ordinal))
-                {
-                    throw new InvalidOperationException(
-                        $"Legacy locale '{localeCode}' defines unsupported top-level property '{property}'.");
-                }
+                throw new InvalidOperationException(
+                    $"Legacy locale '{localeCode}' defines unsupported top-level property '{property}'.");
             }
 
             var builder = new StringBuilder();

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/CanonicalLocaleSchemaTests.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/CanonicalLocaleSchemaTests.cs
@@ -299,6 +299,10 @@ surfaces:
         Assert.Equal("conjunction", baseLocale.CollectionFormatter!.Kind);
         Assert.Equal("and", baseLocale.CollectionFormatter.Argument);
         Assert.Equal("russian", baseLocale.Grammar!.GetScalar("pluralRule"));
+        Assert.Equal("russian", baseLocale.Grammar.GetScalar("dataUnitPluralRule"));
+        var timeUnitGenders = Assert.IsType<HumanizerSourceGenerator.SimpleYamlMapping>(baseLocale.Grammar.Values["timeUnitGenders"]);
+        Assert.Equal("feminine", timeUnitGenders.GetScalar("hour"));
+        Assert.False(baseLocale.Grammar.Values.ContainsKey("engine"));
         Assert.Equal("russian", GetRequiredString(baseLocale.Formatter!, "pluralRule"));
         Assert.Equal("profiled", GetRequiredString(baseLocale.Formatter!, "engine"));
         Assert.Equal("conjunctional-scale", GetRequiredString(baseLocale.NumberToWords!, "engine"));

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/CanonicalLocaleSchemaTests.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/CanonicalLocaleSchemaTests.cs
@@ -298,11 +298,12 @@ surfaces:
 
         Assert.Equal("conjunction", baseLocale.CollectionFormatter!.Kind);
         Assert.Equal("and", baseLocale.CollectionFormatter.Argument);
-        Assert.Equal("russian", baseLocale.Grammar!.GetScalar("pluralRule"));
-        Assert.Equal("russian", baseLocale.Grammar.GetScalar("dataUnitPluralRule"));
-        var timeUnitGenders = Assert.IsType<HumanizerSourceGenerator.SimpleYamlMapping>(baseLocale.Grammar.Values["timeUnitGenders"]);
+        var grammar = Assert.IsType<HumanizerSourceGenerator.SimpleYamlMapping>(baseLocale.Grammar);
+        Assert.Equal("russian", grammar.GetScalar("pluralRule"));
+        Assert.Equal("russian", grammar.GetScalar("dataUnitPluralRule"));
+        var timeUnitGenders = Assert.IsType<HumanizerSourceGenerator.SimpleYamlMapping>(grammar.Values["timeUnitGenders"]);
         Assert.Equal("feminine", timeUnitGenders.GetScalar("hour"));
-        Assert.False(baseLocale.Grammar.Values.ContainsKey("engine"));
+        Assert.False(grammar.Values.ContainsKey("engine"));
         Assert.Equal("russian", GetRequiredString(baseLocale.Formatter!, "pluralRule"));
         Assert.Equal("profiled", GetRequiredString(baseLocale.Formatter!, "engine"));
         Assert.Equal("conjunctional-scale", GetRequiredString(baseLocale.NumberToWords!, "engine"));

--- a/website/docs/contributing/locale-yaml-reference.mdx
+++ b/website/docs/contributing/locale-yaml-reference.mdx
@@ -167,7 +167,7 @@ These are the main files that turn locale YAML into runtime behavior:
    - shared runtime kernels
 
 <!-- humanizer-locale-reference-fingerprint:v1
-src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs c57968b32dd3b175cf0a90d3330781dce69af43d230090a708e4ee390331fee8
+src/Humanizer.SourceGenerators/Common/CanonicalLocaleAuthoring.cs 9ca98923044b4ae2900b14eee1dfc5cda1974a04ac8a584cca7f4d293e918200
 src/Humanizer.SourceGenerators/Common/DurationCaseModels.cs ec2340b7af9e2353af43fb40de3eac0be7e00ae68ac927ea6ff8acaf3a4d35be
 src/Humanizer.SourceGenerators/Common/EngineContractCatalog.cs caf48277eaacf6409eec0a8541b49ec4974fcaaab53b561a5f8c7e67506658da
 src/Humanizer.SourceGenerators/Common/EngineContractModels.cs ed56aeb32417c9f8896f72ec5627422ca364e25386cef72fb69ac64123379feb


### PR DESCRIPTION
## Summary
- filter unsupported canonical schema keys before reporting the first validation error
- use short-circuit scalar validation for month sequences
- filter formatter properties into the grammar projection through one reusable fixed key list
- preserve nested grammar values while excluding formatter-only keys
- update the complete reviewed generator-source fingerprint on current main

Closes CodeQL alerts #374, #386, #387, #416, #419, #420, #440, #441, and #766. Supersedes safety-closed PRs #1913 and #1914.

Source order, first-invalid diagnostics, grammar property order/values, generated contracts, and incremental dependencies are unchanged.

## Validation
- canonical schema tests on net10.0 and net11.0 (58 passed each)
- full source-generator suite on net10.0 and net11.0 (159 passed each)
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
- `pwsh -NoLogo -NoProfile -File tools/docs/build.ps1 -Mode Validate`
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o <temp>`
- `pwsh -NoLogo -NoProfile -File tests/verify-packages.ps1 ...`

## Coordination
Head is based on exact main `6a16ff1aa1f15f1cd5fa5f0d6e1331604a54a16d` and includes accepted #1911/#1912 fingerprints. Live PR #1902 has no production overlap with `CanonicalLocaleAuthoring.cs`; shared test/docs hunks are distinct, and #1902 must regenerate its complete fingerprint block after rebasing.