### PR TITLE
perf: remove linked-vigesimal parser allocations

### DIFF
--- a/src/Humanizer/Localisation/WordsToNumber/LinkedVigesimalWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/LinkedVigesimalWordsToNumberConverter.cs
@@ -210,10 +210,12 @@ internal class LinkedVigesimalWordsToNumberConverter(LinkedVigesimalWordsToNumbe
     {
         for (var index = start; index < end; index++)
         {
-            foreach (var scale in profile.TokenizedScales.Where(scale => (ulong)scale.Value < parentScaleValue))
+            for (var scaleIndex = 0; scaleIndex < profile.TokenizedScales.Length; scaleIndex++)
             {
-                if (TryMatchTokenPhrase(tokens, index, end, scale.NameTokens, out _) ||
-                    TryMatchTokenPhrase(tokens, index, end, scale.NameWithRemainderTokens, out _))
+                var scale = profile.TokenizedScales[scaleIndex];
+                if ((ulong)scale.Value < parentScaleValue &&
+                    (TryMatchTokenPhrase(tokens, index, end, scale.NameTokens, out _) ||
+                     TryMatchTokenPhrase(tokens, index, end, scale.NameWithRemainderTokens, out _)))
                 {
                     return index;
                 }
@@ -226,9 +228,11 @@ internal class LinkedVigesimalWordsToNumberConverter(LinkedVigesimalWordsToNumbe
     bool TryParseExact(string[] tokens, int start, int end, ulong maxValue, out ulong value, out int next)
     {
         var lastCandidateEnd = Math.Min(end, start + profile.MaximumExactTokenCount);
-        foreach (var candidate in profile.MultiTokenExactWords.Where(candidate => start + candidate.Tokens.Length <= lastCandidateEnd))
+        for (var candidateIndex = 0; candidateIndex < profile.MultiTokenExactWords.Length; candidateIndex++)
         {
-            if (candidate.Value >= 0 &&
+            var candidate = profile.MultiTokenExactWords[candidateIndex];
+            if (start + candidate.Tokens.Length <= lastCandidateEnd &&
+                candidate.Value >= 0 &&
                 (ulong)candidate.Value <= maxValue &&
                 TryMatchTokenPhrase(tokens, start, end, candidate.Tokens, out next))
             {


### PR DESCRIPTION
## Summary

- replace two captured LINQ scans over immutable profile arrays with direct indexed loops
- preserve longest-first matching, scale ordering, bounds, and short-circuit behavior
- remove stable per-parse iterator/delegate allocations

Resolves CodeQL library alerts [#557](https://github.com/Humanizr/Humanizer/security/code-scanning/557) and [#558](https://github.com/Humanizr/Humanizer/security/code-scanning/558).

## Validation

- owning LinkedVigesimal/Welsh/Yoruba tests: 183/183 on net8.0, net10.0, and net11.0
- full `Humanizer.Tests`: 61,016/61,016 on net8.0, net10.0, and net11.0
- public-path A/B on net8/net10/net11 preserved exact outputs and reduced allocations:
  - Yoruba boundary: 3,808 to 1,800 B/op (-52.73%)
  - Yoruba composite: 1,304 to 744 B/op (-42.94%)
  - Welsh exact phrase: 592 to 440 B/op (-25.68%)
- net48 Release build: 0 warnings, 0 errors
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`: 0/2,821 files changed
- docs manifest/current/historical validation passed
- docs runtime, snapshot, trimmed, and native-AOT validation passed
- Release pack succeeded
- `tests/verify-packages.ps1` passed
- independent read-only allocation and code reviews: approved with no blocking findings

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] Existing owning tests cover the behavior-preserving loop rewrite
- [x] No code was copied from StackOverflow, a blog, or OSS
- [x] No comments or public APIs changed
- [x] Based on live `main` at branch creation (`5cb5e3d987ea3e7ace96dba9b56e73db8ba6e5bf`)
- [x] Later `main` change #1917 touches only source-generator tests/docs; the affected source blob is unchanged
- [x] CodeQL alert links are included above; there is no corresponding issue
- [x] Readme changes are not required because behavior and public API are unchanged
- [x] Applicable validation from `AGENTS.md` was run
