### PR TITLE
fix: defer exact ordinal suffix concatenation

### DIFF
--- a/src/Humanizer/Localisation/NumberToWords/TriadScaleNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/TriadScaleNumberToWordsConverter.cs
@@ -187,6 +187,8 @@ class TriadScaleNumberToWordsConverter(TriadScaleNumberToWordsConverter.Profile 
     /// </summary>
     string ApplyExactScaleOrdinalTransforms(string words, long number)
     {
+        var exactOrdinalSuffix = string.Empty;
+
         // Walk from the largest scale downward so the first exact scale match wins. A smaller
         // match would be wrong here because the rewrite needs the outermost terminating scale.
         foreach (var scale in profile.Scales)
@@ -210,13 +212,15 @@ class TriadScaleNumberToWordsConverter(TriadScaleNumberToWordsConverter.Profile 
 
             if (!string.IsNullOrEmpty(scale.ExactOrdinalSuffix) && (ulong)number > scale.Value)
             {
-                words += scale.ExactOrdinalSuffix;
+                exactOrdinalSuffix = scale.ExactOrdinalSuffix;
             }
 
             break;
         }
 
-        return words;
+        return string.IsNullOrEmpty(exactOrdinalSuffix)
+            ? words
+            : words + exactOrdinalSuffix;
     }
 
     /// <summary>

--- a/tests/Humanizer.Tests/Localisation/NumberWordPhraseTests.cs
+++ b/tests/Humanizer.Tests/Localisation/NumberWordPhraseTests.cs
@@ -108,6 +108,14 @@ public class NumberWordPhraseTests
     }
 
     [Theory]
+    [InlineData(2000, "duemillesimo")]
+    [InlineData(2000000, "duemilionesimo")]
+    public void ItalianExactScaleOrdinalsUseTheOutermostMatchingScale(int number, string expected)
+    {
+        Assert.Equal(expected, number.ToOrdinalWords(GetCulture("it")));
+    }
+
+    [Theory]
     [MemberData(nameof(LocaleAdditionalNumberTheoryData.AdditionalOrdinalGenderCases), MemberType = typeof(LocaleAdditionalNumberTheoryData))]
     public void UsesExpectedAdditionalOrdinalGenderCases(string localeName, int number, GrammaticalGender gender, string expected)
     {


### PR DESCRIPTION
## Summary

- defer the selected exact ordinal suffix until after the descending scale loop
- preserve first matching outer-scale, compaction, leading-one removal, output, and reference behavior
- cover the Italian suffix and outer-scale paths with a focused regression theory

## Security

Addresses [CodeQL alert #349](https://github.com/Humanizr/Humanizer/security/code-scanning/349) without adding a `StringBuilder` allocation to a loop that can append at most once.

## Validation

- focused Italian regression: 2/2 on net8.0, net10.0, and net11.0
- full Humanizer.Tests: 61,019/61,019 on each net8.0, net10.0, and net11.0
- baseline/candidate equivalence: identical 120,039-input digest and reference semantics on all three TFMs
- allocation parity: exact match for suffix, outer-scale, and mixed paths on all three TFMs
- repeated interleaved timing: no consistent material regression
- `tools/docs/generate-language-coverage.ps1 -UpdateReferenceFingerprint`: canonical no-op
- documentation `-ValidateOnly` and `-Mode Validate`
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
- Release pack for netstandard2.0, net48, net8.0, net10.0, and net11.0
- analyzer package consumer smoke

## Checklist

- [x] Implementation is focused and follows existing coding standards
- [x] No code-analysis or formatting warnings
- [x] Focused and full unit-test coverage passes
- [x] No copied third-party code
- [x] No public API or documentation behavior change
- [x] Based on the current live `main`
