### PR TITLE
test(docs): align production smoke with versioned heading

### DIFF
--- a/website/tests/e2e/production.spec.ts
+++ b/website/tests/e2e/production.spec.ts
@@ -66,7 +66,7 @@ test('deployed site preserves reader, version, search, and legacy contracts', as
   ]) {
     await page.goto(expected.path);
     await expect(
-      page.getByRole('heading', {name: expected.heading}),
+      page.getByRole('heading', {name: expected.heading, exact: true}),
     ).toBeVisible();
     await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
       'href',

--- a/website/tests/e2e/production.spec.ts
+++ b/website/tests/e2e/production.spec.ts
@@ -49,21 +49,24 @@ test('deployed site preserves reader, version, search, and legacy contracts', as
   for (const expected of [
     {
       canonical: 'https://humanizr.net/docs/start/quick-start/',
+      heading: 'Five-minute quick start',
       path: '/docs/start/quick-start/',
     },
     {
       canonical: 'https://humanizr.net/docs/2.10.1/start/quick-start/',
+      heading: 'Five-minute quick start',
       path: '/docs/2.10.1/start/quick-start/',
     },
     {
       canonical: 'https://humanizr.net/docs/next/start/quick-start/',
+      heading: 'Developer quick start',
       noIndex: true,
       path: '/docs/next/start/quick-start/',
     },
   ]) {
     await page.goto(expected.path);
     await expect(
-      page.getByRole('heading', {name: 'Five-minute quick start'}),
+      page.getByRole('heading', {name: expected.heading}),
     ).toBeVisible();
     await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
       'href',


### PR DESCRIPTION
## Summary

Production smoke now distinguishes the versioned quick-start headings: stable 3.0.10 and 2.10.1 retain “Five-minute quick start,” while the v4 preview at `/docs/next/` expects “Developer quick start.” Valid preview deployments no longer trigger rollback because of intentionally removed copy, and every route still verifies its exact page heading.

Related: https://github.com/Humanizr/Humanizer/actions/runs/30676212860

## Validation

- `HUMANIZER_DOCS_EXPECTED_SHA=e997755055f3cede6f275d8a7c610386d1e44a96 pnpm --dir website run test:production` — 1 passed against a fresh complete site build
- `pnpm --dir website run check:content`
- `pnpm --dir website run test:unit` — 54 passed
- `pnpm --dir website run typecheck`
- `pnpm --dir website run build`
- `pwsh tools/docs/build.ps1 -ValidateOnly`
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` — 0 of 2,821 files changed
- `git diff --check`

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] The production smoke regression itself provides focused coverage
- [x] No copied third-party code
- [x] No explanatory source comments were needed
- [x] XML documentation is not applicable to this test-only change
- [x] Branch is based on the latest `main`
- [x] Related failing workflow is linked above; no issue is closed by this test correction
- [x] README changes are not applicable
- [x] Applicable documentation gates were run
