### PR TITLE
fix(security): remove linking-affix recursion

### DIFF
--- a/src/Humanizer/Localisation/WordsToNumber/LinkingAffixWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/LinkingAffixWordsToNumberConverter.cs
@@ -89,13 +89,9 @@ internal class LinkingAffixWordsToNumberConverter(LinkingAffixWordsToNumberProfi
                 continue;
             }
 
-            // Teen tokens are parsed recursively so the suffix lookup stays independent from the
-            // locale's exact teen lexemes.
-            if (token.StartsWith(profile.TeenPrefix, StringComparison.Ordinal) &&
-                token.Length > profile.TeenPrefix.Length &&
-                TryParseCardinal(token[profile.TeenPrefix.Length..], out var teenUnit))
+            if (TryParseTeenToken(token, out var teenValue))
             {
-                current = checked(current + checked(profile.TeenBaseValue + teenUnit));
+                current = checked(current + teenValue);
                 continue;
             }
 
@@ -127,6 +123,38 @@ internal class LinkingAffixWordsToNumberConverter(LinkingAffixWordsToNumberProfi
         }
 
         value = checked(total + current);
+        return true;
+    }
+
+    /// <summary>
+    /// Consumes consecutive teen prefixes without growing the call stack, then resolves the
+    /// remaining cardinal or linked token.
+    /// </summary>
+    bool TryParseTeenToken(string token, out long value)
+    {
+        var remainder = token.AsSpan();
+        long prefixCount = 0;
+
+        while (remainder.StartsWith(profile.TeenPrefix, StringComparison.Ordinal) &&
+               remainder.Length > profile.TeenPrefix.Length)
+        {
+            prefixCount++;
+            remainder = remainder[profile.TeenPrefix.Length..];
+        }
+
+        if (prefixCount == 0)
+        {
+            value = default;
+            return false;
+        }
+
+        if (!TryParseCardinal(remainder.ToString(), out var terminalValue))
+        {
+            value = default;
+            return false;
+        }
+
+        value = checked(checked(prefixCount * profile.TeenBaseValue) + terminalValue);
         return true;
     }
 
@@ -184,7 +212,9 @@ sealed class LinkingAffixWordsToNumberProfile(
     /// <summary>
     /// Gets the prefix that marks a teen stem.
     /// </summary>
-    public string TeenPrefix { get; } = teenPrefix;
+    public string TeenPrefix { get; } = string.IsNullOrEmpty(teenPrefix)
+        ? throw new ArgumentException("Teen prefix cannot be empty.", nameof(teenPrefix))
+        : teenPrefix;
     /// <summary>
     /// Gets the base value added when a teen prefix is matched.
     /// </summary>

--- a/src/Humanizer/Localisation/WordsToNumber/LinkingAffixWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/LinkingAffixWordsToNumberConverter.cs
@@ -134,12 +134,31 @@ internal class LinkingAffixWordsToNumberConverter(LinkingAffixWordsToNumberProfi
     {
         var remainder = token.AsSpan();
         var prefixCount = 0L;
+        var hasMappedTerminal = false;
+        var terminalValue = default(long);
 
         while (remainder.StartsWith(profile.TeenPrefix, StringComparison.Ordinal) &&
                remainder.Length > profile.TeenPrefix.Length)
         {
             prefixCount++;
             remainder = remainder[profile.TeenPrefix.Length..];
+
+            foreach (var cardinal in profile.CardinalMap)
+            {
+                if (remainder.Length != cardinal.Key.Length || !remainder.SequenceEqual(cardinal.Key.AsSpan()))
+                {
+                    continue;
+                }
+
+                terminalValue = cardinal.Value;
+                hasMappedTerminal = true;
+                break;
+            }
+
+            if (hasMappedTerminal)
+            {
+                break;
+            }
         }
 
         if (prefixCount == 0)
@@ -148,7 +167,7 @@ internal class LinkingAffixWordsToNumberConverter(LinkingAffixWordsToNumberProfi
             return false;
         }
 
-        if (!TryParseCardinal(remainder.ToString(), out var terminalValue))
+        if (!hasMappedTerminal && !TryParseCardinal(remainder.ToString(), out terminalValue))
         {
             value = default;
             return false;

--- a/src/Humanizer/Localisation/WordsToNumber/LinkingAffixWordsToNumberConverter.cs
+++ b/src/Humanizer/Localisation/WordsToNumber/LinkingAffixWordsToNumberConverter.cs
@@ -133,7 +133,7 @@ internal class LinkingAffixWordsToNumberConverter(LinkingAffixWordsToNumberProfi
     bool TryParseTeenToken(string token, out long value)
     {
         var remainder = token.AsSpan();
-        long prefixCount = 0;
+        var prefixCount = 0L;
 
         while (remainder.StartsWith(profile.TeenPrefix, StringComparison.Ordinal) &&
                remainder.Length > profile.TeenPrefix.Length)
@@ -154,7 +154,12 @@ internal class LinkingAffixWordsToNumberConverter(LinkingAffixWordsToNumberProfi
             return false;
         }
 
-        value = checked(checked(prefixCount * profile.TeenBaseValue) + terminalValue);
+        value = terminalValue;
+        for (var index = 0L; index < prefixCount; index++)
+        {
+            value = checked(profile.TeenBaseValue + value);
+        }
+
         return true;
     }
 

--- a/tests/Humanizer.Tests/WordsToNumberTests.cs
+++ b/tests/Humanizer.Tests/WordsToNumberTests.cs
@@ -1638,6 +1638,26 @@ public class WordsToNumberTests_Filipino
 
         Assert.Equal("teenPrefix", exception.ParamName);
     }
+
+    [Fact]
+    public void LinkingAffixProfilePreservesCheckedTeenAggregationOrder()
+    {
+        var profile = new LinkingAffixWordsToNumberProfile(
+            new Dictionary<string, long>
+            {
+                ["end"] = -long.MaxValue
+            }.ToFrozenDictionary(),
+            "x",
+            long.MaxValue,
+            [],
+            [],
+            []);
+        var converter = new LinkingAffixWordsToNumberConverter(profile);
+
+        Assert.True(converter.TryConvert("xxend", out var parsed, out var unrecognizedWord));
+        Assert.Equal(long.MaxValue, parsed);
+        Assert.Null(unrecognizedWord);
+    }
 }
 
 [UseCulture("id-ID")]

--- a/tests/Humanizer.Tests/WordsToNumberTests.cs
+++ b/tests/Humanizer.Tests/WordsToNumberTests.cs
@@ -1658,6 +1658,27 @@ public class WordsToNumberTests_Filipino
         Assert.Equal(long.MaxValue, parsed);
         Assert.Null(unrecognizedWord);
     }
+
+    [Fact]
+    public void LinkingAffixProfilePreservesMappedCardinalsBetweenTeenPrefixes()
+    {
+        var profile = new LinkingAffixWordsToNumberProfile(
+            new Dictionary<string, long>
+            {
+                ["xend"] = 50,
+                ["end"] = 1
+            }.ToFrozenDictionary(),
+            "x",
+            10,
+            [],
+            [],
+            []);
+        var converter = new LinkingAffixWordsToNumberConverter(profile);
+
+        Assert.True(converter.TryConvert("xxend", out var parsed, out var unrecognizedWord));
+        Assert.Equal(60, parsed);
+        Assert.Null(unrecognizedWord);
+    }
 }
 
 [UseCulture("id-ID")]

--- a/tests/Humanizer.Tests/WordsToNumberTests.cs
+++ b/tests/Humanizer.Tests/WordsToNumberTests.cs
@@ -1597,6 +1597,47 @@ public class WordsToNumberTests_Filipino
         Assert.Equal(expectedNumber, parsedNumber);
     }
 
