### PR TITLE
fix(docs): anchor recovery releases to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,6 +48,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  DOCS_RELEASE_TARGET: main
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
   GH_REPO: ${{ github.repository }}
@@ -428,13 +429,17 @@ jobs:
               jq -r \
                 --arg archive "$archive_name" \
                 --arg checksum "$checksum_name" \
+                --arg releaseTarget "$DOCS_RELEASE_TARGET" \
                 --arg source "$ROLLBACK_SOURCE_SHA" '
                   [
                     .[][]
                     | select(
                         .draft == false
                         and .immutable == true
-                        and .target_commitish == $source
+                        and (
+                          .target_commitish == $releaseTarget
+                          or .target_commitish == $source
+                        )
                       )
                     | select(
                         ([.assets[].name] | index($archive)) != null
@@ -1070,7 +1075,10 @@ jobs:
             IFS=$'\t' read -r immutable target asset_count asset_names \
               <<<"$release"
             if [[ "$immutable" != true ||
-                  "$target" != "$PRIOR_SOURCE_SHA" ||
+                  (
+                    "$target" != "$DOCS_RELEASE_TARGET" &&
+                    "$target" != "$PRIOR_SOURCE_SHA"
+                  ) ||
                   "$asset_count" != 3 ||
                   "$asset_names" != "${pointer_name},${archive_name},${checksum_name}" ]]; then
               echo "Prior rollback release is invalid." >&2
@@ -1176,7 +1184,7 @@ jobs:
             "prior-archive/${pointer_name}" \
             --latest=false \
             --prerelease \
-            --target "$PRIOR_SOURCE_SHA" \
+            --target "$DOCS_RELEASE_TARGET" \
             --title "Documentation deployment ${PRIOR_DEPLOYMENT_RUN_ID}/${PRIOR_DEPLOYMENT_RUN_ATTEMPT}" \
             --notes "Automation-owned Pages artifact for exact rollback."
           mkdir prior-verify
@@ -1282,7 +1290,7 @@ jobs:
               --draft \
               --latest=false \
               --prerelease \
-              --target "$SOURCE_SHA" \
+              --target "$DOCS_RELEASE_TARGET" \
               --title "Documentation deployment ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" \
               --notes "Automation-owned exact deployment candidate."
             for attempt in {1..10}; do
@@ -1298,7 +1306,7 @@ jobs:
           IFS=$'\t' read -r release_id draft immutable target \
             asset_count asset_names <<<"$release"
           if [[ ! "$release_id" =~ ^[0-9]+$ ||
-                "$target" != "$SOURCE_SHA" ||
+                "$target" != "$DOCS_RELEASE_TARGET" ||
                 "$asset_count" != 3 ||
                 "$asset_names" != "${pointer_name},${archive_name},${checksum_name}" ||
                 ! (
@@ -1492,7 +1500,7 @@ jobs:
           if [[ "$source_tag" != "${release_prefix}${source_attempt}" ||
                 ! "$source_attempt" =~ ^[0-9]+$ ||
                 ! "$release_id" =~ ^[0-9]+$ ||
-                "$target" != "$SOURCE_SHA" ||
+                "$target" != "$DOCS_RELEASE_TARGET" ||
                 "$asset_count" != 3 ||
                 "$manifest_count" != 1 ||
                 ! "$manifest_asset_id" =~ ^[0-9]+$ ||
@@ -1688,7 +1696,7 @@ jobs:
               --draft \
               --latest=false \
               --prerelease \
-              --target "$SOURCE_SHA" \
+              --target "$DOCS_RELEASE_TARGET" \
               --title "Documentation deployment ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" \
               --notes "Automation-owned exact deployment release."
             for attempt in {1..10}; do
@@ -1704,7 +1712,7 @@ jobs:
           IFS=$'\t' read -r release_id draft immutable target \
             asset_count asset_names <<<"$release"
           if [[ ! "$release_id" =~ ^[0-9]+$ ||
-                "$target" != "$SOURCE_SHA" ||
+                "$target" != "$DOCS_RELEASE_TARGET" ||
                 "$asset_count" != 3 ||
                 "$asset_names" != "${pointer_name},${archive_name},${checksum_name}" ||
                 ! (
@@ -1750,7 +1758,7 @@ jobs:
             <<<"$published"
           if [[ "$draft" != false ||
                 "$immutable" != true ||
-                "$target" != "$SOURCE_SHA" ||
+                "$target" != "$DOCS_RELEASE_TARGET" ||
                 "$asset_count" != 3 ||
                 "$asset_names" != "${pointer_name},${archive_name},${checksum_name}" ]]; then
             echo "Published deployment release is invalid." >&2

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -9,6 +9,9 @@ const workflow = readFileSync(
   'utf8',
 );
 const normalizedWorkflow = workflow.replaceAll('\r\n', '\n');
+const docsReleaseTarget = normalizedWorkflow.match(
+  /^  DOCS_RELEASE_TARGET: (.+)$/m,
+)?.[1];
 const deploymentGuide = readFileSync(
   fileURLToPath(
     new URL('../docs/contributing/documentation.mdx', import.meta.url),
@@ -143,6 +146,7 @@ function release({
   smokeAttempt = deploymentAttempt,
   sourceSha = '0123456789abcdef0123456789abcdef01234567',
   stageAttempt = deploymentAttempt,
+  target = docsReleaseTarget,
 }) {
   const manifest = {
     archiveRunAttempt: archiveAttempt,
@@ -170,6 +174,7 @@ function release({
     manifest,
     publishedAt,
     tag: `docs-pages-deployment-v1-${deploymentRunId}-${deploymentAttempt}`,
+    target,
   };
 }
 
@@ -180,6 +185,8 @@ function validRelease(candidate) {
     candidate.immutable &&
     candidate.digestValid &&
     manifest.schemaVersion === 1 &&
+    (candidate.target === docsReleaseTarget ||
+      candidate.target === manifest.sourceSha) &&
     candidate.tag ===
       `docs-pages-deployment-v1-${manifest.deploymentRunId}-${manifest.publicationRunAttempt}` &&
     candidate.assets.join() === deploymentAssets(manifest).join()
@@ -620,8 +627,115 @@ test('deployment release stays draft until production is verified', () => {
   assert.match(record, /"\$draft" != false[\s\S]*?"\$immutable" != true/);
 });
 
+test('release targets remain storage metadata while manifests retain source identity', () => {
+  const historicalSource = '0123456789abcdef0123456789abcdef01234567';
+  const staged = release({sourceSha: historicalSource});
+  const evidence = {
+    archiveAttempts: {1: {build: 'success'}},
+    deploymentAttempts: {
+      1: {
+        conclusion: 'success',
+        deploy: 'success',
+        'production-smoke': 'success',
+        'stage-pages-release': 'success',
+      },
+    },
+  };
+  const stage = normalizedWorkflow
+    .split('\n  stage-pages-release:\n')[1]
+    .split('\n  deploy:\n')[0];
+  const record = normalizedWorkflow
+    .split('\n  record-production-deployment:\n')[1]
+    .split('\n  recover-after-production-failure:\n')[0];
+  const restore = normalizedWorkflow
+    .split('- name: Restore retained Pages artifact')[1]
+    .split('- name: Extract retained Pages artifact')[0];
+  const prior = normalizedWorkflow
+    .split('- name: Inspect retained prior artifact')[1]
+    .split('- name: Download prior Pages artifact')[0];
+
+  assert.equal(docsReleaseTarget, 'main');
+  assert.equal(
+    normalizedWorkflow.match(/--target "\$DOCS_RELEASE_TARGET"/g)?.length,
+    3,
+  );
+  assert.doesNotMatch(
+    normalizedWorkflow,
+    /--target "\$(?:PRIOR_)?SOURCE_SHA"/,
+  );
+  assert.match(stage, /"\$target" != "\$DOCS_RELEASE_TARGET"/);
+  assert.doesNotMatch(stage, /"\$target" != "\$SOURCE_SHA"/);
+  assert.equal(
+    record.match(/"\$target" != "\$DOCS_RELEASE_TARGET"/g)?.length,
+    3,
+  );
+  assert.doesNotMatch(record, /"\$target" != "\$SOURCE_SHA"/);
+  assert.match(
+    restore,
+    /\.target_commitish == \$releaseTarget\s+or \.target_commitish == \$source/,
+  );
+  assert.match(
+    prior,
+    /"\$target" != "\$DOCS_RELEASE_TARGET" &&\s+"\$target" != "\$PRIOR_SOURCE_SHA"/,
+  );
+
+  assert.equal(staged.target, 'main');
+  assert.equal(staged.manifest.sourceSha, historicalSource);
+  assert.equal(validEvidence(staged, evidence), true);
+  assert.equal(
+    validEvidence(
+      {...staged, targetRefSha: 'fedcba9876543210fedcba9876543210fedcba98'},
+      evidence,
+    ),
+    true,
+  );
+
+  const legacy = release({
+    sourceSha: historicalSource,
+    target: historicalSource,
+  });
+  assert.equal(validEvidence(legacy, evidence), true);
+  assert.equal(validRelease({...legacy, target: ''}), false);
+  assert.equal(validRelease({...legacy, target: 'release/storage'}), false);
+  assert.equal(
+    validRelease({
+      ...legacy,
+      manifest: {
+        ...legacy.manifest,
+        sourceSha: 'fedcba9876543210fedcba9876543210fedcba98',
+      },
+    }),
+    false,
+  );
+
+  for (const manifest of [
+    {...staged.manifest, archiveRunAttempt: 2},
+    {...staged.manifest, stageRunAttempt: 2},
+    {...staged.manifest, deployRunAttempt: 2},
+    {...staged.manifest, smokeRunAttempt: 2},
+  ]) {
+    assert.equal(validEvidence({...staged, manifest}, evidence), false);
+  }
+  assert.equal(
+    productionMatchesCandidate(
+      staged.manifest,
+      {
+        ...staged.manifest,
+        sourceSha: 'fedcba9876543210fedcba9876543210fedcba98',
+      },
+    ),
+    false,
+  );
+  assert.equal(
+    productionMatchesCandidate(
+      staged.manifest,
+      {...staged.manifest, archiveRunId: 101},
+    ),
+    false,
+  );
+});
+
 test('candidate staging tolerates eventual release-list visibility', () => {
-  const sourceSha = '0123456789abcdef0123456789abcdef01234567';
   const stage = normalizedWorkflow
     .split('\n  stage-pages-release:\n')[1]
     .split('\n  deploy:\n')[0];
@@ -644,7 +758,7 @@ test('candidate staging tolerates eventual release-list visibility', () => {
     id: 300,
     immutable: false,
     tag_name: 'docs-pages-candidate-v1-200-1',
-    target_commitish: sourceSha,
+    target_commitish: docsReleaseTarget,
   };
   const select = (pages) =>
     spawnSync(
@@ -663,13 +777,12 @@ test('candidate staging tolerates eventual release-list visibility', () => {
   assert.equal(visible.status, 0, visible.stderr);
   assert.equal(
     visible.stdout.trimEnd(),
-    `300\ttrue\tfalse\t${sourceSha}\t3\tdeployment-200-1.json,github-pages-100-1.tar,github-pages-100-1.tar.sha256`,
+    `300\ttrue\tfalse\t${docsReleaseTarget}\t3\tdeployment-200-1.json,github-pages-100-1.tar,github-pages-100-1.tar.sha256`,
   );
   assert.notEqual(select([[candidate, candidate]]).status, 0);
 });
 
 test('final publication tolerates eventual release-list visibility', () => {
-  const sourceSha = '0123456789abcdef0123456789abcdef01234567';
   const record = normalizedWorkflow
     .split('\n  record-production-deployment:\n')[1]
     .split('\n  recover-after-production-failure:\n')[0];
@@ -692,7 +805,7 @@ test('final publication tolerates eventual release-list visibility', () => {
     id: 400,
     immutable: false,
     tag_name: 'docs-pages-deployment-v1-200-1',
-    target_commitish: sourceSha,
+    target_commitish: docsReleaseTarget,
   };
   const select = (pages) =>
     spawnSync(
@@ -711,7 +824,7 @@ test('final publication tolerates eventual release-list visibility', () => {
   assert.equal(visible.status, 0, visible.stderr);
   assert.equal(
     visible.stdout.trimEnd(),
-    `400\ttrue\tfalse\t${sourceSha}\t3\tdeployment-200-1.json,github-pages-200-1.tar,github-pages-200-1.tar.sha256`,
+    `400\ttrue\tfalse\t${docsReleaseTarget}\t3\tdeployment-200-1.json,github-pages-200-1.tar,github-pages-200-1.tar.sha256`,
   );
   assert.notEqual(select([[finalRelease, finalRelease]]).status, 0);
 });

--- a/website/tests/pages-run-selection.test.mjs
+++ b/website/tests/pages-run-selection.test.mjs
@@ -684,7 +684,7 @@ test('release targets remain storage metadata while manifests retain source iden
   assert.equal(validEvidence(staged, evidence), true);
   assert.equal(
     validEvidence(
-      {...staged, targetRefSha: 'fedcba9876543210fedcba9876543210fedcba98'},
+      {...staged, target: staged.manifest.sourceSha},
       evidence,
     ),
     true,


### PR DESCRIPTION
## Summary

Historical documentation rollbacks can now stage and publish with the repository `GITHUB_TOKEN`. New automation-owned releases use `main` as storage/tag-placement metadata, while the retained deployment manifest and archive continue to carry and verify the exact historical source SHA.

Existing immutable releases that target their source SHA remain valid rollback inputs. New candidate and final releases require the `main` storage target, without weakening the source SHA, exact run/attempt, asset inventory, checksum, embedded deployment identity, or successful stage/deploy/smoke evidence checks.

## Validation

- `node --test website/tests/pages-run-selection.test.mjs` — 30/30
- `pnpm --dir website run test:unit` — 55/55
- `pnpm --dir website run check:content`
- `pnpm --dir website run typecheck`
- `pnpm --dir website run build:site`
- `pnpm --dir website run check:links`
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
- `actionlint` 1.7.12 — no new findings; the two existing shellcheck warnings match `main`
- YAML parse and `git diff --check`

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No new Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No copied third-party code or attribution requirement
- [x] Comments remain limited to existing workflow guidance
- [x] XML documentation is not applicable to this workflow-only change
- [x] The PR is based on the latest `main`
- [x] No issue is linked because this is a follow-up to a production workflow failure
- [x] README changes are not applicable
- [x] Applicable validation from `AGENTS.md`, including documentation gates, is complete
