### PR TITLE
Fix Portuguese locale: correct milhar cardinal value and milissegundo spelling

### DIFF
--- a/src/Humanizer/Locales/pt.yml
+++ b/src/Humanizer/Locales/pt.yml
@@ -148,12 +148,12 @@ surfaces:
         template: '{value}'
       millisecond:
         single:
-          numeric: '1 milisegundo'
-          words: 'um milisegundo'
+          numeric: '1 milissegundo'
+          words: 'um milissegundo'
         multiple:
           forms:
-            default: 'milisegundos'
-            singular: 'milisegundo'
+            default: 'milissegundos'
+            singular: 'milissegundo'
       second:
         single:
           numeric: '1 segundo'
@@ -472,7 +472,7 @@ surfaces:
         mil: 1000
         'milhão': 1000000
         'milhões': 1000000
-        milhar: 1000000000
+        milhar: 1000
       ordinalNumberToWordsKind: 'self'
       ordinalGenderVariant: 'masculine-and-feminine'
       compositeScaleMap:

--- a/tests/Humanizer.Tests/Localisation/LocalePhraseTheoryData.cs
+++ b/tests/Humanizer.Tests/Localisation/LocalePhraseTheoryData.cs
@@ -2489,7 +2489,7 @@ static class LocalePhraseTheoryData
         { "pt", 2, TimeUnit.Hour, false, "2 horas" },
         { "pt", 1, TimeUnit.Day, false, "1 dia" },
         { "pt", 2, TimeUnit.Day, false, "2 dias" },
-        { "pt", 0, TimeUnit.Millisecond, false, "0 milisegundos" },
+        { "pt", 0, TimeUnit.Millisecond, false, "0 milissegundos" },
         { "pt", 0, TimeUnit.Millisecond, true, "sem horário" },
         { "pt-BR", 1, TimeUnit.Second, false, "1 segundo" },
         { "pt-BR", 2, TimeUnit.Second, false, "2 segundos" },

--- a/tests/Humanizer.Tests/Localisation/pt/PortugueseNumberToWordsTests.cs
+++ b/tests/Humanizer.Tests/Localisation/pt/PortugueseNumberToWordsTests.cs
@@ -1,0 +1,13 @@
+namespace Humanizer.Tests.Localisation.pt;
+
+[UseCulture("pt")]
+public class PortugueseNumberToWordsTests
+{
+    [Theory]
+    [InlineData("mil", 1000)]
+    [InlineData("milhar", 1000)]
+    [InlineData("milhão", 1_000_000)]
+    [InlineData("mil milhões", 1_000_000_000)]
+    public void ToNumber_ParsesCardinalWordsToNumber(string words, long expected) =>
+        Assert.Equal(expected, words.ToNumber(new CultureInfo("pt")));
+}


### PR DESCRIPTION
- `milhar` is the Portuguese word for a thousand; the cardinal map wrongly mapped it to `1_000_000_000` (one billion is expressed by the composite scale `mil milhões`). Parsing `"milhar"` now returns `1000` instead of `1_000_000_000`.
- Fixed the misspelled `milisegundo`/`milisegundos` to `milissegundo`/`milissegundos` in the duration section, matching the spelling already used in the relativeDate section of the same locale.
- Added regression tests for `milhar` parsing and updated the pt phrase theory expectation.

Verified with `dotnet build` (0 warnings/errors) and the full test suite on `net10.0`; the only 2 failing tests exist on `main` before these changes (ambient-culture dependent).

Fixes #1966


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Portuguese spellings for millisecond duration values.
  * Fixed Portuguese number-word parsing for “milhar” to return 1,000.
  * Updated the Portuguese zero-millisecond output to use the corrected spelling.
  * Improved Portuguese localization accuracy for duration formatting and number conversion.

* **Tests**
  * Added coverage for Portuguese number-word parsing, including thousands and millions.
  * Updated expected localized output to reflect the corrected terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->