### PR TITLE
fix(deps): update brace-expansion

### DIFF
--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -2207,8 +2207,8 @@ packages:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -8774,7 +8774,7 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -10754,7 +10754,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary

This removes the vulnerable `brace-expansion` 1.1.16 resolution from the website dependency graph. The lockfile now resolves 1.1.18, above the patched 1.1.17 floor for GHSA-mh99-v99m-4gvg, without changing the declared dependency surface.

Related: [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) and Dependabot alert 5.

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards; only the generated lockfile resolution changed
- [x] No Code Analysis warnings
- [x] Regression evidence covers the dependency-resolution boundary; a source unit test is not applicable to a transitive lockfile update
- [x] No code was copied from StackOverflow, a blog, or OSS
- [x] Comments are not applicable
- [x] XML documentation is not applicable
- [x] Rebased on the latest `main`
- [x] The advisory and Dependabot alert are linked above
- [x] Readme changes are not applicable

## Terminal evidence (merge owner)

- [x] This PR body matches the current template, contains no stale draft instructions, and the PR is ready, not draft
- [x] Exact evidence pair: `baseSha=6e48fe2a7b3b8a628c1ff95335ad6e4a92f7a13c` / `headSha=7aefd9673d5d1d975673abdc610d6875b3fd520e` / `treeSha=a8958ab49e871bf4468745fa137bbaec6f66bc48`
- [x] Actual `agent-utilities:thermo-nuclear-review` finished terminal APPROVE on that exact pair/tree; it found no correctness, breakage, security, or developer-experience findings
- [x] Actual `agent-utilities:thermo-nuclear-code-quality-review` finished terminal APPROVE on that exact pair/tree; it found no maintainability, minimality, convention, abstraction, branching, or lockfile-correctness findings
- [x] Every finding has an explicit disposition: all three terminal reviewers reported no actionable findings; the unrelated `serialize-javascript` and `uuid` alerts remain separate queued root-boundary fixes
- [x] Applicable checks pass on that exact pair: frozen pnpm install; exact dependency resolution; typecheck; 57 website unit tests; content, links, SEO, search budgets, production Docusaurus/Pagefind build; format; GitHub CodeQL/DevSkim/documentation/dependency-submission checks; and Azure Humanizer-CI
- [x] `compound-engineering:ce-babysit-pr` invocation `4ad1bc4d5c3f4ab99d5fb920c08dc03b` covered the exact pair through review and CI with 314 quiet seconds, zero feedback/CI backlog, current base, and CLEAN merge state
- [x] The exact pair was recorded before reviews; no base, head, or tree replacement occurred
- [x] All actionable review threads are resolved; there were no `needs-human` items
- [x] The head is current and mergeable, and terminal hosted CI and ruleset checks are green
- [x] Security: actual `codex-security:validation` finished terminal APPROVE; 1.1.16 is absent, exactly one 1.1.18 path remains, frozen install preserves lockfile integrity, the advisory-shaped bounded probe terminates, and legitimate brace expansion remains intact
- [x] Rendered docs/site/UI: production site, Pagefind, content, links, SEO, search budgets, browser behavior, and accessibility passed; visual theme changes are N/A
- [x] Localization/source generator: N/A
- [x] Immediately before merge, the merge owner will reauthenticate that this recorded pair exactly matches live base and head; any mismatch refuses the merge
