### PR TITLE
fix(security): bound inverted-tens parsing

### DIFF
--- a/src/Humanizer/Localisation/WordsToNumber/InvertedTensWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/InvertedTensWordsToNumberConverter.cs
@@ -110,9 +110,10 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
                 continue;
             }
 
-            if (!TryParseCompactCore(token, 0, ref remainingWork, out var tokenValue, out unrecognizedWord))
+            if (!TryParseCompactCore(token.AsSpan(), 0, ref remainingWork, out var tokenValue))
             {
                 value = default;
+                unrecognizedWord = token;
                 return false;
             }
 
@@ -145,27 +146,27 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
     bool TryParseCompact(string word, out long value, out string? unrecognizedWord)
     {
         var remainingWork = (long)word.Length * 32L;
-        return TryParseCompactCore(word, 0, ref remainingWork, out value, out unrecognizedWord);
+        var parsed = TryParseCompactCore(word.AsSpan(), 0, ref remainingWork, out value);
+        unrecognizedWord = parsed ? null : word;
+        return parsed;
     }
 
-    bool TryParseCompactCore(string word, int depth, ref long remainingWork, out long value, out string? unrecognizedWord)
+    bool TryParseCompactCore(ReadOnlySpan<char> word, int depth, ref long remainingWork, out long value)
     {
         if (depth >= MaximumParseDepth || remainingWork-- <= 0)
         {
             remainingWork = -1;
             value = default;
-            unrecognizedWord = word;
             return false;
         }
 
-        if (profile.CardinalMap.TryGetValue(word, out value) ||
-            profile.OrdinalMap.TryGetValue(word, out value))
+        if (TryGetValue(profile.CardinalMap, word, out value) ||
+            TryGetValue(profile.OrdinalMap, word, out value))
         {
-            unrecognizedWord = null;
             return true;
         }
 
-        if (TryParseOrdinalStem(word, depth, ref remainingWork, out value, out unrecognizedWord))
+        if (TryParseOrdinalStem(word, depth, ref remainingWork, out value))
         {
             return true;
         }
@@ -180,35 +181,33 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
         // reinterpreted as composites and produce the wrong numeric value.
         foreach (var scale in profile.ScaleTokens)
         {
-            var index = word.IndexOf(scale, StringComparison.Ordinal);
+            var index = word.IndexOf(scale.AsSpan(), StringComparison.Ordinal);
             if (index < 0)
             {
                 continue;
             }
 
             var left = word[..index];
-            var right = StripLeadingIgnoredTokens(word[(index + scale.Length)..].Trim());
+            var right = StripLeadingIgnoredTokens(TrimSpaces(word[(index + scale.Length)..]));
             long factor = 1;
 
-            if (!string.IsNullOrEmpty(left) &&
-                !TryParseCompactCore(left, depth + 1, ref remainingWork, out factor, out _))
+            if (!left.IsEmpty &&
+                !TryParseCompactCore(left, depth + 1, ref remainingWork, out factor))
             {
                 if (remainingWork < 0)
                 {
                     value = default;
-                    unrecognizedWord = word;
                     return false;
                 }
 
                 continue;
             }
 
-            if (!TryParseOptional(right, depth + 1, ref remainingWork, out var remainder, out _))
+            if (!TryParseOptional(right, depth + 1, ref remainingWork, out var remainder))
             {
                 if (remainingWork < 0)
                 {
                     value = default;
-                    unrecognizedWord = word;
                     return false;
                 }
 
@@ -216,13 +215,11 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
             }
 
             value = checked(checked(factor * profile.CardinalMap[scale]) + remainder);
-            unrecognizedWord = null;
             return true;
         }
 
         if (TryParseCompoundTens(word, out value))
         {
-            unrecognizedWord = null;
             return true;
         }
 
@@ -231,9 +228,8 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
         // failure token from the explicit token and scale branches above.
         if (word.Contains(' '))
         {
-            var collapsed = word.Replace(" ", string.Empty);
-            if (!ReferenceEquals(word, collapsed) &&
-                TryParseCompactCore(collapsed, depth + 1, ref remainingWork, out value, out unrecognizedWord))
+            var collapsed = word.ToString().Replace(" ", string.Empty);
+            if (TryParseCompactCore(collapsed.AsSpan(), depth + 1, ref remainingWork, out value))
             {
                 return true;
             }
@@ -241,13 +237,11 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
             if (remainingWork < 0)
             {
                 value = default;
-                unrecognizedWord = word;
                 return false;
             }
         }
 
         value = default;
-        unrecognizedWord = word;
         return false;
     }
 
