### PR TITLE
fix(deps): update uuid

### DIFF
--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   serialize-javascript@<7.0.5: 7.0.5
+  uuid@<11.1.1: 11.1.1
 
 importers:
 
@@ -5262,9 +5263,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   value-equal@1.0.1:
@@ -11980,7 +11980,7 @@ snapshots:
   sockjs@0.3.24:
     dependencies:
       faye-websocket: 0.11.4
-      uuid: 8.3.2
+      uuid: 11.1.1
       websocket-driver: 0.7.5
 
   sort-css-media-queries@2.2.0: {}
@@ -12311,7 +12311,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@8.3.2: {}
+  uuid@11.1.1: {}
 
   value-equal@1.0.1: {}
 

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ allowBuilds:
 minimumReleaseAge: 2880
 overrides:
   'serialize-javascript@<7.0.5': 7.0.5
+  'uuid@<11.1.1': 11.1.1
 trustPolicy: no-downgrade
 trustPolicyExclude:
   - '@algolia/client-analytics@4.27.0'


### PR DESCRIPTION
## Summary

- force the vulnerable transitive `uuid` range to `11.1.1`
- refresh the pnpm lockfile so the Docusaurus development-server path resolves only the fixed release
- preserve the existing package-manager supply-chain policy

Closes Dependabot alert #2 (`GHSA-w5hq-g745-h8pq`).

## Exact review pair

- Base: `92aefe62aca0f9432a05bb6c5e988854ef91c868`
- Head: `cd849501ed32b9f21106c7f56a3d8677e6c1529e`
- Tree: `36f99cf6b4f0e57535dbc28b5da526e61523a2ec`

Review evidence below must apply to this exact base/head/tree. Any head update invalidates it.

## Validation

- `corepack pnpm --dir website install --frozen-lockfile`
- `corepack pnpm --dir website why uuid` (single `uuid@11.1.1` resolution)
- `corepack pnpm --dir website audit --prod --json` (zero advisories)
- `corepack pnpm --dir website test:unit` (57/57)
- `corepack pnpm --dir website typecheck`
- `corepack pnpm --dir website clear && corepack pnpm --dir website build`
- `git diff --check origin/main...HEAD`

## Required terminal gates

- [x] Codex Security adversarial validation: APPROVE on exact base/head/tree; reproduced the base bounds defect and verified fixed malicious plus legitimate controls
- [x] Thermo Nuclear Review: APPROVE on exact base/head/tree; verified dependency compatibility, supply-chain integrity, audit, tests, and production build
- [x] Thermo Nuclear Code Quality Review: APPROVE on exact base/head/tree; verified minimal canonical override and byte-identical lock regeneration
- [x] Hosted CI: terminal green, including CodeQL, DevSkim, documentation, dependency submission, CodeRabbit, and Azure Humanizer-CI
- [x] CE babysit: invocation `6c5926babc6f4c8baa5fbdb1550c9aab`; zero actionable backlog and `merge-ready` after the five-minute quiet settle

## Merge and main reconciliation

- Merge: `0593e2f1af91787067ebf965111c376e14ec610c`
- Merge parents: exact base `92aefe62aca0f9432a05bb6c5e988854ef91c868` and exact head `cd849501ed32b9f21106c7f56a3d8677e6c1529e`
- Merge tree: exact reviewed tree `36f99cf6b4f0e57535dbc28b5da526e61523a2ec`
- Merged-main adversarial and legitimate controls passed for UUID v3/v5/v6 bounds and SockJS CommonJS use
- Dependabot alert #2 automatically transitioned to `fixed`; no dismissal
- Open Dependabot, code-scanning, and secret-scanning alert sets are empty
