### PR TITLE
fix(inflections): group direct reverse selection state

### DIFF
--- a/src/Humanizer/Inflections/InflectionEngine.cs
+++ b/src/Humanizer/Inflections/InflectionEngine.cs
@@ -381,9 +381,7 @@ sealed partial class InflectionBundle
         StringComparison comparison,
         InflectionUnicodeScripts detectedScripts)
     {
-        InflectionRule? selectedDirectRule = null;
-        var selectedDirectCandidate = default(ReverseCandidate);
-        var selectedDirectRuleCoversDetectedScripts = false;
+        var selectedDirect = default(DirectReverseSelection);
         var reverseCandidate = default(ReverseCandidate);
         var reverseCandidateCoversDetectedScripts = false;
         var hasReverseCandidate = false;
@@ -410,9 +408,7 @@ sealed partial class InflectionBundle
                         rule,
                         directCandidate,
                         comparison,
-                        ref selectedDirectRule,
-                        ref selectedDirectCandidate,
-                        ref selectedDirectRuleCoversDetectedScripts,
+                        ref selectedDirect,
                         detectedScripts))
                 {
                     return new(InflectionStatus.Ambiguous, input);
@@ -442,28 +438,28 @@ sealed partial class InflectionBundle
             }
         }
 
-        if (selectedDirectRule is not null)
+        if (selectedDirect.Rule is not null)
         {
             if (hasReverseCandidate &&
-                !selectedDirectCandidate.Equals(reverseCandidate, comparison))
+                !selectedDirect.Candidate.Equals(reverseCandidate, comparison))
             {
                 return new(InflectionStatus.Ambiguous, input);
             }
 
             if (hasReverseCandidate)
             {
-                selectedDirectRuleCoversDetectedScripts |=
+                selectedDirect.CoversDetectedScripts |=
                     reverseCandidateCoversDetectedScripts;
             }
 
-            if (!selectedDirectRuleCoversDetectedScripts)
+            if (!selectedDirect.CoversDetectedScripts)
             {
                 return new(InflectionStatus.Ambiguous, input);
             }
 
             return Project(
                 input,
-                selectedDirectCandidate.Materialize(),
+                selectedDirect.Candidate.Materialize(),
                 projection,
                 InflectionStatus.Productive);
         }
@@ -486,27 +482,25 @@ sealed partial class InflectionBundle
         InflectionRule rule,
         ReverseCandidate candidate,
         StringComparison comparison,