@@ -256,22 +250,20 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
     /// </summary>
     /// <param name="word">The normalized token to inspect.</param>
     /// <param name="value">When this method returns, the parsed numeric value.</param>
-    /// <param name="unrecognizedWord">When parsing fails, the stem that could not be parsed.</param>
     /// <returns><c>true</c> if an ordinal suffix was recognized and the stem parsed; otherwise, <c>false</c>.</returns>
-    bool TryParseOrdinalStem(string word, int depth, ref long remainingWork, out long value, out string? unrecognizedWord)
+    bool TryParseOrdinalStem(ReadOnlySpan<char> word, int depth, ref long remainingWork, out long value)
     {
         foreach (var suffix in profile.OrdinalSuffixes)
         {
-            if (!word.EndsWith(suffix, StringComparison.Ordinal) || word.Length == suffix.Length)
+            if (!word.EndsWith(suffix.AsSpan(), StringComparison.Ordinal) || word.Length == suffix.Length)
             {
                 continue;
             }
 
-            return TryParseCompactCore(word[..^suffix.Length], depth + 1, ref remainingWork, out value, out unrecognizedWord);
+            return TryParseCompactCore(word[..^suffix.Length], depth + 1, ref remainingWork, out value);
         }
 
         value = default;
-        unrecognizedWord = null;
         return false;
     }
 
@@ -280,18 +272,16 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
     /// </summary>
     /// <param name="word">The normalized fragment to parse.</param>
     /// <param name="value">When this method returns, the parsed numeric value.</param>
-    /// <param name="unrecognizedWord">When parsing fails, the fragment that could not be parsed.</param>
     /// <returns><c>true</c> if the fragment was parsed successfully; otherwise, <c>false</c>.</returns>
-    bool TryParseOptional(string word, int depth, ref long remainingWork, out long value, out string? unrecognizedWord)
+    bool TryParseOptional(ReadOnlySpan<char> word, int depth, ref long remainingWork, out long value)
     {
-        if (string.IsNullOrEmpty(word))
+        if (word.IsEmpty)
         {
             value = 0;
-            unrecognizedWord = null;
             return true;
         }
 
-        return TryParseCompactCore(word, depth, ref remainingWork, out value, out unrecognizedWord);
+        return TryParseCompactCore(word, depth, ref remainingWork, out value);
     }
 
     /// <summary>
@@ -300,23 +290,26 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
     /// <param name="word">The normalized compact token to parse.</param>
     /// <param name="value">When this method returns, the parsed numeric value.</param>
     /// <returns><c>true</c> if the token matched a supported unit-plus-tens pattern; otherwise, <c>false</c>.</returns>
