### PR TITLE
fix(clock): correct Latvian and Maltese minute agreement

### DIFF
--- a/src/Humanizer/Locales/lv.yml
+++ b/src/Humanizer/Locales/lv.yml
@@ -1058,6 +1058,7 @@ surfaces:
   clock:
     engine: 'phrase-clock'
     hourMode: 'h24'
+    minuteGender: 'feminine'
     min0: '{hour}'
     min5: '{hour} un piecas'
     defaultTemplate: '{hour} un {minutes}'

--- a/src/Humanizer/Locales/mt.yml
+++ b/src/Humanizer/Locales/mt.yml
@@ -552,6 +552,8 @@ surfaces:
     engine: 'phrase-clock'
     hourMode: 'h12'
     hourGender: 'feminine'
+    minuteWordsMap:
+      1: 'minuta'
     min0: 'is-siegħa {hour}'
     defaultTemplate: 'is-siegħa {hour} u {minutes}'
 

--- a/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.cs
+++ b/tests/Humanizer.SourceGenerators.Tests/SourceGenerators/HumanizerSourceGeneratorTests.cs
@@ -107,6 +107,17 @@ surfaces:
     }
 
     [Fact]
+    public void TimeOnlyClockNotationProfilesEmitLatvianAndMalteseMinuteAgreement()
+    {
+        var source = GetGeneratedSource("TimeOnlyToClockNotationProfileCatalog.g.cs");
+        var latvianProfile = ExtractCacheClassBody(source, "lv_cache");
+        var malteseProfile = ExtractCacheClassBody(source, "mt_cache");
+
+        Assert.Contains("GrammaticalGender.Feminine", latvianProfile, StringComparison.Ordinal);
+        Assert.Contains("new string[] { \"\", \"minuta\" }", malteseProfile, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ChildClockMinuteWordsOverrideEquivalentParentNumericKeys()
     {
         const string parentLocale = """

--- a/tests/Humanizer.Tests/Localisation/LocaleCoverageData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocaleCoverageData.cs
@@ -692,7 +692,7 @@ static class LocaleCoverageData
         { "ku", new(13, 23, "یەک و بیست و پێنجی ئێوارە") },
         { "lb", new(13, 23, "fënnef vir hallwer zwou") },
         { "lt", new(13, 23, "trylika valandų dvidešimt penkios minutės") },
-        { "lv", new(13, 23, "trīspadsmit un divdesmit pieci") },
+        { "lv", new(13, 23, "trīspadsmit un divdesmit piecas") },
         { "ms", new(13, 23, "pukul satu dua puluh lima petang") },
         { "mt", new(13, 23, "is-siegħa waħda u ħamsa u għoxrin") },
         { "nb", new(13, 23, "tretten tjuefem") },

--- a/tests/Humanizer.Tests/Localisation/lv/LatvianClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/lv/LatvianClockNotationTests.cs
@@ -1,0 +1,27 @@
+namespace Humanizer.Tests.Localisation.lv;
+
+#if NET6_0_OR_GREATER
+[UseCulture("lv")]
+public class LatvianClockNotationTests
+{
+    static readonly CultureInfo LvLv = new("lv-LV");
+
+    [Theory]
+    [InlineData(1, "pieci un viena")]
+    [InlineData(2, "pieci un divas")]
+    [InlineData(21, "pieci un divdesmit viena")]
+    [InlineData(22, "pieci un divdesmit divas")]
+    public void ToClockNotation_UsesMinuteValuesThatAgreeWithTheMinuteNoun(int minutes, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(5, minutes).ToClockNotation(ClockNotationRounding.None));
+    }
+
+    [Fact]
+    public void ToClockNotation_RegionalCultureUsesLatvianProfile()
+    {
+        Assert.Equal(
+            "pieci un divdesmit divas",
+            new TimeOnly(5, 22).ToClockNotation(ClockNotationRounding.None, LvLv));
+    }
+}
+#endif

--- a/tests/Humanizer.Tests/Localisation/mt/MalteseClockNotationTests.cs
+++ b/tests/Humanizer.Tests/Localisation/mt/MalteseClockNotationTests.cs
@@ -1,0 +1,26 @@
+namespace Humanizer.Tests.Localisation.mt;
+
+#if NET6_0_OR_GREATER
+[UseCulture("mt")]
+public class MalteseClockNotationTests
+{
+    static readonly CultureInfo MtMt = new("mt-MT");
+
+    [Theory]
+    [InlineData(1, "is-siegħa ħamsa u minuta")]
+    [InlineData(2, "is-siegħa ħamsa u tnejn")]
+    [InlineData(21, "is-siegħa ħamsa u wieħed u għoxrin")]
+    public void ToClockNotation_UsesTheOneMinuteConstructionWithoutChangingOtherMinuteValues(int minutes, string expected)
+    {
+        Assert.Equal(expected, new TimeOnly(5, minutes).ToClockNotation(ClockNotationRounding.None));
+    }
+
+    [Fact]
+    public void ToClockNotation_RegionalCultureUsesMalteseProfile()
+    {
+        Assert.Equal(
+            "is-siegħa ħamsa u minuta",
+            new TimeOnly(5, 1).ToClockNotation(ClockNotationRounding.None, MtMt));
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Latvian clock phrases now use feminine minute-number forms, while Maltese one-minute phrases now render `minuta` instead of the bare cardinal. The correction stays in generated locale metadata, applies through the accepted `lv-LV` and `mt-MT` routes, and leaves the other 100 clock profiles unchanged.

Related: #1918

## Validation

- Exhaustive clock matrix: 293,760 rows across all 102 locale profiles, every hour/minute pair, and both rounding modes; only `lv` and `mt` changed, with no missing or extra keys.
- Humanizer runtime suite: .NET 8, 10, and 11 passed with zero failures (one intentional performance-gate skip per target).
- Source-generator suite: 350/350 passed on both .NET 10 and .NET 11.
- Release packaging compiled .NET Standard 2.0, .NET Framework 4.8, .NET 8, .NET 10, and .NET 11; package verification passed.
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`: 0 of 2,885 files changed.
- Post-merge verification on `d6d200786294fe21c281cc5ea1337c1803d9ea5f`: Latvian 5/5 and Maltese 4/4 clock tests passed on each of .NET 8, .NET 10, and .NET 11; the generator agreement assertion passed on .NET 10 and .NET 11.

Here is a checklist you should tick through before submitting a pull request: 
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards; e.g. no curlies for one-line blocks, no redundant empty lines between methods or code blocks, spaces rather than tabs, etc.
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow (or a blog or OSS) full disclosure is included. That includes required license files and/or file headers explaining where the code came from with proper attribution
 - [x] There are very few or no comments (because comments shouldn't be needed if you write clean code)
 - [x] Xml documentation is added/updated for the addition/change
 - [ ] Your PR is (re)based on top of the latest commits from the `main` branch (more info below)
 - [x] Link to the issue(s) you're fixing from your PR description. Use `fixes #<the issue number>`
 - [x] Readme is updated if you change an existing feature or add a new one
 - [x] Run the applicable validation from `AGENTS.md`; documentation changes include the documentation gates

## Terminal evidence (merge owner)

 - [x] This PR body matches the current template, contains no stale draft instructions, and the PR is ready, not draft
 - [x] Exact evidence pair: `baseSha=d6fc84b2211a59bf49cb227b98c827856052b64d` / `headSha=7f54efff0e641d2c6c58480552e24ea24d6381e4`
 - [x] Thermos correctness, breakage, security, and developer-experience review finished final clean/APPROVE and merge-eligible on that exact pair: `APPROVE; no findings`
 - [x] Thermos code-quality and maintainability review finished final clean/APPROVE and merge-eligible on that exact pair: `APPROVE; no findings`
 - [x] Every finding has an explicit disposition: valid findings were fixed and both reviews reran on the replacement pair; invalid or non-actionable findings record evidence, reason, and final reviewer acceptance; or reviewers accepted `no valid findings; no push required`: `Both reviewers accepted no valid findings; no push required`
 - [x] Applicable tests, format, build, package, documentation, browser, security, and platform gates pass on that exact pair: runtime net8/net10/net11, source generators net10/net11, Release pack including net48, package verification, exhaustive 102-locale matrix, and diagnostic format all pass
 - [x] `compound-engineering:ce-babysit-pr` covered the exact pair through the current-head reviewer lifecycle, CI, and base movement; terminal clean evidence: `CLEAN/MERGEABLE/APPROVED, 11 passed checks, 6 intentional deployment skips, zero pending or failed checks, zero feedback backlog`
 - [x] If either SHA changed, the PR body was first updated with the replacement `{baseSha, headSha}` pair; both Thermos reviews, every applicable check, and babysitting then reran against that recorded pair; stale evidence was removed: `N/A; reviewed head remained unchanged`
 - [x] All actionable review threads are resolved; any `needs-human` item pauses merge: `zero open threads, comments, or needs-human items`
 - [x] The head is current and mergeable, and terminal hosted CI and ruleset checks are green: `GitHub reported CLEAN/MERGEABLE and integrated the exact head onto then-current main 76e14811f5da3a82bb71156a5793317b17c65dc4`
 - [x] Security: Codex Security proof-of-concept or attack-path closure passes, or N/A: `N/A; locale-data correction with no security boundary change`
 - [x] Rendered docs/site/UI: desktop, mobile, light, dark, accessibility, links, and version snapshots pass for affected rendered surfaces, or N/A: `N/A; no rendered surface changed`
 - [x] Localization/source generator: applicable locale, schema, generator, and runtime matrices pass with no partial or English fallback, or N/A: `293,760-row exhaustive clock matrix plus full generator/runtime suites; all unaffected profiles byte-identical`
 - [x] Immediately before merge, the merge owner reauthenticated that the recorded head exactly matched the live head; exact approved head `7f54efff0e641d2c6c58480552e24ea24d6381e4` merged normally as `d6d200786294fe21c281cc5ea1337c1803d9ea5f`
