### PR TITLE
fix(deps): update serialize-javascript

### DIFF
--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  serialize-javascript@<7.0.5: 7.0.5
+
 importers:
 
   .:
@@ -4557,9 +4560,6 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
     engines: {node: '>= 0.6'}
@@ -4829,8 +4829,9 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+    engines: {node: '>=20.0.0'}
 
   serve-handler@6.1.7:
     resolution: {integrity: sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==}
@@ -9028,7 +9029,7 @@ snapshots:
       globby: 13.2.2
       normalize-path: 3.0.0
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       webpack: 5.109.0(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.23)
 
   core-js-compat@3.49.0:
@@ -9094,7 +9095,7 @@ snapshots:
       jest-worker: 29.7.0
       postcss: 8.5.23
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       webpack: 5.109.0(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.23)
     optionalDependencies:
       clean-css: 5.3.3
@@ -11507,10 +11508,6 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   range-parser@1.2.0: {}
 
   range-parser@1.2.1: {}
@@ -11864,9 +11861,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.0.5: {}
 
   serve-handler@6.1.7:
     dependencies:

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 allowBuilds:
   core-js: false
 minimumReleaseAge: 2880
+overrides:
+  'serialize-javascript@<7.0.5': 7.0.5
 trustPolicy: no-downgrade
 trustPolicyExclude:
   - '@algolia/client-analytics@4.27.0'


### PR DESCRIPTION
## Summary

This removes the vulnerable `serialize-javascript` 6.0.2 resolution from the website build graph. A workspace-level bounded override now resolves 7.0.5 for affected transitive consumers, closing both the code-execution and algorithmic-denial-of-service advisories while preserving the declared Docusaurus dependency surface.

Related: [GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq), [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v), and Dependabot alerts 1 and 3.

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings
- [x] Regression evidence covers both dependency and advisory boundaries; a source unit test is not applicable to a transitive lockfile override
- [x] No code was copied from StackOverflow, a blog, or OSS
- [x] Comments and XML documentation are not applicable
- [x] Rebased on the latest `main`
- [x] The advisories and Dependabot alerts are linked above
- [x] Readme changes are not applicable

## Terminal evidence (merge owner)

- [x] This PR body matches the current template, contains no stale draft instructions, and the PR is ready, not draft
- [x] Exact evidence pair: `baseSha=98522306c45e43d5de26779b443e9c4b1c3ecac2` / `headSha=d41e556f54acb62cb82916e07e850305635ed68b` / `treeSha=07699fe723c322c3a10ae89a14759b94f9837691`
- [x] Actual `agent-utilities:thermo-nuclear-review` finished terminal APPROVE on that exact pair/tree; it found no correctness, breakage, security, compatibility, or developer-experience findings
- [x] Actual `agent-utilities:thermo-nuclear-code-quality-review` finished terminal APPROVE on that exact pair/tree; it found no maintainability, override-placement, lockfile-correctness, minimality, or convention findings
- [x] Every finding has an explicit disposition: both advisories were validated on the base and fixed on the head; all reviewers reported no residual findings; the unrelated `uuid` alert remains a separate queued boundary
- [x] Applicable checks pass on that exact pair: frozen pnpm install and supply-chain policy; byte-identical lock regeneration; single-version resolution; typecheck; 57 website unit tests; content, artifact, links, SEO, search budgets, production Docusaurus/Pagefind build; GitHub CodeQL/DevSkim/documentation/dependency-submission checks; and Azure Humanizer-CI
- [x] `compound-engineering:ce-babysit-pr` invocation `c3dd7aab7e064dc98685bf63beec391a` covered the exact pair through review and CI with 353 quiet seconds, zero feedback/CI backlog, current base, and CLEAN merge state
- [x] The replacement exact pair was recorded before reviews; no later base, head, or tree change occurred
- [x] All actionable review threads are resolved; CodeRabbit reported no actionable comments and there were no `needs-human` items
- [x] The head is current and mergeable, and terminal hosted CI and ruleset checks are green
- [x] Security: actual `codex-security:validation` finished terminal APPROVE; 6.0.2 is absent, one 7.0.5 path serves both consumers, alternate direct vulnerable requests cannot survive frozen resolution, RegExp/Date injection probes fail safely, and the crafted array-like DoS drops from a base timeout to about 0.01 ms
- [x] Rendered docs/site/UI: production site, Pagefind, content, artifacts, links, SEO, search budgets, hosted browser behavior, and accessibility passed; visual theme changes are N/A
- [x] Localization/source generator: N/A
- [x] Immediately before merge, the merge owner will reauthenticate that this recorded pair exactly matches live base and head; any mismatch refuses the merge
