### PR TITLE
fix(security): bound compound-scale parsing

### DIFF
--- a/src/Humanizer/Localisation/WordsToNumber/CompoundScaleWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/CompoundScaleWordsToNumberConverter.cs
@@ -14,6 +14,8 @@ namespace Humanizer;
 /// </summary>
 internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberProfile profile) : GenderlessWordsToNumberConverter
 {
+    const int MaximumParseDepth = 128;
+
     readonly CompoundScaleWordsToNumberProfile profile = profile;
 
     /// <inheritdoc />
@@ -85,6 +87,19 @@ internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberPro
     /// <returns><c>true</c> if the phrase was parsed successfully; otherwise, <c>false</c>.</returns>
     bool TryParseCardinal(string words, out long value)
     {
+        var remainingWork = (long)words.Length * 32L;
+        return TryParseCardinal(words, 0, ref remainingWork, out value);
+    }
+
+    bool TryParseCardinal(string words, int depth, ref long remainingWork, out long value)
+    {
+        if (depth >= MaximumParseDepth || remainingWork-- <= 0)
+        {
+            remainingWork = -1;
+            value = default;
+            return false;
+        }
+
         if (profile.CardinalMap.TryGetValue(words, out value))
         {
             return true;
@@ -107,7 +122,7 @@ internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberPro
                     continue;
                 }
 
-                if (!TryParseCardinal(token, out var tokenValue))
+                if (!TryParseCardinal(token, depth + 1, ref remainingWork, out var tokenValue))
                 {
                     value = default;
                     return false;
@@ -149,12 +164,31 @@ internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberPro
             var right = words[(index + scale.Length)..].Trim();
             long factor = 1;
 
-            if ((string.IsNullOrEmpty(left) || TryParseCardinal(left, out factor)) &&
-                TryParseOptional(right, out var remainder))
+            if (!string.IsNullOrEmpty(left) &&
+                !TryParseCardinal(left, depth + 1, ref remainingWork, out factor))
             {
-                value = checked(checked(factor * profile.CardinalMap[scale]) + remainder);
-                return true;
+                if (remainingWork < 0)
+                {
+                    value = default;
+                    return false;
+                }
+
+                continue;
             }
+
+            if (!TryParseOptional(right, depth + 1, ref remainingWork, out var remainder))
+            {
+                if (remainingWork < 0)
+                {
+                    value = default;
+                    return false;
+                }
+
+                continue;
+            }
+
+            value = checked(checked(factor * profile.CardinalMap[scale]) + remainder);
+            return true;
         }
 
         // The tens fallback handles glued compounds where the tens stem is written as one token
@@ -174,10 +208,16 @@ internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberPro
                 return true;
             }
 
-            if (TryParseCardinal(remainder, out var unit) && unit is >= 1 and <= 9)
+            if (TryParseCardinal(remainder, depth + 1, ref remainingWork, out var unit) && unit is >= 1 and <= 9)
             {
                 value = checked(profile.CardinalMap[tens] + unit);
                 return true;
+            }
+
+            if (remainingWork < 0)
+            {
+                value = default;
+                return false;
             }
         }
 
@@ -191,7 +231,7 @@ internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberPro
     /// <param name="words">The remainder text following a scale token.</param>
     /// <param name="value">When this method returns, the parsed remainder value.</param>
     /// <returns><c>true</c> if the remainder is empty or parsed successfully; otherwise, <c>false</c>.</returns>
-    bool TryParseOptional(string words, out long value)
+    bool TryParseOptional(string words, int depth, ref long remainingWork, out long value)
     {
         if (string.IsNullOrEmpty(words))
         {
@@ -212,7 +252,7 @@ internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberPro
             }
         }
 
-        return TryParseCardinal(words, out value);
+        return TryParseCardinal(words, depth, ref remainingWork, out value);
     }
 
     /// <summary>

--- a/src/Humanizer/Localisation/WordsToNumber/CompoundScaleWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/CompoundScaleWordsToNumberConverter.cs
@@ -118,21 +118,10 @@ internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberPro
             // Multi-token phrases are reduced left to right. Small tokens accumulate into the
             // current group, while scale tokens flush the current group into the total using the
             // locale's scale-multiplier semantics.
