### PR TITLE
refactor(words): avoid duplicate ordinal lookup

### DIFF
--- a/src/Humanizer/Localisation/WordsToNumber/GreedyCompoundWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/GreedyCompoundWordsToNumberConverter.cs
@@ -107,18 +107,13 @@ internal class GreedyCompoundWordsToNumberConverter(GreedyCompoundWordsToNumberP
         {
             foreach (var gender in new[] { GrammaticalGender.Masculine, GrammaticalGender.Feminine })
             {
-                var ordinal = Normalize(
+                ordinals.TryAdd(Normalize(
                     converter.ConvertToOrdinal(number, gender),
                     charactersToRemove,
                     charactersToReplaceWithSpace,
                     textReplacements,
                     lowercase,
-                    removeDiacritics);
-
-                if (!ordinals.ContainsKey(ordinal))
-                {
-                    ordinals[ordinal] = number;
-                }
+                    removeDiacritics), number);
             }
         }
 

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -61,6 +61,19 @@ public class CoverageGapTests
         Assert.Equal(7, ordinals[expectedKey]);
     }
 
+    [Fact]
+    public void GreedyCompoundOrdinalBuilderKeepsFirstNormalizedDuplicate()
+    {
+        var ordinals = GreedyCompoundWordsToNumberConverter.BuildOrdinalMap(
+            new GenderEchoOrdinalConverter(),
+            "0123456789.",
+            string.Empty,
+            [new("masculine", "shared"), new("feminine", "shared")]);
+
+        Assert.Single(ordinals);
+        Assert.Equal(1, ordinals["shared"]);
+    }
+
     [Theory]
     [InlineData("42", 42)]
     [InlineData("minus two", -2)]


### PR DESCRIPTION
## Summary

Greedy compound ordinal maps now preserve the earliest normalized spelling with one dictionary lookup. This keeps output ordering and collision behavior unchanged while removing the map-local loop pattern flagged by CodeQL.

The literal LINQ rewrite produced the same 397-entry map but added about 9.7 KB per build and 7.9–9.0% runtime across net8/net10/net11. `TryAdd` produced the same ordered and sorted fingerprints with baseline-identical allocations and no measured regression.

Related: https://github.com/Humanizr/Humanizer/security/code-scanning/302

## Validation

- 61,021/61,021 tests passed on each of net8.0, net10.0, and net11.0
- First-normalized-spelling-wins regression passed on all three TFMs
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic` formatted 0/2,821 files
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release` passed for netstandard2.0, net48, net8.0, net10.0, and net11.0 with no warnings or errors
- Analyzer package inventory and net8 consumer smoke passed
- Documentation `-ValidateOnly` and full `-Mode Validate` gates passed
- Locale reference fingerprint updater was a no-op

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] There is proper unit test coverage
- [x] No copied code requires attribution
- [x] Comments remain minimal
- [x] XML documentation is not affected because there is no public API change
- [x] Rebased on the latest `main` before publication
- [x] Related CodeQL alert is linked above
- [x] Readme is not affected because behavior and public APIs are unchanged
- [x] Applicable validation from `AGENTS.md` passed