### PR TITLE
Add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Funding options for Humanizer.
+# GitHub Sponsors requires the listed account to have an active Sponsors profile.
+github: [clairernovotny]


### PR DESCRIPTION
## What changed

Adds `.github/FUNDING.yml` and directs the repository's Sponsor button to `clairernovotny`.

## Why

This makes Humanizer's funding option discoverable from the repository once the corresponding GitHub Sponsors profile is active.

## Validation

- Confirmed the repository had no existing `FUNDING.yml`.
- Confirmed `clairernovotny` is the connected maintainer account.
- Verified the file exists on the proposed branch with valid GitHub funding syntax.