+    [Fact]
+    public void TryToNumber_ConsumesRepeatedTeenPrefixesWithoutRecursiveWork()
+    {
+        Assert.Equal(21, "labinglabingisa".ToNumber(CultureInfo.CurrentCulture));
+        Assert.Equal(20, "labinglabing".ToNumber(CultureInfo.CurrentCulture));
+        Assert.Equal(11, "labingisang".ToNumber(CultureInfo.CurrentCulture));
+        Assert.Equal(10, "labingat".ToNumber(CultureInfo.CurrentCulture));
+        Assert.Equal(-21, "minus labinglabingisa".ToNumber(CultureInfo.CurrentCulture));
+        Assert.Equal(21.1m, "labinglabingisa tuldok isa".ToDecimalNumber(CultureInfo.CurrentCulture));
+
+        const int prefixCount = 4096;
+        var words = string.Concat(Enumerable.Repeat("labing", prefixCount)) + "isa";
+        "labingisa".TryToNumber(out _, CultureInfo.CurrentCulture);
+
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        Assert.True(words.TryToNumber(out var parsed, CultureInfo.CurrentCulture, out var unrecognizedWord));
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        Assert.Equal(prefixCount * 10 + 1, parsed);
+        Assert.Null(unrecognizedWord);
+        Assert.True(allocated < 1_000_000, $"Linking-affix parsing allocated {allocated:N0} bytes.");
+
+        var malformed = string.Concat(Enumerable.Repeat("labing", 256)) + "mystery";
+        Assert.False(malformed.TryToNumber(out parsed, CultureInfo.CurrentCulture, out unrecognizedWord));
+        Assert.Equal(0, parsed);
+        Assert.Equal(malformed, unrecognizedWord);
+    }
+
+    [Fact]
+    public void LinkingAffixProfileRejectsEmptyTeenPrefix()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => new LinkingAffixWordsToNumberProfile(
+            new Dictionary<string, long>().ToFrozenDictionary(),
+            string.Empty,
+            10,
+            [],
+            [],
+            []));
+
+        Assert.Equal("teenPrefix", exception.ParamName);
+    }
 }
 
 [UseCulture("id-ID")]


### PR DESCRIPTION
## Summary