-    bool TryParseCompoundTens(string word, out long value)
+    bool TryParseCompoundTens(ReadOnlySpan<char> word, out long value)
     {
         foreach (var tensToken in profile.TensTokens)
         {
-            if (!word.EndsWith(tensToken.Word, StringComparison.Ordinal))
+            if (!word.EndsWith(tensToken.Word.AsSpan(), StringComparison.Ordinal))
             {
                 continue;
             }
 
             var prefix = word[..^tensToken.Word.Length];
-            if (!prefix.EndsWith(profile.TensLinker, StringComparison.Ordinal))
+            if (!prefix.EndsWith(profile.TensLinker.AsSpan(), StringComparison.Ordinal))
             {
                 continue;
             }
 
-            var unitPart = ApplyUnitPartReplacements(prefix[..^profile.TensLinker.Length]);
-            if (profile.UnitMap.TryGetValue(unitPart, out var unitValue) && unitValue is >= 1 and <= 9)
+            var unitPart = prefix[..^profile.TensLinker.Length];
+            var foundUnit = profile.UnitPartReplacements.Length == 0
+                ? TryGetValue(profile.UnitMap, unitPart, out var unitValue)
+                : profile.UnitMap.TryGetValue(ApplyUnitPartReplacements(unitPart.ToString()), out unitValue);
+            if (foundUnit && unitValue is >= 1 and <= 9)
             {
                 value = tensToken.Value + unitValue;
                 return true;
@@ -332,9 +325,9 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
     /// </summary>
     /// <param name="words">The normalized remainder to trim.</param>
     /// <returns>The remainder without any configured leading ignored tokens.</returns>
-    string StripLeadingIgnoredTokens(string words)
+    ReadOnlySpan<char> StripLeadingIgnoredTokens(ReadOnlySpan<char> words)
     {
-        if (string.IsNullOrEmpty(words))
+        if (words.IsEmpty)
         {
             return words;
         }
@@ -348,24 +341,55 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
 
             foreach (var ignoredToken in profile.IgnoredTokens)
             {
-                var ignoredTokenWithSpace = ignoredToken + " ";
-                if (remaining.StartsWith(ignoredTokenWithSpace, StringComparison.Ordinal))
+                if (string.IsNullOrEmpty(ignoredToken) ||
+                    !remaining.StartsWith(ignoredToken.AsSpan(), StringComparison.Ordinal))
                 {
-                    remaining = remaining[ignoredTokenWithSpace.Length..].TrimStart();
-                    stripped = true;
-                    break;
+                    continue;
                 }
 
-                if (remaining.StartsWith(ignoredToken, StringComparison.Ordinal))
-                {
-                    remaining = remaining[ignoredToken.Length..].TrimStart();
-                    stripped = true;
-                    break;
-                }
+                remaining = TrimStartSpaces(remaining[ignoredToken.Length..]);
+                stripped = true;
+                break;
             }
         }
 
         return remaining;
+    }
+
+    static bool TryGetValue(FrozenDictionary<string, long> values, ReadOnlySpan<char> word, out long value)
+    {
+        foreach (var candidate in values)
+        {
+            if (word.Equals(candidate.Key.AsSpan(), StringComparison.Ordinal))
+            {
+                value = candidate.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    static ReadOnlySpan<char> TrimSpaces(ReadOnlySpan<char> words)
+    {
+        var trimmed = TrimStartSpaces(words);
+        while (!trimmed.IsEmpty && trimmed[^1] == ' ')
+        {
+            trimmed = trimmed[..^1];
+        }
+
+        return trimmed;
+    }
+
+    static ReadOnlySpan<char> TrimStartSpaces(ReadOnlySpan<char> words)
+    {
+        while (!words.IsEmpty && words[0] == ' ')
+        {
+            words = words[1..];
+        }
+
+        return words;
     }
 
     /// <summary>

--- a/src/Humanizer/Localisation/WordsToNumber/InvertedTensWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/InvertedTensWordsToNumberConverter.cs
@@ -11,6 +11,8 @@ namespace Humanizer;
 /// </remarks>
 internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfile profile) : GenderlessWordsToNumberConverter
 {
+    const int MaximumParseDepth = 128;
+
     readonly InvertedTensWordsToNumberProfile profile = profile;
 
     /// <inheritdoc />
@@ -94,6 +96,7 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
             return TryParseCompact(words, out value, out unrecognizedWord);
         }
 
+        var remainingWork = (long)words.Length * 32L;
         long total = 0;
         long current = 0;
         unrecognizedWord = null;
@@ -107,7 +110,7 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
                 continue;
             }
 
-            if (!TryParseCompact(token, out var tokenValue, out unrecognizedWord))
+            if (!TryParseCompactCore(token, 0, ref remainingWork, out var tokenValue, out unrecognizedWord))
             {
                 value = default;
                 return false;
@@ -141,6 +144,20 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
     /// <returns><c>true</c> if the token was parsed successfully; otherwise, <c>false</c>.</returns>
     bool TryParseCompact(string word, out long value, out string? unrecognizedWord)
     {
+        var remainingWork = (long)word.Length * 32L;
+        return TryParseCompactCore(word, 0, ref remainingWork, out value, out unrecognizedWord);
+    }
+
+    bool TryParseCompactCore(string word, int depth, ref long remainingWork, out long value, out string? unrecognizedWord)
+    {
+        if (depth >= MaximumParseDepth || remainingWork-- <= 0)
+        {
+            remainingWork = -1;
+            value = default;
+            unrecognizedWord = word;
+            return false;
+        }
+
         if (profile.CardinalMap.TryGetValue(word, out value) ||
             profile.OrdinalMap.TryGetValue(word, out value))
         {
@@ -148,9 +165,14 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
             return true;
         }
 
-        if (TryParseOrdinalStem(word, out value, out unrecognizedWord))
+        if (TryParseOrdinalStem(word, depth, ref remainingWork, out value, out unrecognizedWord))
         {
             return true;
+        }
+
+        if (remainingWork < 0)
+        {
+            return false;
         }
 
         // Direct lexical matches must win before structural splitting. If the scale or compact-ten
@@ -169,9 +191,27 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
             long factor = 1;
 
             if (!string.IsNullOrEmpty(left) &&
-                !TryParseCompact(left, out factor, out _) ||
-                !TryParseOptional(right, out var remainder, out _))
+                !TryParseCompactCore(left, depth + 1, ref remainingWork, out factor, out _))
             {
+                if (remainingWork < 0)
+                {
+                    value = default;
+                    unrecognizedWord = word;
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (!TryParseOptional(right, depth + 1, ref remainingWork, out var remainder, out _))
+            {
+                if (remainingWork < 0)
+                {
+                    value = default;
+                    unrecognizedWord = word;
+                    return false;
+                }
+
                 continue;
             }
 
@@ -193,9 +233,16 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
         {
             var collapsed = word.Replace(" ", string.Empty);
             if (!ReferenceEquals(word, collapsed) &&
-                TryParseCompact(collapsed, out value, out unrecognizedWord))
+                TryParseCompactCore(collapsed, depth + 1, ref remainingWork, out value, out unrecognizedWord))
             {
                 return true;
+            }
+
+            if (remainingWork < 0)
+            {
+                value = default;
+                unrecognizedWord = word;
+                return false;
             }
         }
 
@@ -211,7 +258,7 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
     /// <param name="value">When this method returns, the parsed numeric value.</param>
     /// <param name="unrecognizedWord">When parsing fails, the stem that could not be parsed.</param>
     /// <returns><c>true</c> if an ordinal suffix was recognized and the stem parsed; otherwise, <c>false</c>.</returns>
-    bool TryParseOrdinalStem(string word, out long value, out string? unrecognizedWord)
+    bool TryParseOrdinalStem(string word, int depth, ref long remainingWork, out long value, out string? unrecognizedWord)
     {
         foreach (var suffix in profile.OrdinalSuffixes)
         {
@@ -220,7 +267,7 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
                 continue;
             }
 
-            return TryParseCompact(word[..^suffix.Length], out value, out unrecognizedWord);
+            return TryParseCompactCore(word[..^suffix.Length], depth + 1, ref remainingWork, out value, out unrecognizedWord);
         }
 
         value = default;
@@ -235,7 +282,7 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
     /// <param name="value">When this method returns, the parsed numeric value.</param>
     /// <param name="unrecognizedWord">When parsing fails, the fragment that could not be parsed.</param>
     /// <returns><c>true</c> if the fragment was parsed successfully; otherwise, <c>false</c>.</returns>
-    bool TryParseOptional(string word, out long value, out string? unrecognizedWord)
+    bool TryParseOptional(string word, int depth, ref long remainingWork, out long value, out string? unrecognizedWord)
     {
         if (string.IsNullOrEmpty(word))
         {
@@ -244,7 +291,7 @@ internal class InvertedTensWordsToNumberConverter(InvertedTensWordsToNumberProfi
             return true;
         }
 
-        return TryParseCompact(word, out value, out unrecognizedWord);
+        return TryParseCompactCore(word, depth, ref remainingWork, out value, out unrecognizedWord);
     }
 
     /// <summary>

--- a/tests/Humanizer.Tests/CoverageGapTests.cs
+++ b/tests/Humanizer.Tests/CoverageGapTests.cs
@@ -879,9 +879,13 @@ public class CoverageGapTests
         Assert.False(suffixOnly.Success);
         Assert.Equal("th", suffixOnly.UnrecognizedWord);
 
-        Assert.Equal(string.Empty, InvokePrivate<string>(typeof(InvertedTensWordsToNumberConverter), converter, "StripLeadingIgnoredTokens", string.Empty));
-        Assert.Equal("one", InvokePrivate<string>(typeof(InvertedTensWordsToNumberConverter), converter, "StripLeadingIgnoredTokens", "and of one"));
-        Assert.Equal("one", InvokePrivate<string>(typeof(InvertedTensWordsToNumberConverter), converter, "StripLeadingIgnoredTokens", "andone"));
+        var ignoredRemainder = InvokeInvertedTensTryParseCompact(converter, "twothousandand of one");
+        Assert.True(ignoredRemainder.Success);
+        Assert.Equal(2001, ignoredRemainder.Value);
+
+        var gluedIgnoredRemainder = InvokeInvertedTensTryParseCompact(converter, "twothousandandofone");
+        Assert.True(gluedIgnoredRemainder.Success);
+        Assert.Equal(2001, gluedIgnoredRemainder.Value);
     }
 
     [Theory]

--- a/tests/Humanizer.Tests/Localisation/so/SomaliNumberToWordsTests.cs
+++ b/tests/Humanizer.Tests/Localisation/so/SomaliNumberToWordsTests.cs
@@ -75,4 +75,36 @@ public class SomaliNumberToWordsTests
     {
         Assert.Equal(expected, words.ToNumber(So));
     }
+
+    [Fact]
+    public void WordsToNumber_BoundsRecursiveInvertedTensParsing()
+    {
+        var legitimateWords = string.Concat(Enumerable.Repeat("kun", 64));
+        Assert.Equal(64000, legitimateWords.ToNumber(So));
+        Assert.Equal(20, "labaatan".ToNumber(So));
+        Assert.Equal(2, "labaad".ToNumber(So));
+        Assert.Equal(20.1m, "labaatan dhibic kow".ToDecimalNumber(So));
+        Assert.Equal(21, "einundzwanzig".ToNumber(new("de")));
+
+        var scaleWords = string.Concat(Enumerable.Repeat("kun", 256));
+        AssertRejected(scaleWords);
+        AssertRejected($"laga jaray {scaleWords}");
+        AssertRejected("laba" + string.Concat(Enumerable.Repeat("aad", 256)));
+
+        Assert.False($"{scaleWords} dhibic kow".TryToDecimalNumber(out var parsedDecimal, So, out var unrecognizedWord));
+        Assert.Equal(0, parsedDecimal);
+        Assert.NotNull(unrecognizedWord);
+
+        void AssertRejected(string words)
+        {
+            var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+            Assert.False(words.TryToNumber(out var parsed, So, out var unrecognizedWord));
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+            Assert.Equal(0, parsed);
+            Assert.NotNull(unrecognizedWord);
+            Assert.True(allocated < 8_000_000, $"Inverted-tens rejection allocated {allocated:N0} bytes.");
+            Assert.Throws<ArgumentException>(() => words.ToNumber(So));
+        }
+    }
 }

--- a/tests/Humanizer.Tests/Localisation/so/SomaliNumberToWordsTests.cs
+++ b/tests/Humanizer.Tests/Localisation/so/SomaliNumberToWordsTests.cs
@@ -86,7 +86,7 @@ public class SomaliNumberToWordsTests
         Assert.Equal(20.1m, "labaatan dhibic kow".ToDecimalNumber(So));
         Assert.Equal(21, "einundzwanzig".ToNumber(new("de")));
 
-        var scaleWords = string.Concat(Enumerable.Repeat("kun", 256));
+        var scaleWords = string.Concat(Enumerable.Repeat("kun", 33_000));
         AssertRejected(scaleWords);
         AssertRejected($"laga jaray {scaleWords}");
         AssertRejected("laba" + string.Concat(Enumerable.Repeat("aad", 256)));


### PR DESCRIPTION
## Summary

Inverted-tens word parsing now shares a bounded recursion depth and input-proportional work budget across compact tokens, scale splits, ordinal stems, whitespace collapse, and decimal wrappers while carrying recursive slices as spans over the normalized input. This prevents attacker-controlled Somali compounds from exhausting either the process stack or memory through recursive substring amplification while preserving legitimate Somali, German, ordinal, and decimal parsing.

## Validation

- Exact vulnerable-main red control (`fc14e5e8c056b85294548976e33d9cdf352ec44b`): 32,000 repeated Somali `kun` scales (96,000 characters) terminated the child process with exit 134; legitimate `labaatan` parsed as 20
- Exact replacement green control (`4374f810cbe4a2805864d4c8c4f8b065e419adfb`): the same hostile input returned normally with `accepted=False`, value 0; legitimate control remained 20
- Security regression covers positive, negative, ordinal-stem, whitespace, and decimal paths plus 64-scale legitimate input and a 99,000-character allocation closure
- Independent allocation matrix at 300,000 hostile characters: cardinal 776 bytes, negative ~1.2 MB, ordinal 776 bytes, decimal ~2.4 MB; the superseded head allocated ~76.8 MB on cardinal input alone
- Somali localization tests: 39/39 passed on each of .NET 8, .NET 10, and .NET 11
- Full Humanizer test suite: 61,067/61,067 passed on each of .NET 8, .NET 10, and .NET 11
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`: 0 of 2,824 files changed
- Release package built for net8.0, net10.0, net11.0, net48, and netstandard2.0; package verification passed
- Live-main integration: no changed-path overlap; `git merge-tree --write-tree origin/main HEAD` completed cleanly as tree `69f46be205994d58dca99d2b195efa2eb4df9e58`
- Rolling-main integration after #1933: no new overlap from the base movement; GitHub remained MERGEABLE and current-main merge tree `5afff29a208ad1a0a706aaed9a5b2cb1d8dc0dba` is clean
- `git diff --check`: passed

Here is a checklist you should tick through before submitting a pull request:
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow or another source, required attribution is included (N/A: no copied code)
 - [x] Comments are limited to existing parser guidance
 - [x] XML documentation is added or updated (N/A: no public API change)
 - [x] Existing head merges cleanly with current `main`; no unrelated replay is required
 - [x] Link to the issue being fixed (N/A: sealed security-review finding; no public issue)
 - [x] Readme is updated if behavior changes (N/A: supported behavior and public API are unchanged)
 - [x] Applicable validation from `AGENTS.md` passed

## Terminal evidence (merge owner)

 - [x] This PR is ready, not draft
 - [x] Exact replacement commit: `4374f810cbe4a2805864d4c8c4f8b065e419adfb`; tree `1e294a6ce195778b45b6213aeeb4bc54ee45d3ab`; live-main integration tree `69f46be205994d58dca99d2b195efa2eb4df9e58`
 - [x] Actual `codex-security:validation` terminal approval on exact replacement head `4374f810cbe4a2805864d4c8c4f8b065e419adfb`; no remaining findings
 - [x] Actual `agent-utilities:thermo-nuclear-review` terminal approval on the exact replacement head; no findings
 - [x] Actual `agent-utilities:thermo-nuclear-code-quality-review` terminal approval on the exact replacement head; prior P1 closed and no remaining findings
 - [x] Every review finding has an explicit disposition: allocation amplification fixed; ordinal failure-token thread fixed/resolved; extra null assertions declined as redundant; span/LINQ CodeQL suggestion declined because ref-struct capture is illegal and string materialization would restore the allocation sink; no query or alert was weakened
 - [x] Applicable local tests, format, build, package, and security gates pass
 - [x] `compound-engineering:ce-babysit-pr` covered exact-head reviewer lifecycle, CI, feedback, and a final 322-second quiet settle
 - [x] All actionable review threads are resolved; no `needs-human` item remains
 - [x] The head is CLEAN/MERGEABLE and every hosted CI and ruleset check is terminal green or skipped as expected
 - [x] Rendered docs/site/UI: N/A; no rendered surface changed
 - [x] Localization/source generator: runtime-only parser fix; locale data and generation are unchanged
 - [x] Immediately before merge, reauthenticated exact head `4374f810cbe4a2805864d4c8c4f8b065e419adfb`; normal GitHub merge completed without administrative bypass

## Review correction

The first exact-head security and Thermo code-quality passes proved that the depth/work caps stopped stack exhaustion but still allowed up to 128 near-full substring copies, measuring about 256× allocation amplification. The replacement commit carries recursive scale, ordinal, and optional-tail slices as `ReadOnlySpan<char>`, materializes the failure token only once at the API boundary, replaces private-helper reflection assertions with parser behavior coverage, and enlarges the malicious regression from 768 to 99,000 characters. Unaffected stack-safety, parser-semantics, packaging, and legitimate-behavior conclusions remained valid; all three required reviewers examined only this incremental correction plus affected gates and returned terminal APPROVE verdicts on the exact replacement head.

## Post-merge closure

- Exact reviewed head `4374f810cbe4a2805864d4c8c4f8b065e419adfb` merged normally as main `81fdfa55ce4312c4fd25f1b9ba6e477ccc01fd83`; merged tree `5afff29a208ad1a0a706aaed9a5b2cb1d8dc0dba`
- Original sealed 96,000-character PoC rerun on merged main: legitimate `labaatan` control parsed as 20; hostile repeated-scale trigger returned normally with `parsed=False`, value 0, exit 0
- Merged-main security regression passed 1/1 on each of .NET 8, .NET 10, and .NET 11 using isolated artifact paths
- Dashboard readback after merge: 0 open Dependabot alerts, 0 open secret-scanning alerts, 0 open security-severity CodeQL alerts, and 0 open DevSkim alerts; no alert was dismissed and no query was weakened
