### PR TITLE
perf: reduce appended-group rendering allocations

### DIFF
--- a/src/Humanizer/Localisation/NumberToWords/AppendedGroupNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/AppendedGroupNumberToWordsConverter.cs
@@ -30,7 +30,9 @@ class AppendedGroupNumberToWordsConverter(AppendedGroupNumberToWordsConverter.Pr
 
     string ConvertPositive(ulong number, GrammaticalGender gender)
     {
-        var result = string.Empty;
+        string? result = null;
+        StringBuilder? builder = null;
+        var renderedGroupCount = 0;
         var groupLevel = 0;
 
         // Walk from least significant triad to most significant triad so the group word can be
@@ -119,39 +121,67 @@ class AppendedGroupNumberToWordsConverter(AppendedGroupNumberToWordsConverter.Pr
 
             if (!string.IsNullOrEmpty(process))
             {
-                if (groupLevel > 0)
+                string? groupWord = null;
+                if (groupLevel > 0 && groupNumber != 2)
                 {
-                    if (!string.IsNullOrEmpty(result))
+                    groupWord = groupNumber switch
                     {
-                        // Once a higher group already exists, the conjunction belongs between the
-                        // group words rather than inside the current triad fragment.
-                        result = profile.ConjunctionWord + " " + result;
-                    }
-
-                    if (groupNumber != 2)
-                    {
-                        if (groupNumber % 100 != 1)
-                        {
-                            // Singular, plural, and appended group words are data-driven because
-                            // different locales use different inflection rules for the same group.
-                            result = groupNumber is >= 3 and <= 10
-                                ? profile.PluralGroups[groupLevel] + " " + result
-                                : (string.IsNullOrEmpty(result) ? profile.Groups[groupLevel] : profile.AppendedGroups[groupLevel]) + " " + result;
-                        }
-                        else
-                        {
-                            result = profile.Groups[groupLevel] + " " + result;
-                        }
-                    }
+                        >= 3 and <= 10 => profile.PluralGroups[groupLevel],
+                        _ when groupNumber % 100 == 1 || result == null => profile.Groups[groupLevel],
+                        _ => profile.AppendedGroups[groupLevel]
+                    };
                 }
 
-                result = process + " " + result;
+                if (result == null)
+                {
+                    result = groupWord == null
+                        ? process
+                        : string.Concat(process, " ", groupWord);
+                }
+                else if (renderedGroupCount == 1)
+                {
+                    var separator = groupWord == null
+                        ? string.Concat(profile.ConjunctionWord, " ")
+                        : string.Concat(groupWord, " ", profile.ConjunctionWord, " ");
+                    result = string.Concat(process, " ", separator, result);
+                }
+                else
+                {
+                    builder ??= new(result);
+                    builder.Insert(0, ' ').Insert(0, profile.ConjunctionWord);
+
+                    if (groupWord != null)
+                    {
+                        builder.Insert(0, ' ').Insert(0, groupWord);
+                    }
+
+                    builder.Insert(0, ' ').Insert(0, process);
+                }
+
+                renderedGroupCount++;
             }
 
             groupLevel++;
         }
 
-        return result.Trim();
+        if (builder == null)
+        {
+            return result!.Trim();
+        }
+
+        var startIndex = 0;
+        while (startIndex < builder.Length && char.IsWhiteSpace(builder[startIndex]))
+        {
+            startIndex++;
+        }
+
+        var endIndex = builder.Length;
+        while (endIndex > startIndex && char.IsWhiteSpace(builder[endIndex - 1]))
+        {
+            endIndex--;
+        }
+
+        return builder.ToString(startIndex, endIndex - startIndex);
     }
 
     /// <summary>

--- a/tests/Humanizer.Tests/Localisation/LocaleNumberMagnitudeTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleNumberMagnitudeTheoryData.cs
@@ -62,6 +62,7 @@ public static class LocaleNumberMagnitudeTheoryData
         { "af", 1001L, "een duisend en een" },
         { "af", 1000001L, "een miljoen en een" },
         { "ar", 1001L, "ألف و واحد" },
+        { "ar", 2001L, "ألفان و واحد" },
         { "ar", 1000001L, "مليون و واحد" },
         { "az", 1001L, "min bir" },
         { "az", 1000001L, "bir milyon bir" },


### PR DESCRIPTION
## Summary

- keep the first two rendered groups as strings and create a `StringBuilder` only when a third group must be prepended
- select singular, plural, and appended group words once with an ordered switch
- cover the previously untested Arabic dual-with-remainder case (`2001`)

## CodeQL mapping

- alert `327`: `cs/string-concatenation-in-loop` at the final group prepend
- alert `336`: `cs/missed-ternary-operator` in group-word selection
- alert `347`: `cs/string-concatenation-in-loop` at the conjunction prepend
- alert `348`: `cs/string-concatenation-in-loop` at the process prepend

All four findings share `AppendedGroupNumberToWordsConverter.ConvertPositive`; this is one root-cause correction.

## Validation

- `NumberWordMagnitudeTests`: 678/678 on net8.0, net10.0, and net11.0
- full `Humanizer.Tests`: 61,017/61,017 on net8.0, net10.0, and net11.0
- net48 Release compile: 0 warnings, 0 errors
- allocation A/B on net8/net10/net11: identical outputs and lower allocation for every sampled path (24–50% savings)
- independent isolated-ALC comparison: 83,130 public calls, 0 mismatches; public API delta: 0
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
- Release pack and `tests/verify-packages.ps1`
- `tools/docs/build.ps1 -Mode Validate`
- `tools/docs/test.ps1 -RequireNativeAot`