Filipino linking-affix parsing now consumes repeated teen prefixes iteratively over a span and resolves the terminal token once. This removes attacker-controlled recursive substring work and stack growth while preserving valid cardinal, negative, decimal, malformed-token, and ordinary teen forms.

## Validation

- Exact vulnerable scan revision (`146d74c025b80fa615bd8660f3c4c4949f61ac56`): 100,000 repeated `labing` prefixes (600,003 characters) failed to complete within 30 seconds; ordinary `labingisa` remained 11
- Exact replacement patch (`2d2bff2001033d144efb0f556255c72fb792eb4c`) retains the same linear, stack-safe parser, restores the legacy checked-addition order, and preserves cardinal-map resolution after each prefix removal
- Exact-head 100,000-prefix probe remains linear: 600,003 characters parse in 5 ms with 1.20 MB allocated; the intermediate-map counterexample `xxend` resolves to the legacy value 60
- Security regression covers repeated prefixes, positive/negative/decimal paths, malformed terminal input, legitimate compact forms, and allocation closure
- Filipino word-to-number tests: 13/13 passed on each of .NET 8, .NET 10, and .NET 11
- Full Humanizer test suite: 61,070/61,070 passed on each of .NET 8, .NET 10, and .NET 11
- `dotnet format Humanizer.slnx --verify-no-changes --verbosity diagnostic`: 0 of 2,824 files changed
- Release package built for net8.0, net10.0, net11.0, net48, and netstandard2.0; analyzer package entries and net8 consumer load verified
- Live-main integration: `git merge-tree --write-tree origin/main HEAD` completed cleanly against `81fdfa55ce4312c4fd25f1b9ba6e477ccc01fd83` as tree `659b7e9f7d9aa9d3f01e698a5c0d21dc0c766c3d`; the shared test file overlaps only distant locale sections and has no semantic overlap
- `git diff --check`: passed

Here is a checklist you should tick through before submitting a pull request:
 - [x] Implementation is clean
 - [x] Code adheres to the existing coding standards
 - [x] No Code Analysis warnings
 - [x] There is proper unit test coverage
 - [x] If the code is copied from StackOverflow or another source, required attribution is included (N/A: no copied code)
 - [x] Comments are limited to parser intent
 - [x] XML documentation is added or updated for the new private helper; no public API changed
 - [x] Existing head merges cleanly with current `main`; no unrelated replay is required
 - [x] Link to the issue being fixed (N/A: sealed security-review finding; no public issue)
 - [x] Readme is updated if behavior changes (N/A: supported behavior and public API are unchanged)
 - [x] Applicable validation from `AGENTS.md` passed

## Terminal evidence (merge owner)

 - [x] This PR is ready, not draft
 - [x] Exact replacement commit: `2d2bff2001033d144efb0f556255c72fb792eb4c`; tree `eabda6211373e75c71499c4f94f9b0c9fd677acb`; live-main integration tree `659b7e9f7d9aa9d3f01e698a5c0d21dc0c766c3d`
 - [x] Actual `codex-security:validation` terminal approval on the exact pushed head
 - [x] Actual `agent-utilities:thermo-nuclear-review` terminal approval on the exact pushed head
 - [x] Actual `agent-utilities:thermo-nuclear-code-quality-review` terminal approval on the exact pushed head
 - [x] Every review finding has an explicit disposition: checked aggregation and intermediate-map precedence fixed and retested; redundant null-prefix test request resolved with same-guard evidence; style nit applied
 - [x] Applicable local tests, format, build, package, and security gates pass
 - [x] `compound-engineering:ce-babysit-pr` covered exact-head reviewer lifecycle, CI, feedback, and 331-second quiet settle
 - [x] All actionable review threads are resolved; no `needs-human` item remains
 - [x] The head is CLEAN/MERGEABLE and terminal hosted CI and ruleset checks are green/skipped as expected
 - [x] Rendered docs/site/UI: N/A; no rendered surface changed
 - [x] Localization/source generator: runtime-only parser fix; locale data and generation are unchanged
 - [x] Immediately before merge, reauthenticated `clairernovotny`, exact live head `2d2bff2001033d144efb0f556255c72fb792eb4c`, and the normal GitHub merge gate; no administrative bypass

## Post-merge security closure

- Squash merge/default-main commit: `81836ba5c0fbe33fca0ef7ec6a9ad86e2d9dea8d`; tree `659b7e9f7d9aa9d3f01e698a5c0d21dc0c766c3d`
- Clean detached merged-main worktree authenticated at that exact commit
- Original legitimate control `labingisa`: success, value 11
- Original hostile shape with 100,000 repeated prefixes (600,003 characters): success, value 1,000,001; no recursion failure or timeout
- Merged-main Filipino security regression: 13/13 passed on each of .NET 8, .NET 10, and .NET 11
- Live dashboards after merge: 0 open Dependabot alerts, 0 open secret-scanning alerts, and 0 security-severity CodeQL/DevSkim alerts; no alert was dismissed and no query was weakened
- The 20 remaining open CodeQL results are non-security code-quality notes/warnings and were left intact for their own review boundaries
