### PR TITLE
refactor(words): simplify token membership checks

### DIFF
--- a/src/Humanizer/Localisation/WordsToNumber/InvertedTensWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/InvertedTensWordsToNumberConverter.cs
@@ -343,18 +343,8 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
     /// </summary>
     /// <param name="token">The normalized token to inspect.</param>
     /// <returns><c>true</c> if the token is configured as ignorable; otherwise, <c>false</c>.</returns>
-    bool ShouldIgnore(string token)
-    {
-        foreach (var ignoredToken in profile.IgnoredTokens)
-        {
-            if (token == ignoredToken)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    bool ShouldIgnore(string token) =>
+        Array.IndexOf(profile.IgnoredTokens, token) >= 0;
 
     /// <summary>
     /// Normalizes words for dictionary lookup by lowercasing them and removing periods.

--- a/src/Humanizer/Localisation/WordsToNumber/LinkingAffixWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/LinkingAffixWordsToNumberConverter.cs
@@ -135,18 +135,8 @@ internal class LinkingAffixWordsToNumberConverter(LinkingAffixWordsToNumberProfi
     /// </summary>
     /// <param name="token">The token to inspect.</param>
     /// <returns><c>true</c> if the token should be skipped; otherwise, <c>false</c>.</returns>
-    bool ShouldIgnore(string token)
-    {
-        foreach (var ignoredToken in profile.IgnoredTokens)
-        {
-            if (token == ignoredToken)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    bool ShouldIgnore(string token) =>
+        Array.IndexOf(profile.IgnoredTokens, token) >= 0;
 
     /// <summary>
     /// Tries to strip a linked suffix from a token and resolve the base token as a cardinal value.

--- a/src/Humanizer/Localisation/WordsToNumber/VigesimalCompoundWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/VigesimalCompoundWordsToNumberConverter.cs
@@ -144,36 +144,16 @@ internal class VigesimalCompoundWordsToNumberConverter(VigesimalCompoundWordsToN
     /// </summary>
     /// <param name="token">The token to inspect.</param>
     /// <returns><c>true</c> if the token should be skipped; otherwise, <c>false</c>.</returns>
-    bool ShouldIgnore(string token)
-    {
-        foreach (var ignoredToken in profile.IgnoredTokens)
-        {
-            if (token == ignoredToken)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    bool ShouldIgnore(string token) =>
+        Array.IndexOf(profile.IgnoredTokens, token) >= 0;
 
     /// <summary>
     /// Returns <c>true</c> when the next token is a supported follower for the vigesimal leader.
     /// </summary>
     /// <param name="token">The token to inspect.</param>
     /// <returns><c>true</c> if the token is a known follower; otherwise, <c>false</c>.</returns>
-    bool IsVigesimalFollower(string token)
-    {
-        foreach (var follower in profile.VigesimalFollowerTokens)
-        {
-            if (token == follower)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    bool IsVigesimalFollower(string token) =>
+        Array.IndexOf(profile.VigesimalFollowerTokens, token) >= 0;
 }
 
 /// <summary>

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -906,6 +906,7 @@ public class CoverageGapTests
     [InlineData("first", 1)]
     [InlineData("score one", 20)]
     [InlineData("score five", 25)]
+    [InlineData("one and two", 3)]
     [InlineData("twenty teen three", 33)]
     [InlineData("two hundred three", 203)]
     [InlineData("two thousand three", 2003)]


### PR DESCRIPTION
## Summary

Four parser membership predicates now use the runtime's allocation-free array lookup instead of hand-written filtering loops. This clears the routed CodeQL findings while preserving ordinal string equality and public behavior; independent A/B validation found identical outputs and allocations on net8, net10, and net11 with zero public API delta.

Related: [alert 312](https://github.com/Humanizr/Humanizer/security/code-scanning/312), [alert 313](https://github.com/Humanizr/Humanizer/security/code-scanning/313), [alert 321](https://github.com/Humanizr/Humanizer/security/code-scanning/321), [alert 322](https://github.com/Humanizr/Humanizer/security/code-scanning/322)

## Validation

- CoverageGapTests: 195/195 on net8.0, net10.0, and net11.0
- Full Humanizer.Tests: 61,018/61,018 on net8.0, net10.0, and net11.0
- net48 Release build: 0 warnings, 0 errors
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
- Release pack and `tests/verify-packages.ps1`
- Complete docs validation and native-AOT runtime suite
- Independent public-path A/B: identical outputs and allocations across da, so, fil, and fr; zero API delta

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No copied third-party code
- [x] Comments remain limited to existing API documentation
- [x] XML documentation remains accurate
- [x] Based on live `main`
- [x] Routed CodeQL alerts are linked above
- [x] Readme change is not needed for this behavior-preserving internal refactor
- [x] Applicable validation from `AGENTS.md` passed