-        ref InflectionRule? selectedRule,
-        ref ReverseCandidate selectedCandidate,
-        ref bool selectedRuleCoversDetectedScripts,
+        ref DirectReverseSelection selection,
         InflectionUnicodeScripts detectedScripts)
     {
-        if (selectedRule is null)
+        if (selection.Rule is null)
         {
-            selectedRule = rule;
-            selectedCandidate = candidate;
-            selectedRuleCoversDetectedScripts = CoversDetectedScripts(
+            selection.Rule = rule;
+            selection.Candidate = candidate;
+            selection.CoversDetectedScripts = CoversDetectedScripts(
                 rule.Scripts,
                 detectedScripts);
             return true;
         }
 
-        var rank = CompareRuleRank(rule, selectedRule.Value);
+        var rank = CompareRuleRank(rule, selection.Rule.Value);
         if (rank > 0)
         {
-            selectedRule = rule;
-            selectedCandidate = candidate;
-            selectedRuleCoversDetectedScripts = CoversDetectedScripts(
+            selection.Rule = rule;
+            selection.Candidate = candidate;
+            selection.CoversDetectedScripts = CoversDetectedScripts(
                 rule.Scripts,
                 detectedScripts);
             return true;
@@ -517,12 +511,12 @@ sealed partial class InflectionBundle
             return true;
         }
 
-        if (!selectedCandidate.Equals(candidate, comparison))
+        if (!selection.Candidate.Equals(candidate, comparison))
         {
             return false;
         }
 
-        selectedRuleCoversDetectedScripts |= CoversDetectedScripts(
+        selection.CoversDetectedScripts |= CoversDetectedScripts(
             rule.Scripts,
             detectedScripts);
         return true;
@@ -997,6 +991,13 @@ sealed partial class InflectionBundle
 
             return first;
         }
+    }
+
+    struct DirectReverseSelection
+    {
+        public InflectionRule? Rule;
+        public ReverseCandidate Candidate;
+        public bool CoversDetectedScripts;
     }
 
     static bool Contains(


### PR DESCRIPTION
## Summary

Direct reverse inflection selection now carries its rule, candidate, and script-coverage state as one stack-local value. The helper therefore no longer exposes three coupled `ref` parameters, while ranking, equal-rank ambiguity, script coverage, and output behavior remain unchanged. This closes CodeQL alert #823 without changing the public API.

## Validation

- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0 --filter-class LocalizedInflectionEngineTests` — 230 passed.
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net8.0` — 61,416 passed, 1 skipped.
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net10.0` — 61,415 passed, 1 skipped.
- `dotnet test tests/Humanizer.Tests/Humanizer.Tests.csproj --framework net11.0` — 61,415 passed, 1 skipped.
- `dotnet format Humanizer.slnx --verify-no-changes --include src/Humanizer/Inflections/InflectionEngine.cs` — passed.
- `dotnet pack src/Humanizer/Humanizer.csproj -c Release -o /tmp/humanizer-823-pack.gMddg5` — passed; package created without warnings.
- Hosted exact-head checks — Analyze C#, CodeQL, DevSkim, documentation build/runtime/manifests, Humanizer-CI, dependency submission, and build all passed; non-applicable deployment jobs skipped.

## Checklist

- [x] Implementation is clean
- [x] Code adheres to the existing coding standards
- [x] No Code Analysis warnings in local build/format validation
- [x] Existing unit coverage exercises direct reverse ranking, ambiguity, script coverage, and lexeme gates
- [x] No copied code or third-party attribution is involved
- [x] No new comments are needed
- [x] No public API or XML documentation change is involved
- [x] Branch is based on the latest `main` at the recorded base SHA
- [ ] No GitHub issue was supplied; this PR references CodeQL alert #823 in the summary
- [x] Readme is unchanged because the public feature contract is unchanged
- [x] Applicable validation from `AGENTS.md` is complete

## Terminal evidence (merge owner)

- [x] This PR body matches the current template, contains no stale draft instructions, and the PR is ready, not draft
- [x] Exact evidence pair: `baseSha=bd6df6130e15c980103f2ea2c9a69ad97013a467` / `headSha=2a5b4a8891322d0473403777275cc4a4eba5a493`
- [x] Thermos correctness/security review on the exact pair: fresh Sol review completed with no findings; agent `019fc6e7-0366-7003-a42d-9bbe2c04bba7`
- [x] Thermos code-quality review on the exact pair: fresh Sol review completed with no findings; agent `019fc6e7-0483-72e3-838d-d506f2758dd4`
- [x] Finding disposition: CodeQL #823 was fixed; both exact-pair reviewers found no additional valid findings, so no further push was required
- [x] Applicable tests, format, build, and package gates pass on that exact pair; hosted CI is green as listed above
- [x] `compound-engineering:ce-babysit-pr` covered the exact pair through reviewer lifecycle, CI, base movement, and quiet settle; terminal snapshot invocation `2998a4650fdc46519822685de4fd6a39` reported `CLEAN`, `APPROVED`, `all_checks_ok=true`, `quiet_seconds=112`, and zero actionable items
- [x] Neither SHA changed after the recorded pair; no stale evidence remains
- [x] All actionable review threads are resolved; `needs-human=0`
- [x] The head is current and mergeable, and terminal hosted CI and ruleset checks are green
- [x] Security: N/A; this is a CodeQL maintainability finding with no security-boundary change
- [x] Rendered docs/site/UI: N/A
- [x] Localization/source generator: N/A
- [x] Immediately before merge, the merge owner will reauthenticate the recorded pair exactly and merge only that approved head
