### PR TITLE
refactor: build greedy ordinal map with TryAdd

### DIFF
--- a/src/Humanizer/Localisation/WordsToNumber/GreedyCompoundWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/GreedyCompoundWordsToNumberConverter.cs
@@ -107,18 +107,15 @@ internal class GreedyCompoundWordsToNumberConverter(GreedyCompoundWordsToNumberP
         {
             foreach (var gender in new[] { GrammaticalGender.Masculine, GrammaticalGender.Feminine })
             {
-                var ordinal = Normalize(
-                    converter.ConvertToOrdinal(number, gender),
-                    charactersToRemove,
-                    charactersToReplaceWithSpace,
-                    textReplacements,
-                    lowercase,
-                    removeDiacritics);
-
-                if (!ordinals.ContainsKey(ordinal))
-                {
-                    ordinals[ordinal] = number;
-                }
+                ordinals.TryAdd(
+                    Normalize(
+                        converter.ConvertToOrdinal(number, gender),
+                        charactersToRemove,
+                        charactersToReplaceWithSpace,
+                        textReplacements,
+                        lowercase,
+                        removeDiacritics),
+                    number);
             }
         }
 

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -61,6 +61,19 @@ public class CoverageGapTests
         Assert.Equal(7, ordinals[expectedKey]);
     }
 
+    [Fact]
+    public void GreedyOrdinalBuilderKeepsFirstValueForDuplicateNormalizedForms()
+    {
+        var ordinals = GreedyCompoundWordsToNumberConverter.BuildOrdinalMap(
+            new GenderEchoOrdinalConverter(),
+            "0123456789.",
+            string.Empty,
+            [new("masculine", "ordinal"), new("feminine", "ordinal")]);
+
+        Assert.Equal(1, ordinals["ordinal"]);
+        Assert.Single(ordinals);
+    }
+
     [Theory]
     [InlineData("42", 42)]
     [InlineData("minus two", -2)]


### PR DESCRIPTION
## Summary

- Add normalized greedy ordinal entries with `Dictionary.TryAdd`, removing the mapped local that triggers CodeQL's missed-`Select` pattern and avoiding the second dictionary probe.
- Preserve first-write-wins behavior when multiple ordinal forms normalize to the same key.
- Add focused compatibility coverage for duplicate normalized masculine/feminine forms.

## CodeQL mapping

- Alert `302`: `cs/linq/missed-select`
- `src/Humanizer/Localisation/WordsToNumber/GreedyCompoundWordsToNumberConverter.cs:108-122`

## Validation

- Targeted regression: net8.0, net10.0, net11.0 — 1/1 each
- Full `Humanizer.Tests`: net8.0, net10.0, net11.0 — 61,021/61,021 each
- net48 Release compile — 0 warnings, 0 errors
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`
- Release pack plus `tests/verify-packages.ps1`
- `tools/docs/build.ps1 -Mode Validate`
- `tools/docs/test.ps1 -RequireNativeAot`
- Independent review of patch SHA-256 `0c3f8ea4520ccbecc7292c3016d345fc0ae80e706dda7abd70330f0a63ce8898` — approved with no findings

## Main-branch note

The branch started from live main `a137fdbd`. Main later advanced through #1925, whose source change is unrelated and whose `CoverageGapTests` addition is a distant hunk. The exact patch applies cleanly to current main `03ba60a3`; the ruleset does not require strict updates, so the reviewed head was not rebased solely to chase that merge.

## Checklist

- [x] Implementation is clean and follows existing coding standards
- [x] No code-analysis warnings
- [x] Focused unit coverage is included
- [x] No copied third-party code
- [x] No public API or XML documentation change
- [x] No README change is needed for this behavior-preserving refactor
- [x] Applicable `AGENTS.md` validation completed
- [x] CodeQL alert mapping is documented above
