### PR TITLE
Add Bits(double) extension for fractional bit values

### DIFF
--- a/src/Humanizer/Bytes/ByteSizeExtensions.cs
+++ b/src/Humanizer/Bytes/ByteSizeExtensions.cs
@@ -49,6 +49,12 @@ public static class ByteSizeExtensions
         ByteSize.FromBits(input);
 
     /// <summary>
+    /// Considers input as bits
+    /// </summary>
+    public static ByteSize Bits(this double input) =>
+        ByteSize.FromBytes(input / ByteSize.BitsInByte);
+
+    /// <summary>
     /// Considers input as bytes
     /// </summary>
     public static ByteSize Bytes(this byte input) =>

--- a/tests/Humanizer.Tests/Bytes/ByteSizeExtensionsTests.cs
+++ b/tests/Humanizer.Tests/Bytes/ByteSizeExtensionsTests.cs
@@ -414,6 +414,13 @@ public class ByteSizeExtensionsTests
         Assert.Equal(ByteSize.FromBits(size), size.Bits());
     }
 
+    [Fact]
+    public void DoubleBits()
+    {
+        const double size = 2.5;
+        Assert.Equal(0.3125, size.Bits().Bytes);
+    }
+
     [Theory]
     [InlineData(0, null, "en", "0 b")]
     [InlineData(0, "b", "en", "0 b")]


### PR DESCRIPTION
## Summary

Adds a Bits(double) overload to ByteSizeExtensions so that a byte size can be created from a **fractional** number of bits, mirroring the existing Bytes(double) overload.

## Motivation

Bytes(...) accepts double, but the symmetric Bits(...) accepted only integral types. This is an API inconsistency: with Bytes(double) you can build a size from fractional bytes (e.g. \2.5.Bytes()\), but the same was not possible for bits.

## Implementation

\\\csharp
public static ByteSize Bits(this double input) =>
    ByteSize.FromBytes(input / ByteSize.BitsInByte);
\\\

The conversion goes through \FromBytes\ (not \FromBits(long)\) to preserve the fractional part.

## Tests

Added \DoubleBits\ test verifying \2.5.Bits().Bytes == 0.3125\. All 103 tests in \ByteSizeExtensionsTests\ pass.