### PR TITLE
docs: require public issue updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Here is a checklist you should tick through before submitting a pull request:
  - [ ] Xml documentation is added/updated for the addition/change
  - [ ] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
  - [ ] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
- - [ ] Issue communication is current per `AGENTS.md`, or N/A: `<issue comment/evidence>`
+ - [ ] For issue-driven work, public issue communication includes a comment URL and current reproduction/resolution evidence; use N/A only when no related issue exists
  - [ ] Readme is updated if you change an existing feature or add a new one
  - [ ] Run the applicable validation from `AGENTS.md`; documentation changes include the documentation gates
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,6 @@ Here is a checklist you should tick through before submitting a pull request:
  - [ ] Xml documentation is added/updated for the addition/change
  - [ ] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
  - [ ] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
- - [ ] For issue-driven work, public issue communication includes a comment URL and current reproduction/resolution evidence; use N/A only when no related issue exists
  - [ ] Readme is updated if you change an existing feature or add a new one
  - [ ] Run the applicable validation from `AGENTS.md`; documentation changes include the documentation gates
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@ Here is a checklist you should tick through before submitting a pull request:
  - [ ] Xml documentation is added/updated for the addition/change
  - [ ] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
  - [ ] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
+ - [ ] Issue communication is current per `AGENTS.md`, or N/A: `<issue comment/evidence>`
  - [ ] Readme is updated if you change an existing feature or add a new one
  - [ ] Run the applicable validation from `AGENTS.md`; documentation changes include the documentation gates
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ These instructions apply to the entire repository.
 ## Pull Request Guidelines
 - Keep changes focused with clear commit messages.
 - Follow repository PR template expectations: summarize changes, list tests run, and reference related issues (e.g., `fixes #123`) when applicable.
+- For issue-driven work, especially reports from external contributors, communicate politely in the public issue: thank or acknowledge the reporter once reproduction is confirmed; link the fixing pull request; distinguish reproduced, fixed, merged, and released states; keep promised sibling or applicability follow-ups current; and post a final resolution without claiming release before publication. Do not add noisy pre-reproduction updates or disclose security-sensitive details.
 - Ensure the codebase remains backward-compatible unless intentionally introducing a documented breaking change.
 
 ## Terminal Pull Request Gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,10 +51,12 @@ These instructions apply to the entire repository.
 - Update `readme.md`, resource comments, or XML docs when introducing new features or behavior changes.
 - Provide meaningful examples in documentation and XML summaries where appropriate.
 
+## Issue Communication
+- For issue-driven work, especially reports from external contributors, communicate politely in the public issue: thank or acknowledge the reporter once reproduction is confirmed; link the fixing pull request; distinguish reproduced, fixed, merged, and released states; keep promised sibling or applicability follow-ups current; and post a final resolution without claiming release before publication. Do not add noisy pre-reproduction updates or disclose security-sensitive details.
+
 ## Pull Request Guidelines
 - Keep changes focused with clear commit messages.
 - Follow repository PR template expectations: summarize changes, list tests run, and reference related issues (e.g., `fixes #123`) when applicable.
-- For issue-driven work, especially reports from external contributors, communicate politely in the public issue: thank or acknowledge the reporter once reproduction is confirmed; link the fixing pull request; distinguish reproduced, fixed, merged, and released states; keep promised sibling or applicability follow-ups current; and post a final resolution without claiming release before publication. Do not add noisy pre-reproduction updates or disclose security-sensitive details.
 - Ensure the codebase remains backward-compatible unless intentionally introducing a documented breaking change.
 
 ## Terminal Pull Request Gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ These instructions apply to the entire repository.
 - Provide meaningful examples in documentation and XML summaries where appropriate.
 
 ## Issue Communication