-            while (!words.IsEmpty)
+            var tokenizer = new WordsToNumberTokenizer.Enumerator(words);
+            while (tokenizer.MoveNext())
             {
-                while (!words.IsEmpty && words[0] == ' ')
-                {
-                    words = words[1..];
-                }
-
-                if (words.IsEmpty)
-                {
-                    break;
-                }
-
-                var separatorIndex = words.IndexOf(' ');
-                var token = separatorIndex < 0 ? words : words[..separatorIndex];
-                words = separatorIndex < 0 ? [] : words[(separatorIndex + 1)..];
+                var token = tokenizer.Current;
 
                 if (token.SequenceEqual(profile.IgnoredToken))
                 {

--- a/src/Humanizer/Localisation/WordsToNumber/CompoundScaleWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/CompoundScaleWordsToNumberConverter.cs
@@ -87,11 +87,16 @@ internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberPro
     /// <returns><c>true</c> if the phrase was parsed successfully; otherwise, <c>false</c>.</returns>
     bool TryParseCardinal(string words, out long value)
     {
+        if (profile.CardinalMap.TryGetValue(words, out value))
+        {
+            return true;
+        }
+
         var remainingWork = (long)words.Length * 32L;
-        return TryParseCardinal(words, 0, ref remainingWork, out value);
+        return TryParseCardinal(words.AsSpan(), 0, ref remainingWork, out value);
     }
 
-    bool TryParseCardinal(string words, int depth, ref long remainingWork, out long value)
+    bool TryParseCardinal(ReadOnlySpan<char> words, int depth, ref long remainingWork, out long value)
     {
         if (depth >= MaximumParseDepth || remainingWork-- <= 0)
         {
@@ -100,7 +105,7 @@ internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberPro
             return false;
         }
 
-        if (profile.CardinalMap.TryGetValue(words, out value))
+        if (TryGetValue(profile.CardinalMap, words, out value))
         {
             return true;
         }
@@ -113,11 +118,23 @@ internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberPro
             // Multi-token phrases are reduced left to right. Small tokens accumulate into the
             // current group, while scale tokens flush the current group into the total using the
             // locale's scale-multiplier semantics.
-            foreach (var tokenSpan in WordsToNumberTokenizer.Enumerate(words))
+            while (!words.IsEmpty)
             {
-                var token = tokenSpan.ToString();
+                while (!words.IsEmpty && words[0] == ' ')
+                {
+                    words = words[1..];
+                }
 
-                if (token == profile.IgnoredToken)
+                if (words.IsEmpty)
+                {
+                    break;
+                }
+
+                var separatorIndex = words.IndexOf(' ');
+                var token = separatorIndex < 0 ? words : words[..separatorIndex];
+                words = separatorIndex < 0 ? [] : words[(separatorIndex + 1)..];
+
+                if (token.SequenceEqual(profile.IgnoredToken))
                 {
                     continue;
                 }
@@ -154,17 +171,17 @@ internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberPro
         // left-to-right reduction.
         foreach (var scale in profile.LargeScales)
         {
-            var index = words.IndexOf(scale, StringComparison.Ordinal);
+            var index = words.IndexOf(scale.AsSpan(), StringComparison.Ordinal);
             if (index < 0)
             {
                 continue;
             }
 
-            var left = words[..index].Trim();
-            var right = words[(index + scale.Length)..].Trim();
+            var left = TrimSpaces(words[..index]);
+            var right = TrimSpaces(words[(index + scale.Length)..]);
             long factor = 1;
 
-            if (!string.IsNullOrEmpty(left) &&
+            if (!left.IsEmpty &&
                 !TryParseCardinal(left, depth + 1, ref remainingWork, out factor))
             {
                 if (remainingWork < 0)
@@ -196,13 +213,13 @@ internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberPro
         // fallback cannot swallow unrelated larger cardinals.
         foreach (var tens in profile.Tens)
         {
-            if (!words.StartsWith(tens, StringComparison.Ordinal))
+            if (!words.StartsWith(tens.AsSpan(), StringComparison.Ordinal))
             {
                 continue;
             }
 
             var remainder = words[tens.Length..];
-            if (string.IsNullOrEmpty(remainder))
+            if (remainder.IsEmpty)
             {
                 value = profile.CardinalMap[tens];
                 return true;
@@ -231,9 +248,9 @@ internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberPro
     /// <param name="words">The remainder text following a scale token.</param>
     /// <param name="value">When this method returns, the parsed remainder value.</param>
     /// <returns><c>true</c> if the remainder is empty or parsed successfully; otherwise, <c>false</c>.</returns>
-    bool TryParseOptional(string words, int depth, ref long remainingWork, out long value)
+    bool TryParseOptional(ReadOnlySpan<char> words, int depth, ref long remainingWork, out long value)
     {
-        if (string.IsNullOrEmpty(words))
+        if (words.IsEmpty)
         {
             value = 0;
             return true;
@@ -241,18 +258,50 @@ internal class CompoundScaleWordsToNumberConverter(CompoundScaleWordsToNumberPro
 
         if (!string.IsNullOrEmpty(profile.IgnoredToken))
         {
-            var ignoredTokenWithSpace = profile.IgnoredToken + " ";
-            if (words.StartsWith(ignoredTokenWithSpace, StringComparison.Ordinal))
+            var ignoredToken = profile.IgnoredToken.AsSpan();
+            if (words.StartsWith(ignoredToken, StringComparison.Ordinal) &&
+                words.Length > ignoredToken.Length &&
+                words[ignoredToken.Length] == ' ')
             {
-                words = words[ignoredTokenWithSpace.Length..];
+                words = words[(ignoredToken.Length + 1)..];
             }
-            else if (words.StartsWith(profile.IgnoredToken, StringComparison.Ordinal))
+            else if (words.StartsWith(ignoredToken, StringComparison.Ordinal))
             {
-                words = words[profile.IgnoredToken.Length..];
+                words = words[ignoredToken.Length..];
             }
         }
 
         return TryParseCardinal(words, depth, ref remainingWork, out value);
+    }
+
+    static bool TryGetValue(FrozenDictionary<string, long> values, ReadOnlySpan<char> word, out long value)
+    {
+        foreach (var candidate in values)
+        {
+            if (word.Equals(candidate.Key.AsSpan(), StringComparison.Ordinal))
+            {
+                value = candidate.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    static ReadOnlySpan<char> TrimSpaces(ReadOnlySpan<char> words)
+    {
+        while (!words.IsEmpty && words[0] == ' ')
+        {
+            words = words[1..];
+        }
+
+        while (!words.IsEmpty && words[^1] == ' ')
+        {
+            words = words[..^1];
+        }
+
+        return words;
     }
 
     /// <summary>

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -1789,31 +1789,12 @@ public class CoverageGapTests
         Assert.Equal(string.Empty, unrecognizedWord);
 
         var compound = new CompoundScaleWordsToNumberConverter(CompoundScaleProfile);
-        object?[] emptyOptionalArguments = [string.Empty, 0, 1000L, 1L];
-        Assert.True(InvokePrivate<bool>(
-            typeof(CompoundScaleWordsToNumberConverter),
-            compound,
-            "TryParseOptional",
-            [typeof(string), typeof(int), typeof(long).MakeByRefType(), typeof(long).MakeByRefType()],
-            emptyOptionalArguments));
-        Assert.Equal(0L, emptyOptionalArguments[3]);
-
-        object?[] optionalArguments = ["and five", 0, 1000L, 0L];
-        Assert.True(InvokePrivate<bool>(
-            typeof(CompoundScaleWordsToNumberConverter),
-            compound,
-            "TryParseOptional",
-            [typeof(string), typeof(int), typeof(long).MakeByRefType(), typeof(long).MakeByRefType()],
-            optionalArguments));
-        Assert.Equal(5L, optionalArguments[3]);
-        object?[] gluedIgnoredArguments = ["andfive", 0, 1000L, 0L];
-        Assert.True(InvokePrivate<bool>(
-            typeof(CompoundScaleWordsToNumberConverter),
-            compound,
-            "TryParseOptional",
-            [typeof(string), typeof(int), typeof(long).MakeByRefType(), typeof(long).MakeByRefType()],
-            gluedIgnoredArguments));
-        Assert.Equal(5L, gluedIgnoredArguments[3]);
+        Assert.True(compound.TryConvert("onethousand", out parsed));
+        Assert.Equal(1000, parsed);
+        Assert.True(compound.TryConvert("onethousandandfive", out parsed));
+        Assert.Equal(1005, parsed);
+        Assert.True(compound.TryConvert("one thousand and five", out parsed));
+        Assert.Equal(1005, parsed);
 
         var linking = new LinkingAffixWordsToNumberConverter(LinkingAffixProfile);
         Assert.True(linking.TryConvert("minus two", out parsed));

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -1789,31 +1789,31 @@ public class CoverageGapTests
         Assert.Equal(string.Empty, unrecognizedWord);
 
         var compound = new CompoundScaleWordsToNumberConverter(CompoundScaleProfile);
-        object?[] emptyOptionalArguments = [string.Empty, 1L];
+        object?[] emptyOptionalArguments = [string.Empty, 0, 1000L, 1L];
         Assert.True(InvokePrivate<bool>(
             typeof(CompoundScaleWordsToNumberConverter),
             compound,
             "TryParseOptional",
-            [typeof(string), typeof(long).MakeByRefType()],
+            [typeof(string), typeof(int), typeof(long).MakeByRefType(), typeof(long).MakeByRefType()],
             emptyOptionalArguments));
-        Assert.Equal(0L, emptyOptionalArguments[1]);
+        Assert.Equal(0L, emptyOptionalArguments[3]);
 
-        object?[] optionalArguments = ["and five", 0L];
+        object?[] optionalArguments = ["and five", 0, 1000L, 0L];
         Assert.True(InvokePrivate<bool>(
             typeof(CompoundScaleWordsToNumberConverter),
             compound,
             "TryParseOptional",
-            [typeof(string), typeof(long).MakeByRefType()],
+            [typeof(string), typeof(int), typeof(long).MakeByRefType(), typeof(long).MakeByRefType()],
             optionalArguments));
-        Assert.Equal(5L, optionalArguments[1]);
-        object?[] gluedIgnoredArguments = ["andfive", 0L];
+        Assert.Equal(5L, optionalArguments[3]);
+        object?[] gluedIgnoredArguments = ["andfive", 0, 1000L, 0L];
         Assert.True(InvokePrivate<bool>(
             typeof(CompoundScaleWordsToNumberConverter),
             compound,
             "TryParseOptional",
-            [typeof(string), typeof(long).MakeByRefType()],
+            [typeof(string), typeof(int), typeof(long).MakeByRefType(), typeof(long).MakeByRefType()],
             gluedIgnoredArguments));
-        Assert.Equal(5L, gluedIgnoredArguments[1]);
+        Assert.Equal(5L, gluedIgnoredArguments[3]);
 
         var linking = new LinkingAffixWordsToNumberConverter(LinkingAffixProfile);
         Assert.True(linking.TryConvert("minus two", out parsed));

--- a/tests/Humanizer.Tests/WordsToNumberTests.cs
+++ b/tests/Humanizer.Tests/WordsToNumberTests.cs
@@ -531,6 +531,7 @@ public class WordsToNumberTests_Swedish
     [InlineData("tjugoett", 21, null)]
     [InlineData("hundraåtta", 108, null)]
     [InlineData("ett tusen", 1000, null)]
+    [InlineData("etttusenfem", 1005, null)]
     [InlineData("ett tusen hundraelva", 1111, null)]
     [InlineData("en miljon", 1000000, null)]
     [InlineData("första", 1, null)]
@@ -550,6 +551,34 @@ public class WordsToNumberTests_Swedish
         Assert.False(words.TryToNumber(out var parsedNumber, CultureInfo.CurrentCulture, out var unrecognizedWord));
         Assert.Equal(expectedUnrecognizedWord, unrecognizedWord);
         Assert.Equal(expectedNumber, parsedNumber);
+    }
+
+    [Theory]
+    [InlineData("sv-SE", "tusen", "minus ")]
+    [InlineData("nb-NO", "tusen", "minus ")]
+    [InlineData("is-IS", "þúsund", "mínus ")]
+    public void TryToNumber_BoundsCompoundScaleRecursion(string cultureName, string scale, string negativePrefix)
+    {
+        var culture = CultureInfo.GetCultureInfo(cultureName);
+        var legitimateWords = string.Concat(Enumerable.Repeat(scale, 64));
+        Assert.Equal(64000, legitimateWords.ToNumber(culture));
+        Assert.Equal(64000.1m, $"{legitimateWords} komma {1.ToWords(culture)}".ToDecimalNumber(culture));
+
+        var words = string.Concat(Enumerable.Repeat(scale, 256));
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        Assert.False(words.TryToNumber(out var parsedNumber, culture, out var unrecognizedWord));
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        Assert.Equal(0, parsedNumber);
+        Assert.NotNull(unrecognizedWord);
+        Assert.True(allocated < 8_000_000, $"Compound-scale rejection allocated {allocated:N0} bytes.");
+        Assert.Throws<ArgumentException>(() => words.ToNumber(culture));
+
+        Assert.False($"{negativePrefix}{words}".TryToNumber(out parsedNumber, culture, out unrecognizedWord));
+        Assert.Equal(0, parsedNumber);
+        Assert.NotNull(unrecognizedWord);
+        Assert.False($"{words} komma {1.ToWords(culture)}".TryToDecimalNumber(out var parsedDecimal, culture, out unrecognizedWord));
+        Assert.Equal(0, parsedDecimal);
+        Assert.NotNull(unrecognizedWord);
     }
 }
 

--- a/tests/Humanizer.Tests/WordsToNumberTests.cs
+++ b/tests/Humanizer.Tests/WordsToNumberTests.cs
@@ -564,7 +564,7 @@ public class WordsToNumberTests_Swedish
         Assert.Equal(64000, legitimateWords.ToNumber(culture));
         Assert.Equal(64000.1m, $"{legitimateWords} komma {1.ToWords(culture)}".ToDecimalNumber(culture));
 
-        var words = string.Concat(Enumerable.Repeat(scale, 256));
+        var words = string.Concat(Enumerable.Repeat(scale, 20_000));
         var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
         Assert.False(words.TryToNumber(out var parsedNumber, culture, out var unrecognizedWord));
         var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;


### PR DESCRIPTION
## Summary

Compound-scale word parsing now enforces a shared recursion depth and work budget while parsing recursive slices as spans over the original normalized input. This closes both stack exhaustion and recursive substring-allocation amplification while preserving valid Swedish, Norwegian Bokmål, and Icelandic compound numbers.

## Validation

- Exact live-main red control (`8a752fe1962c77bd153359cf94878fa1d0cfddbf`): the sealed 160,000-character Swedish glued-scale PoC terminated the child process with exit 134 after stack exhaustion; the legitimate control parsed as 1,005
- Exact patch green control: the same hostile input returned normally with `accepted=False`; the legitimate control remained accepted with value 1,005
- Security regression matrix: Swedish, Norwegian Bokmål, and Icelandic hostile suffixes; positive, negative, and decimal paths; 64-scale legitimate controls; a 100,000-character malicious allocation regression under 8 MB
- Targeted security tests: 3/3 passed on each of .NET 8, .NET 10, and .NET 11
- Full Humanizer test suite: 61,070/61,070 passed on each of .NET 8, .NET 10, and .NET 11
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`: 0 of 2,824 files changed
- Release package built for net8.0, net10.0, net11.0, net48, and netstandard2.0; analyzer package entries and net8 consumer load verified
- Documentation validation: all frozen snapshots, current API/examples, manifests, upgrade paths, and generated outputs passed
- Current-main integration: no changed-path overlap; `git merge-tree --write-tree origin/main HEAD` completed cleanly as tree `e7d8f41551887704489ab878c2bab16ad74a7afb`
- `git diff --check origin/main...HEAD`: passed

Here is a checklist you should tick through before submitting a pull request:
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow or another source, required attribution is included (N/A: no copied code)
 - [x] Comments are limited to existing parser guidance
 - [x] XML documentation is added or updated (N/A: no public API change)
 - [x] The existing head merges cleanly with current `main`; no unrelated replay is required
 - [x] Link to the issue being fixed (N/A: sealed security-review finding; no public issue)
 - [x] Readme is updated if behavior changes (N/A: supported behavior and public API are unchanged)
 - [x] Applicable validation from `AGENTS.md` passed

## Terminal evidence (merge owner)

 - [x] This PR is ready, not draft
 - [x] Exact evidence pair: `baseSha=76e14811f5da3a82bb71156a5793317b17c65dc4` / `headSha=aecadecab8175849ccb698d1d3c7d7ab8c8e0943`; head tree `267bd618b5704086c3eda1103971e3bec8d8b4ed`; synthetic merge tree `e7d8f41551887704489ab878c2bab16ad74a7afb`
 - [x] Actual `agent-utilities:thermo-nuclear-review` terminal approval on the exact head; no findings
 - [x] Actual `agent-utilities:thermo-nuclear-code-quality-review` terminal approval on the exact head; no findings
 - [x] Every review finding has an explicit disposition; the non-actionable span/LINQ CodeQL suggestion is evidence-backed and resolved without weakening the query
 - [x] Applicable local tests, format, build, package, security, documentation, and platform gates pass
 - [x] `compound-engineering:ce-babysit-pr` covered exact-head reviewer lifecycle, CI, feedback, and a final 316-second quiet settle
 - [x] All actionable review threads are resolved; no `needs-human` item remains
 - [x] The head was CLEAN/MERGEABLE and every hosted CI and ruleset check was terminal green or skipped as expected
 - [x] Actual `codex-security:validation` terminal approval on the exact head; hostile cardinal/negative/decimal matrices, allocation closure, one-million-token controls, and 30,000 randomized roundtrips passed
 - [x] Rendered docs/site/UI: N/A; no rendered surface changed
 - [x] Localization/source generator: runtime-only parser fix; locale data and generation are unchanged
 - [x] Immediately before merge, reauthenticated exact head `aecadecab8175849ccb698d1d3c7d7ab8c8e0943`; normal GitHub merge completed without administrative bypass


## Review correction

The first Thermo pass found that the depth-only head still allocated near-full suffix strings at every recursive frame, measuring about 129x transient allocation amplification. The incremental replacement commit removes those substring allocations by carrying `ReadOnlySpan<char>` slices through every recursive path and enlarges the regression input from 1,280 to 100,000 characters. Unaffected review conclusions remain valid; security and both Thermos reviewers are rerunning the incremental delta and affected gates on this replacement head.

The incremental code-quality pass then identified a duplicated span-tokenization loop. The final delta deletes that copy and reuses `WordsToNumberTokenizer.Enumerator`; affected security tests and all-target Release packaging remain green. Reviewers examined only this final three-line canonical-helper delta plus affected gates.

All three required final-head reviews completed with terminal APPROVE verdicts. The final canonical-tokenizer delta introduced no finding and preserved the previously established linear allocation and recursion/work-budget closure.

## Post-merge closure

- Exact reviewed head `aecadecab8175849ccb698d1d3c7d7ab8c8e0943` merged normally as main `3875517c9ce30f984f5cdbad3126d3f29707ab8c`; merged tree `d0922513b798a40586701b3c6b35a2b48adf3c82`
- Original sealed 160,000-character PoC rerun on merged main: legitimate `etttusenfem` control parsed as 1,005; hostile glued-scale trigger returned normally with `parsed=False`, value 0, exit 0
- Merged-main security regression passed 3/3 on each of .NET 8, .NET 10, and .NET 11 using isolated artifact paths
- Dashboard readback after merge: 0 open Dependabot alerts, 0 open secret-scanning alerts, 0 open security-severity CodeQL alerts, and 0 open DevSkim alerts; no alert was dismissed and no query was weakened