-- For issue-driven work, especially reports from external contributors, communicate politely in the public issue: thank or acknowledge the reporter once reproduction is confirmed; link the fixing pull request; distinguish reproduced, fixed, merged, and released states; keep promised sibling or applicability follow-ups current; and post a final resolution without claiming release before publication. Do not add noisy pre-reproduction updates or disclose security-sensitive details.
+- For issue-driven work, especially reports from external contributors, communicate politely in the public issue: thank or acknowledge the reporter once reproduction is confirmed; link any fixing pull request when one exists; distinguish reproduced, fixed, merged, and released states; keep promised sibling or applicability follow-ups current; and post a final resolution without claiming release before publication. Do not add noisy pre-reproduction updates or disclose security-sensitive details.
 
 ## Pull Request Guidelines
 - Keep changes focused with clear commit messages.


### PR DESCRIPTION
## Summary

Agent-managed issue work now has a standalone communication obligation from confirmed reproduction through final resolution, including investigations and resolutions that never produce a pull request. This prevents a fix from advancing privately while an external reporter receives no update, and it keeps reproduced, fixed, merged, and released states distinct.

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No Code Analysis warnings — N/A, policy-only Markdown
 - [x] There is proper unit test coverage — N/A, no executable behavior
 - [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution — N/A
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change — N/A
 - [x] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>` — N/A, repository policy follow-up
 - [x] Readme is updated if you change an existing feature or add a new one — N/A
 - [x] Run the applicable validation from `AGENTS.md`; documentation changes include the documentation gates — `git diff --check`; exact one-file agent-policy scope reviewed

## Terminal evidence (merge owner)

 - [x] This PR body matches the current template, contains no stale draft instructions, and the PR is ready, not draft
 - [x] Exact evidence pair: `baseSha=fc14e5e8c056b85294548976e33d9cdf352ec44b` / `headSha=fb8f16a0d96dd603dc33a8be596986c4a72dcc46` / `treeSha=837a4833c8ca5adeaf02ce750324c9b5baaf8f0f`
 - [x] Thermos correctness, breakage, security, and developer-experience review finished final clean/APPROVE and merge-eligible on that exact pair: fresh exact-pair review returned no findings
 - [x] Thermos code-quality and maintainability review finished final clean/APPROVE and merge-eligible on that exact pair: fresh exact-pair review returned no findings
 - [x] Every finding has an explicit disposition: both fresh exact-pair reviewers reported no valid findings; no further push was required
 - [x] Applicable tests, format, build, package, documentation, browser, security, and platform gates pass on that exact pair: `git diff --check`; runtime/build/package/browser/security/platform gates N/A for one policy-only Markdown insertion
 - [x] `compound-engineering:ce-babysit-pr` covered the exact pair through the current-head reviewer lifecycle, CI, base movement, and a quiet settle; terminal clean evidence: exact pair unchanged, all hosted checks terminal green, zero actionable or `needs-human` items, and 333 seconds without movement
 - [x] If either SHA changed, the PR body was first updated with the replacement `{baseSha, headSha}` pair; both Thermos reviews, every applicable check, and babysitting then reran against that recorded pair; stale evidence was removed — exact replacement pair was recorded before its single push, and both fresh reviews approved it
 - [x] All actionable review threads are resolved; any `needs-human` item pauses merge — zero unresolved threads and zero `needs-human` items
 - [x] The head is current and mergeable, and terminal hosted CI and ruleset checks are green — `CLEAN`, `MERGEABLE`, and every hosted check passed or was intentionally skipped
 - [x] Security: Codex Security proof-of-concept or attack-path closure passes, or N/A: N/A, no security behavior changes
 - [x] Rendered docs/site/UI: desktop, mobile, light, dark, accessibility, links, and version snapshots pass for affected rendered surfaces, or N/A: N/A, repository agent instructions only
 - [x] Localization/source generator: applicable locale, schema, generator, and runtime matrices pass with no partial or English fallback, or N/A: N/A, no locale or source-generator changes
 - [x] Immediately before merge, the merge owner reauthenticated that the recorded pair exactly matches the live base and head; any mismatch refuses the merge, and only the exact approved head will be merged — live base/head/tree matched exactly; `git diff --check` passed; the PR template remained byte-identical to the base
